### PR TITLE
feat(video): add optional MP3 audio upload to video library

### DIFF
--- a/apps/backend/app/database/drizzle/20260518064208_white_whistler/migration.sql
+++ b/apps/backend/app/database/drizzle/20260518064208_white_whistler/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "event_videos" ADD COLUMN "audio_key" varchar(500);--> statement-breakpoint
+ALTER TABLE "event_videos" ADD COLUMN "audio_filename" varchar(300);

--- a/apps/backend/app/database/schema/org-events.ts
+++ b/apps/backend/app/database/schema/org-events.ts
@@ -138,6 +138,8 @@ export const eventVideos = pg.pgTable(
     title: pg.varchar({ length: 300 }).notNull(),
     youtubeId: pg.varchar({ length: 20 }).notNull(),
     sortOrder: pg.integer().notNull().default(0),
+    audioKey: pg.varchar({ length: 500 }),
+    audioFilename: pg.varchar({ length: 300 }),
     ...timestamps,
   },
   (table) => [

--- a/apps/backend/app/modules/orgs/events/routes.ts
+++ b/apps/backend/app/modules/orgs/events/routes.ts
@@ -51,6 +51,8 @@ const ListVideosController = () => import("./videos/list/controller.ts");
 const CreateVideoController = () => import("./videos/create/controller.ts");
 const UpdateVideoController = () => import("./videos/update/controller.ts");
 const DeleteVideoController = () => import("./videos/delete/controller.ts");
+const AudioUploadUrlController = () =>
+  import("./videos/audio-upload-url/controller.ts");
 const AttendEventController = () => import("./attend/controller.ts");
 const ScheduleController = () => import("./schedule/controller.ts");
 
@@ -365,6 +367,16 @@ router
       ]);
     router
       .delete(":slug/events/:id/videos/:videoId", [DeleteVideoController])
+      .use([
+        middleware.auth(),
+        middleware.org(),
+        middleware.orgMember(),
+        middleware.orgAdmin(),
+      ]);
+    router
+      .post(":slug/events/:id/videos/audio-upload-url", [
+        AudioUploadUrlController,
+      ])
       .use([
         middleware.auth(),
         middleware.org(),

--- a/apps/backend/app/modules/orgs/events/videos/audio-upload-url/controller.ts
+++ b/apps/backend/app/modules/orgs/events/videos/audio-upload-url/controller.ts
@@ -1,0 +1,12 @@
+import type { HttpContext } from "@adonisjs/core/http";
+import { inject } from "@adonisjs/core";
+import { AudioUploadUrlService } from "./service.ts";
+import { schema } from "./validator.ts";
+
+export default class AudioUploadUrlController {
+  @inject()
+  async handle(ctx: HttpContext, service: AudioUploadUrlService) {
+    const payload = await ctx.request.validateUsing(schema);
+    return ctx.response.ok(await service.execute(ctx.params.id, payload));
+  }
+}

--- a/apps/backend/app/modules/orgs/events/videos/audio-upload-url/service.ts
+++ b/apps/backend/app/modules/orgs/events/videos/audio-upload-url/service.ts
@@ -1,0 +1,17 @@
+import drive from "@adonisjs/drive/services/main";
+import { randomUUID } from "node:crypto";
+import type { Validator } from "./validator.ts";
+
+export class AudioUploadUrlService {
+  async execute(eventId: string, input: Validator) {
+    const disk = drive.use("r2");
+    const key = `event-audio/${eventId}/${randomUUID()}.mp3`;
+
+    const url = await disk.getSignedUploadUrl(key, {
+      expiresIn: "15 mins",
+      contentType: input.contentType,
+    });
+
+    return { key, url };
+  }
+}

--- a/apps/backend/app/modules/orgs/events/videos/audio-upload-url/validator.ts
+++ b/apps/backend/app/modules/orgs/events/videos/audio-upload-url/validator.ts
@@ -1,0 +1,15 @@
+import vine from "@vinejs/vine";
+import { type Infer } from "@vinejs/vine/types";
+
+export const schema = vine.compile(
+  vine.object({
+    contentType: vine.enum(["audio/mpeg", "audio/mp3"]),
+    filename: vine
+      .string()
+      .trim()
+      .minLength(1)
+      .maxLength(300)
+      .regex(/\.mp3$/i),
+  })
+);
+export type Validator = Infer<typeof schema>;

--- a/apps/backend/app/modules/orgs/events/videos/create/service.ts
+++ b/apps/backend/app/modules/orgs/events/videos/create/service.ts
@@ -26,6 +26,8 @@ export class CreateVideoService {
           title: input.title,
           youtubeId: input.youtubeId,
           sortOrder: (row?.maxOrder ?? -1) + 1,
+          audioKey: input.audioKey ?? null,
+          audioFilename: input.audioFilename ?? null,
         })
         .returning();
 

--- a/apps/backend/app/modules/orgs/events/videos/create/validator.ts
+++ b/apps/backend/app/modules/orgs/events/videos/create/validator.ts
@@ -6,6 +6,8 @@ export const schema = vine.compile(
     title: vine.string().trim().minLength(1).maxLength(300),
     categoryId: vine.string().uuid(),
     youtubeId: vine.string().trim().minLength(1).maxLength(20),
+    audioKey: vine.string().maxLength(500).nullable().optional(),
+    audioFilename: vine.string().maxLength(300).nullable().optional(),
   })
 );
 export type Validator = Infer<typeof schema>;

