### PR TITLE
feat: add skill picker with weights to admin school skills tab

### DIFF
--- a/apps/backend/app/database/schema/relations.ts
+++ b/apps/backend/app/database/schema/relations.ts
@@ -133,6 +133,12 @@ export const relations = defineRelations(schema, (r) => ({
       to: r.schoolApplications.schoolId,
     }),
   },
+  schoolSkills: {
+    skill: r.one.skills({
+      from: r.schoolSkills.skillId,
+      to: r.skills.slug,
+    }),
+  },
   danceEvents: {
     organizer: r.one.schoolProfiles({
       from: r.danceEvents.schoolId,

--- a/apps/backend/app/modules/schools/get-school/service.ts
+++ b/apps/backend/app/modules/schools/get-school/service.ts
@@ -16,6 +16,12 @@ export class Service {
 
     if (!schoolProfile) return null;
 
+    const { schoolSkills, ...profile } = schoolProfile;
+    const skills = schoolSkills.flatMap((ss) => {
+      if (!ss.skill) return [];
+      return [{ name: ss.skill.name, slug: ss.skill.slug, category: ss.skill.category, weight: ss.weight ?? 1 }];
+    });
+
     const profileImages = images.map((image) => ({
       ...image,
       mediaUrl: imageUrl(image.mediaUrl, "feed"),
@@ -35,7 +41,8 @@ export class Service {
       images: profileImages,
       avatar: profilePicture,
       videos: profileVideos,
-      ...schoolProfile,
+      ...profile,
+      skills,
     };
   }
 
@@ -65,7 +72,9 @@ export class Service {
           videos: true,
           schoolProfile: {
             with: {
-              skills: true,
+              schoolSkills: {
+                with: { skill: true },
+              },
               styles: true,
               events: {
                 orderBy: {

--- a/apps/frontend/src/features/admin/schools/components/edit-school-dialog.tsx
+++ b/apps/frontend/src/features/admin/schools/components/edit-school-dialog.tsx
@@ -97,6 +97,9 @@ function EditSchoolDialogContent({ username, activeTab, onFooterStateChange }: E
   }, [activeTab, activeState, activeRef, onFooterStateChange]);
 
   const skillIds = data.skills.map((s) => s.slug);
+  const skillWeights = new Map(
+    data.skills.map((s) => [s.slug, s.weight] as const),
+  );
   const styleIds = data.styles.map((s) => s.slug);
   const sportIds = data.sports.map((s) => s.slug);
 
@@ -121,7 +124,7 @@ function EditSchoolDialogContent({ username, activeTab, onFooterStateChange }: E
       </TabsContent>
 
       <TabsContent value="skills" className="flex-1 overflow-hidden">
-        <SkillsTab ref={skillsRef} username={username} selectedSkillIds={skillIds} onStateChange={handleStateChange("skills")} />
+        <SkillsTab ref={skillsRef} username={username} selectedSkillIds={skillIds} selectedWeights={skillWeights} onStateChange={handleStateChange("skills")} />
       </TabsContent>
 
       <TabsContent value="styles" className="flex-1 overflow-hidden">

--- a/apps/frontend/src/features/admin/schools/components/tabs/skills-tab.tsx
+++ b/apps/frontend/src/features/admin/schools/components/tabs/skills-tab.tsx
@@ -1,6 +1,7 @@
 import { Spinner } from "@/components/ui/spinner";
 import { toastManager } from "@/components/ui/toast-manager";
 import { useAdminUpdateSchoolSkills } from "@/features/admin/api/mutations";
+import { SkillsList } from "@/shared/skills/components/skills-list";
 import { SkillsWeightedList } from "@/shared/skills/components/skills-weighted-list";
 import { forwardRef, Suspense, useCallback, useEffect, useImperativeHandle, useState } from "react";
 import type { TabHandle } from "./types";
@@ -34,6 +35,20 @@ export const SkillsTab = forwardRef<TabHandle, SkillsTabProps>(
 
     const [localWeights, setLocalWeights] = useState<Map<string, number>>(initialWeights);
     const { mutate, isPending } = useAdminUpdateSchoolSkills();
+
+  const selectedSkillIdList = [...localWeights.keys()];
+
+  const handleToggle = useCallback((skillId: string) => {
+    setLocalWeights((prev) => {
+      const next = new Map(prev);
+      if (next.has(skillId)) {
+        next.delete(skillId);
+      } else {
+        next.set(skillId, 1);
+      }
+      return next;
+    });
+  }, []);
 
   const handleWeightChange = useCallback((skillId: string, weight: number | null) => {
     setLocalWeights((prev) => {
@@ -88,9 +103,16 @@ export const SkillsTab = forwardRef<TabHandle, SkillsTabProps>(
   return (
     <div className="h-full overflow-auto">
       <Suspense fallback={<SkillsTabFallback />}>
-        <SkillsWeightedList
-          selectedSkills={localWeights}
-          onWeightChange={handleWeightChange}
+        <SkillsList
+          selectedSkillIds={selectedSkillIdList}
+          onToggle={handleToggle}
+          summarySlot={
+            <SkillsWeightedList
+              className="hidden md:flex"
+              selectedSkills={localWeights}
+              onWeightChange={handleWeightChange}
+            />
+          }
         />
       </Suspense>
     </div>

--- a/apps/frontend/src/lib/api/types.d.ts
+++ b/apps/frontend/src/lib/api/types.d.ts
@@ -6766,6 +6766,7 @@ export interface components {
                 name: string;
                 slug: string;
                 category: string;
+                weight: number;
             }[];
             sports: {
                 name: string;


### PR DESCRIPTION
The admin skills tab previously only showed a summary of selected skills with no way to add or remove them. Now embeds the full skill picker (category dropdown + toggle buttons) alongside the weighted summary panel. Also includes weight data in the school profile API response so weights persist across sessions.