--- a/apps/backend/app/modules/orgs/events/videos/list/service.ts
+++ b/apps/backend/app/modules/orgs/events/videos/list/service.ts
@@ -2,18 +2,34 @@ import { DatabaseService } from "#database/service";
 import { eventVideos } from "#database/schema/org-events";
 import { inject } from "@adonisjs/core";
 import { eq, asc } from "drizzle-orm";
+import drive from "@adonisjs/drive/services/main";
 
 @inject()
 export class ListVideosService {
   constructor(private db: DatabaseService) {}
 
   async execute(eventId: string) {
-    return this.db.use((db) =>
+    const videos = await this.db.use((db) =>
       db
         .select()
         .from(eventVideos)
         .where(eq(eventVideos.eventId, eventId))
         .orderBy(asc(eventVideos.sortOrder), asc(eventVideos.createdAt))
     );
+
+    const disk = drive.use("r2");
+    const results = await Promise.all(
+      videos.map(async (video) => {
+        if (!video.audioKey) {
+          return { ...video, audioUrl: null };
+        }
+        const audioUrl = await disk.getSignedUrl(video.audioKey, {
+          expiresIn: "1 hr",
+        });
+        return { ...video, audioUrl };
+      })
+    );
+
+    return results;
   }
 }

--- a/apps/backend/app/modules/orgs/events/videos/update/service.ts
+++ b/apps/backend/app/modules/orgs/events/videos/update/service.ts
@@ -29,6 +29,10 @@ export class UpdateVideoService {
           title: input.title,
           categoryId: input.categoryId,
           youtubeId: input.youtubeId,
+          ...(input.audioKey !== undefined && { audioKey: input.audioKey }),
+          ...(input.audioFilename !== undefined && {
+            audioFilename: input.audioFilename,
+          }),
         })
         .where(
           and(eq(eventVideos.id, videoId), eq(eventVideos.eventId, eventId))

--- a/apps/backend/app/modules/orgs/events/videos/update/validator.ts
+++ b/apps/backend/app/modules/orgs/events/videos/update/validator.ts
@@ -6,6 +6,8 @@ export const schema = vine.compile(
     title: vine.string().trim().minLength(1).maxLength(300),
     categoryId: vine.string().uuid(),
     youtubeId: vine.string().trim().minLength(1).maxLength(20),
+    audioKey: vine.string().maxLength(500).nullable().optional(),
+    audioFilename: vine.string().maxLength(300).nullable().optional(),
   })
 );
 export type Validator = Infer<typeof schema>;

--- a/apps/frontend/src/features/org/api/video-queries.ts
+++ b/apps/frontend/src/features/org/api/video-queries.ts
@@ -24,6 +24,9 @@ export interface EventVideo {
   sortOrder: number;
   createdAt: string;
   updatedAt: string;
+  audioKey?: string | null;
+  audioFilename?: string | null;
+  audioUrl?: string | null;
 }
 
 export interface EventVideoGroup {
@@ -141,6 +144,8 @@ export function useCreateVideo(slug: string, eventId: string) {
       title: string;
       categoryId: string;
       youtubeId: string;
+      audioKey?: string | null;
+      audioFilename?: string | null;
     }) =>
       postJson<EventVideo>(
         `/orgs/${slug}/events/${eventId}/videos`,
@@ -167,6 +172,8 @@ export function useUpdateVideo(slug: string, eventId: string) {
       title: string;
       categoryId: string;
       youtubeId: string;
+      audioKey?: string | null;
+      audioFilename?: string | null;
     }) =>
       patchJson<EventVideo>(
         `/orgs/${slug}/events/${eventId}/videos/${videoId}`,
@@ -197,6 +204,22 @@ export function useDeleteVideo(slug: string, eventId: string) {
     onError: () => {
       toastManager.add({
         title: "Failed to delete video",
+        type: "error",
+      });
+    },
+  });
+}
+
+export function useAudioUploadUrl(slug: string, eventId: string) {
+  return useMutation({
+    mutationFn: (body: { contentType: string; filename: string }) =>
+      postJson<{ key: string; url: string }>(
+        `/orgs/${slug}/events/${eventId}/videos/audio-upload-url`,
+        body,
+      ),
+    onError: () => {
+      toastManager.add({
+        title: "Failed to get audio upload URL",
         type: "error",
       });
     },

--- a/apps/frontend/src/features/org/components/event-video/add-edit-video-dialog.tsx
+++ b/apps/frontend/src/features/org/components/event-video/add-edit-video-dialog.tsx
@@ -17,7 +17,9 @@ import {
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
 import { getYouTubeId } from "@/utils/get-youtube-id";
+import { uploadToCloudflare } from "@/utils/upload-to-cloudflare";
 import { useMemo, useRef, useState } from "react";
+import { Music2Icon, XIcon } from "lucide-react";
 import type {
   EventVideo,
   VideoCategory,
@@ -25,6 +27,7 @@ import type {
 import {
   useCreateVideo,
   useUpdateVideo,
+  useAudioUploadUrl,
 } from "@/features/org/api/video-queries";
 
 interface AddEditVideoDialogProps {
@@ -47,13 +50,21 @@ export function AddEditVideoDialog({
   const isEditing = !!editingVideo;
   const createVideo = useCreateVideo(slug, eventId);
   const updateVideo = useUpdateVideo(slug, eventId);
-  const isPending = createVideo.isPending || updateVideo.isPending;
 
   const prevOpenRef = useRef(open);
   const [title, setTitle] = useState("");
   const [categoryId, setCategoryId] = useState<string>("");
   const [youtubeUrl, setYoutubeUrl] = useState("");
   const [errors, setErrors] = useState<Record<string, string>>({});
+  const [audioFile, setAudioFile] = useState<File | null>(null);
+  const [existingAudioFilename, setExistingAudioFilename] = useState<
+    string | null
+  >(null);
+  const [audioRemoved, setAudioRemoved] = useState(false);
+  const [audioUploading, setAudioUploading] = useState(false);
+  const [audioProgress, setAudioProgress] = useState(0);
+  const audioUploadUrl = useAudioUploadUrl(slug, eventId);
+  const audioInputRef = useRef<HTMLInputElement>(null);
 
   if (open && !prevOpenRef.current) {
     if (editingVideo) {
@@ -62,14 +73,23 @@ export function AddEditVideoDialog({
       setYoutubeUrl(
         `https://www.youtube.com/watch?v=${editingVideo.youtubeId}`,
       );
+      setExistingAudioFilename(editingVideo.audioFilename ?? null);
     } else {
       setTitle("");
       setCategoryId("");
       setYoutubeUrl("");
+      setExistingAudioFilename(null);
     }
     setErrors({});
+    setAudioFile(null);
+    setAudioRemoved(false);
+    setAudioUploading(false);
+    setAudioProgress(0);
   }
   prevOpenRef.current = open;
+
+  const isPending =
+    createVideo.isPending || updateVideo.isPending || audioUploading;
 
   const youtubeId = useMemo(() => getYouTubeId(youtubeUrl), [youtubeUrl]);
 
@@ -84,10 +104,64 @@ export function AddEditVideoDialog({
     return Object.keys(next).length === 0;
   }
 
-  function handleSubmit() {
+  function handleAudioSelect(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (file.size > 20 * 1024 * 1024) {
+      setErrors((prev) => ({ ...prev, audio: "File must be under 20 MB" }));
+      return;
+    }
+    setErrors((prev) => {
+      const { audio: _, ...rest } = prev;
+      return rest;
+    });
+    setAudioFile(file);
+    setExistingAudioFilename(null);
+    setAudioRemoved(false);
+  }
+
+  function clearAudio() {
+    setAudioFile(null);
+    setExistingAudioFilename(null);
+    setAudioRemoved(true);
+    if (audioInputRef.current) audioInputRef.current.value = "";
+  }
+
+  async function handleSubmit() {
     if (!validate() || !youtubeId) return;
 
-    const body = { title: title.trim(), categoryId, youtubeId };
+    let audioKey: string | null | undefined;
+    let audioFilename: string | null | undefined;
+
+    if (audioFile) {
+      setAudioUploading(true);
+      setAudioProgress(0);
+      try {
+        const { key, url } = await audioUploadUrl.mutateAsync({
+          contentType: audioFile.type || "audio/mpeg",
+          filename: audioFile.name,
+        });
+        await uploadToCloudflare(url, audioFile, setAudioProgress);
+        audioKey = key;
+        audioFilename = audioFile.name;
+      } catch {
+        setErrors((prev) => ({ ...prev, audio: "Audio upload failed" }));
+        setAudioUploading(false);
+        return;
+      }
+      setAudioUploading(false);
+    } else if (audioRemoved) {
+      audioKey = null;
+      audioFilename = null;
+    }
+
+    const body = {
+      title: title.trim(),
+      categoryId,
+      youtubeId,
+      ...(audioKey !== undefined && { audioKey }),
+      ...(audioFilename !== undefined && { audioFilename }),
+    };
 
     if (isEditing && editingVideo) {
       updateVideo.mutate(
@@ -161,6 +235,79 @@ export function AddEditVideoDialog({
               </div>
             </div>
           )}
+
+          <Field invalid={!!errors.audio}>
+            <FieldLabel>Music Track (optional)</FieldLabel>
+            {audioFile ? (
+              <div className="flex items-center gap-2 rounded-lg border bg-muted/50 px-3 py-2 text-sm">
+                <Music2Icon className="size-4 shrink-0 text-muted-foreground" />
+                <span className="min-w-0 flex-1 truncate">
+                  {audioFile.name}
+                </span>
+                <span className="shrink-0 text-muted-foreground">
+                  {(audioFile.size / (1024 * 1024)).toFixed(1)} MB
+                </span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  onClick={clearAudio}
+                >
+                  <XIcon className="size-3" />
+                </Button>
+              </div>
+            ) : existingAudioFilename && !audioRemoved ? (
+              <div className="flex items-center gap-2 rounded-lg border bg-muted/50 px-3 py-2 text-sm">
+                <Music2Icon className="size-4 shrink-0 text-muted-foreground" />
+                <span className="min-w-0 flex-1 truncate">
+                  {existingAudioFilename}
+                </span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  onClick={clearAudio}
+                >
+                  <XIcon className="size-3" />
+                </Button>
+              </div>
+            ) : (
+              <div>
+                <input
+                  ref={audioInputRef}
+                  type="file"
+                  accept="audio/mpeg,.mp3"
+                  onChange={handleAudioSelect}
+                  className="hidden"
+                  id="audio-file-input"
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => audioInputRef.current?.click()}
+                >
+                  <Music2Icon className="mr-1.5 size-3.5" />
+                  Add music track (MP3, max 20 MB)
+                </Button>
+              </div>
+            )}
+            {audioUploading && (
+              <div className="mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-muted">
+                <div
+                  className="h-full rounded-full bg-primary transition-all duration-300"
+                  style={{ width: `${audioProgress}%` }}
+                />
+              </div>
+            )}
+            <FieldError
+              error={
+                errors.audio
+                  ? { type: "validate", message: errors.audio }
+                  : undefined
+              }
+            />
+          </Field>
         </div>
 
         <DialogFooter>

--- a/apps/frontend/src/features/org/components/event-video/event-video-card.tsx
+++ b/apps/frontend/src/features/org/components/event-video/event-video-card.tsx
@@ -7,7 +7,7 @@ import {
   DialogClose,
 } from "@/components/ui/dialog";
 import { Frame, FramePanel } from "@/components/ui/frame";
-import { PencilIcon, Trash2Icon, VideoIcon, XIcon } from "lucide-react";
+import { DownloadIcon, PencilIcon, Trash2Icon, VideoIcon, XIcon } from "lucide-react";
 import { useState } from "react";
 import type { EventVideo, VideoCategory } from "@/features/org/api/video-queries";
 
@@ -82,6 +82,23 @@ export function EventVideoCard({ video, category, onEdit, onDelete }: EventVideo
               </div>
             )}
           </div>
+          {video.audioUrl && (
+            <div className="flex items-center gap-2 border-t px-3 py-2">
+              <audio
+                controls
+                src={video.audioUrl}
+                preload="none"
+                className="h-8 min-w-0 flex-1"
+              />
+              <a
+                href={video.audioUrl}
+                download={video.audioFilename ?? "audio.mp3"}
+                className="inline-flex shrink-0 items-center justify-center rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              >
+                <DownloadIcon className="size-4" />
+              </a>
+            </div>
+          )}
         </FramePanel>
       </Frame>
 


### PR DESCRIPTION
## Summary

- Add optional MP3 file upload alongside each video entry so dancers get counts video + music in one place
- Backend: presigned R2 upload URL endpoint, audio fields on create/update video, presigned GET URLs in list response
- Frontend: audio file picker with progress bar in add/edit dialog, inline HTML5 audio player + download button on dancer video cards

## Changes

### Backend
- `event_videos` table gains nullable `audioKey` (R2 object key) and `audioFilename` columns
- New `POST .../videos/audio-upload-url` endpoint returns presigned R2 PUT URL for MP3 uploads
- Create/update video validators accept optional `audioKey` and `audioFilename`
- List videos generates presigned GET URLs for audio playback (1hr TTL)

### Frontend
- `EventVideo` type extended with `audioKey`, `audioFilename`, `audioUrl`
- New `useAudioUploadUrl` mutation for presigned URL requests
- Add/edit dialog: file picker, 20MB validation, upload progress bar, remove/replace states
- Video card: `<audio controls>` player + download button when audio is present

## Test Plan

- [ ] Admin: add video with MP3 → progress bar shows, dialog closes, video appears
- [ ] Admin: add video without MP3 → saves normally, no audio strip on card
- [ ] Admin: edit video, remove audio → audio strip disappears
- [ ] Admin: edit video, replace audio → new audio plays
- [ ] Dancer: audio player visible on card, plays correctly
- [ ] Dancer: download button downloads with original filename
- [ ] Verify 20MB file size validation rejects large files
- [ ] Run `pnpm make:docs` and `pnpm types` after merge to regenerate API types

🤖 Generated with [Claude Code](https://claude.com/claude-code)