### PR TITLE
feat: callbacks publish system with showcase lifecycle

### DIFF
--- a/apps/backend/.adonisjs/api.ts
+++ b/apps/backend/.adonisjs/api.ts
@@ -220,8 +220,8 @@ type OrgsIdEventsIdRostersIdPatch = {
   response: MakeTuyauResponse<import('../app/modules/orgs/events/rosters/update/controller.ts').default['handle'], true>
 }
 type OrgsIdEventsIdRostersDelete = {
-  request: MakeTuyauRequest<InferInput<typeof import('../app/modules/orgs/events/rosters/delete/validator.ts')['schema']>>
-  response: MakeTuyauResponse<import('../app/modules/orgs/events/rosters/delete/controller.ts').default['handle'], true>
+  request: unknown
+  response: MakeTuyauResponse<import('../app/modules/orgs/events/rosters/delete/controller.ts').default['handle'], false>
 }
 type OrgsIdEventsIdRostersResendinvitesPost = {
   request: MakeTuyauRequest<InferInput<typeof import('../app/modules/orgs/events/rosters/resend-invites/validator.ts')['schema']>>
@@ -386,6 +386,22 @@ type OrgsIdCallbacksIdDelete = {
 type OrgsIdAdminCallbacksGetHead = {
   request: unknown
   response: MakeTuyauResponse<import('../app/modules/orgs/scouting/callbacks/admin-board/controller.ts').default['handle'], false>
+}
+type OrgsIdShowcasesGetHead = {
+  request: unknown
+  response: MakeTuyauResponse<import('../app/modules/orgs/scouting/showcases/list/controller.ts').default['handle'], false>
+}
+type OrgsIdShowcasesPublishPost = {
+  request: unknown
+  response: MakeTuyauResponse<import('../app/modules/orgs/scouting/showcases/publish/controller.ts').default['handle'], false>
+}
+type OrgsIdShowcasesNextPost = {
+  request: unknown
+  response: MakeTuyauResponse<import('../app/modules/orgs/scouting/showcases/next/controller.ts').default['handle'], false>
+}
+type OrgsIdDancerCallbacksGetHead = {
+  request: unknown
+  response: MakeTuyauResponse<import('../app/modules/orgs/scouting/callbacks/dancer-callbacks/controller.ts').default['handle'], false>
 }
 type OrgsIdGetHead = {
   request: unknown
@@ -1261,6 +1277,30 @@ export interface ApiDefinition {
           };
           '$get': OrgsIdAdminCallbacksGetHead;
           '$head': OrgsIdAdminCallbacksGetHead;
+        };
+      };
+      'showcases': {
+        '$url': {
+        };
+        '$get': OrgsIdShowcasesGetHead;
+        '$head': OrgsIdShowcasesGetHead;
+        'publish': {
+          '$url': {
+          };
+          '$post': OrgsIdShowcasesPublishPost;
+        };
+        'next': {
+          '$url': {
+          };
+          '$post': OrgsIdShowcasesNextPost;
+        };
+      };
+      'dancer': {
+        'callbacks': {
+          '$url': {
+          };
+          '$get': OrgsIdDancerCallbacksGetHead;
+          '$head': OrgsIdDancerCallbacksGetHead;
         };
       };
       '$url': {

--- a/apps/backend/app/database/drizzle/20260518064741_curly_senator_kelly/migration.sql
+++ b/apps/backend/app/database/drizzle/20260518064741_curly_senator_kelly/migration.sql
@@ -1,0 +1,44 @@
+CREATE TABLE "event_showcases" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+	"event_id" uuid NOT NULL,
+	"number" integer NOT NULL,
+	"status" text DEFAULT 'active' NOT NULL,
+	"published_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "published_callbacks" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+	"showcase_id" uuid NOT NULL,
+	"coach_roster_id" uuid NOT NULL,
+	"dancer_roster_id" uuid NOT NULL,
+	"rank" integer NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DROP INDEX "event_callbacks_event_id_coach_roster_id_dancer_roster_id_index";--> statement-breakpoint
+ALTER TABLE "event_callbacks" ADD COLUMN "showcase_id" uuid;
+--> statement-breakpoint
+INSERT INTO "event_showcases" ("event_id", "number", "status")
+SELECT DISTINCT "event_id", 1, 'active'
+FROM "event_callbacks"
+ON CONFLICT DO NOTHING;
+--> statement-breakpoint
+UPDATE "event_callbacks" SET "showcase_id" = (
+  SELECT "id" FROM "event_showcases"
+  WHERE "event_showcases"."event_id" = "event_callbacks"."event_id"
+  LIMIT 1
+);
+--> statement-breakpoint
+ALTER TABLE "event_callbacks" ALTER COLUMN "showcase_id" SET NOT NULL;
+--> statement-breakpoint
+CREATE UNIQUE INDEX "event_callbacks_showcase_id_coach_roster_id_dancer_roster_id_index" ON "event_callbacks" ("showcase_id","coach_roster_id","dancer_roster_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "event_showcases_one_active_per_event" ON "event_showcases" ("event_id") WHERE status = 'active';--> statement-breakpoint
+CREATE INDEX "event_showcases_event_id_index" ON "event_showcases" ("event_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "published_callbacks_showcase_id_coach_roster_id_dancer_roster_id_index" ON "published_callbacks" ("showcase_id","coach_roster_id","dancer_roster_id");--> statement-breakpoint
+CREATE INDEX "published_callbacks_showcase_id_dancer_roster_id_index" ON "published_callbacks" ("showcase_id","dancer_roster_id");--> statement-breakpoint
+ALTER TABLE "event_callbacks" ADD CONSTRAINT "event_callbacks_showcase_id_event_showcases_id_fkey" FOREIGN KEY ("showcase_id") REFERENCES "event_showcases"("id") ON DELETE CASCADE;--> statement-breakpoint
+ALTER TABLE "event_showcases" ADD CONSTRAINT "event_showcases_event_id_org_events_id_fkey" FOREIGN KEY ("event_id") REFERENCES "org_events"("id") ON DELETE CASCADE;--> statement-breakpoint
+ALTER TABLE "published_callbacks" ADD CONSTRAINT "published_callbacks_showcase_id_event_showcases_id_fkey" FOREIGN KEY ("showcase_id") REFERENCES "event_showcases"("id") ON DELETE CASCADE;--> statement-breakpoint
+ALTER TABLE "published_callbacks" ADD CONSTRAINT "published_callbacks_coach_roster_id_event_rosters_id_fkey" FOREIGN KEY ("coach_roster_id") REFERENCES "event_rosters"("id") ON DELETE CASCADE;--> statement-breakpoint
+ALTER TABLE "published_callbacks" ADD CONSTRAINT "published_callbacks_dancer_roster_id_event_rosters_id_fkey" FOREIGN KEY ("dancer_roster_id") REFERENCES "event_rosters"("id") ON DELETE CASCADE;

--- a/apps/backend/app/database/drizzle/20260518064741_curly_senator_kelly/snapshot.json
+++ b/apps/backend/app/database/drizzle/20260518064741_curly_senator_kelly/snapshot.json
@@ -1,0 +1,11047 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "a39937ca-121f-45b1-a5c0-498c0cd76cb5",
+  "prevIds": [
+    "bc911b11-73c9-444b-b3ac-e9656d432eca"
+  ],
+  "ddl": [
+    {
+      "values": [
+        "dancer",
+        "school"
+      ],
+      "name": "account_type",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "upload",
+        "create",
+        "update",
+        "delete",
+        "activate",
+        "resend_invite"
+      ],
+      "name": "audit_action",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "roster",
+        "event",
+        "checklist",
+        "csv_upload",
+        "invite",
+        "video_category",
+        "video"
+      ],
+      "name": "audit_resource",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "uda",
+        "dtu",
+        "nda",
+        "usa",
+        "non-competitive",
+        "other"
+      ],
+      "name": "competitive_circuit_type",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "audition",
+        "rehearsal",
+        "recital",
+        "showcase",
+        "competition",
+        "class",
+        "intensive",
+        "workshop",
+        "fundraiser",
+        "combine",
+        "convention",
+        "clinic",
+        "deadline",
+        "recruitment",
+        "performance",
+        "camp",
+        "other"
+      ],
+      "name": "dance_event_type",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "image",
+        "video",
+        "profile",
+        "reference",
+        "achievement"
+      ],
+      "name": "feed_item_type",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "image",
+        "video"
+      ],
+      "name": "media_type",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "coach",
+        "dancer"
+      ],
+      "name": "org_member_type",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "admin",
+        "member"
+      ],
+      "name": "org_role",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "core",
+        "prodigy"
+      ],
+      "name": "platform_name",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "org_event"
+      ],
+      "name": "premium_grant_source",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "pending",
+        "released",
+        "in_review",
+        "accepted"
+      ],
+      "name": "prospect_status",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "admin",
+        "prodigy_admin",
+        "user"
+      ],
+      "name": "role",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "pending",
+        "accepted",
+        "rejected"
+      ],
+      "name": "school_application_status",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "stripe",
+        "revenuecat"
+      ],
+      "name": "subscription_source",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "recruitment",
+        "audition",
+        "hybrid"
+      ],
+      "name": "team_selection_type",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "youtube",
+        "cloudflare"
+      ],
+      "name": "video_type",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "pending",
+        "processing",
+        "ready",
+        "failed"
+      ],
+      "name": "video_upload_status",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "crv_submissions",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "crv_videos",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "dancer_achievements",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "dancer_profiles",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "dancer_interests",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "dancer_references",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "dance_event_attendees",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "dance_event_schedules",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "dance_events",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "global_dance_event_attendees",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "global_dance_events",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "feed",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "video_library",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "posts",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "profile_images",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "video_uploads",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "profile_videos",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "global_notifications",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "notifications",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "outbox",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "processed_events",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "org_dancer_invites",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "org_memberships",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "organizations",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "premium_grants",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "school_favorites",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "dancer_follows",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "profile_views",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "school_applications",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "school_invites",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "school_profiles",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "suggested_claim_dismissals",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "dancer_skills",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "school_skills",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "skill_rarity",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "profile_skills",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "dancer_sports",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "school_sports",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "profile_sports",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "dancer_styles",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "school_styles",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "profile_styles",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "user_subscriptions",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "user_platforms",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "user_activities",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "users",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "csv_uploads",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "event_audit_log",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "event_checklist",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "event_dancer_profiles",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "event_rosters",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "event_video_categories",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "event_videos",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "org_events",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "event_callbacks",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "event_favorites",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "event_notes",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "event_ratings",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "event_school_selections",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "event_showcases",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "published_callbacks",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crv_submissions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dancer_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crv_submissions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "school_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crv_submissions"
+    },
+    {
+      "type": "prospect_status",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'pending'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crv_submissions"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "watched",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crv_submissions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "watched_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crv_submissions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crv_submissions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crv_submissions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crv_videos"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dancer_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crv_videos"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "youtube_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crv_videos"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crv_videos"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crv_videos"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_achievements"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "profile_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_achievements"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_achievements"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_achievements"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_achievements"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_achievements"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "type": "date",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "birthday",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "location",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "biography",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "awards",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "instagram",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "tiktok",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "youtube",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "team_level",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "high_school",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "studio",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "type": "double precision",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "gpa",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "grad_year",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "training_hours",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dancer_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_interests"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "school_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_interests"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "1",
+      "generated": null,
+      "identity": null,
+      "name": "count",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_interests"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_interests"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_interests"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_references"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "profile_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_references"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_references"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_references"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_references"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_references"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_references"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_event_attendees"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_event_attendees"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_event_attendees"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_event_attendees"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_event_schedules"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_event_schedules"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "schedule",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_event_schedules"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_event_schedules"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_event_schedules"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "school_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "location",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "address",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "website",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 1,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "tags",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "type": "numeric",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "cost",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "type": "dance_event_type",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "start_datetime",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "end_datetime",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_dance_event_attendees"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_dance_event_attendees"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_dance_event_attendees"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_dance_event_attendees"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_dance_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_dance_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "thumbnail",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_dance_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_dance_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "location",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_dance_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "website",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_dance_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_dance_events"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "start_datetime",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_dance_events"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "end_datetime",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_dance_events"
+    },
+    {
+      "type": "dance_event_type",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_dance_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_dance_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_dance_events"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "feed"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "content_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "feed"
+    },
+    {
+      "type": "feed_item_type",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "content_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "feed"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "payload",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "feed"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "feed"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "feed"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "feed"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "video_library"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "video_library"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "category",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "video_library"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "video_library"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "video_library"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "video_library"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "content",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "thumbnail",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 1,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "tags",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_images"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_images"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "media_url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_images"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "caption",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_images"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_images"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_images"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "video_uploads"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "video_uploads"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "cloudflare_media_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "video_uploads"
+    },
+    {
+      "type": "video_upload_status",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'pending'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "video_uploads"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "thumbnail_url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "video_uploads"
+    },
+    {
+      "type": "real",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "duration",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "video_uploads"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "error_message",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "video_uploads"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "video_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "video_uploads"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "video_uploads"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "video_uploads"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_videos"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_videos"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "media_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_videos"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "caption",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_videos"
+    },
+    {
+      "type": "video_type",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'youtube'",
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_videos"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_videos"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_videos"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_notifications"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "content",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_notifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_notifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_notifications"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "notifications"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "notifications"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "content",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "notifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "seen_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "notifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "notifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "notifications"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "outbox"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "outbox"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "payload",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "outbox"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "published_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "outbox"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "outbox"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "processed_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "processed_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "processed_events"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_dancer_invites"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "org_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_dancer_invites"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_dancer_invites"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_dancer_invites"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_dancer_invites"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "consumed_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_dancer_invites"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_dancer_invites"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_dancer_invites"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_memberships"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_memberships"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "org_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_memberships"
+    },
+    {
+      "type": "org_role",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'member'",
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_memberships"
+    },
+    {
+      "type": "org_member_type",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_memberships"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_memberships"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_memberships"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "logo_url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "primary_color",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "accent_color",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "features",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "settings",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "premium_grants"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "premium_grants"
+    },
+    {
+      "type": "premium_grant_source",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "premium_grants"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "premium_grants"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "granted_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "premium_grants"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "premium_grants"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "revoked_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "premium_grants"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "premium_grants"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "premium_grants"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_favorites"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "school_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_favorites"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dancer_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_favorites"
+    },
+    {
+      "type": "platform_name",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "platform_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_favorites"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source_org_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_favorites"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "comment",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_favorites"
+    },
+    {
+      "type": "smallint",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "rating",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_favorites"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_contacted",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_favorites"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_notification",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_favorites"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_favorites"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_favorites"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_follows"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dancer_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_follows"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "school_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_follows"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_follows"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_follows"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_views"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dancer_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_views"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "school_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_views"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_views"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_views"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_applications"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "school_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_applications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "media_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_applications"
+    },
+    {
+      "type": "school_application_status",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'pending'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_applications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "notes",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_applications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_applications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_applications"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_invites"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_invites"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_invites"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_invites"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_invites"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_invites"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "consumed_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_invites"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_invites"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "location",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "city",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "common_recruiting",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "team_selection_type",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'recruitment'",
+      "generated": null,
+      "identity": null,
+      "name": "team_selection",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "competitive_circuit_type",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'non-competitive'",
+      "generated": null,
+      "identity": null,
+      "name": "competitive_circuit",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "division",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "benefits",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "about",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "website",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "time_commitment",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "head_coach",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "assistant_coach",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "mission_statement",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "what_we_do",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "double precision",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "gpa",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "size",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "tiktok",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "instagram",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "suggested_claim_dismissals"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "suggested_claim_dismissals"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "roster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "suggested_claim_dismissals"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "suggested_claim_dismissals"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dancer_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_skills"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "skill_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_skills"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_skills"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_skills"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "school_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_skills"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "skill_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_skills"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "1",
+      "generated": null,
+      "identity": null,
+      "name": "weight",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_skills"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_skills"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_skills"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "skill_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "skill_rarity"
+    },
+    {
+      "type": "real",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "rarity",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "skill_rarity"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "count",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "skill_rarity"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "skill_rarity"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "skill_rarity"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_skills"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_skills"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "category",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_skills"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dancer_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_sports"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "sport_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_sports"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_sports"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_sports"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "school_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_sports"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "sport_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_sports"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_sports"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_sports"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_sports"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_sports"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dancer_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_styles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "style_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_styles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_styles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_styles"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "school_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_styles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "style_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_styles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_styles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_styles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_styles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_styles"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_subscriptions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_subscriptions"
+    },
+    {
+      "type": "subscription_source",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'active'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "subscription_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "customer_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "price_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_subscriptions"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "cancel_at_period_end",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "current_period_end",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "canceled_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_subscriptions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_platforms"
+    },
+    {
+      "type": "platform_name",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "platform_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_platforms"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_platforms"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_activities"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_activities"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_activities"
+    },
+    {
+      "type": "platform_name",
+      "typeSchema": "public",
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "platform_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_activities"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_activities"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "citext",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "username",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "citext",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "role",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "account_type",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "display_email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "first_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "password",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "avatar",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "phone",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "verified",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "true",
+      "generated": null,
+      "identity": null,
+      "name": "notifications",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_uploads"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_uploads"
+    },
+    {
+      "type": "org_member_type",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_uploads"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "file_url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_uploads"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "uploaded_by",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_uploads"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "rows_added",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_uploads"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "rows_updated",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_uploads"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "rows_errored",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_uploads"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "error_details",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_uploads"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_uploads"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_uploads"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_audit_log"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_audit_log"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "actor_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_audit_log"
+    },
+    {
+      "type": "audit_action",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "action",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_audit_log"
+    },
+    {
+      "type": "audit_resource",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "resource",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_audit_log"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "resource_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_audit_log"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_audit_log"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "parent_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_audit_log"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_audit_log"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_checklist"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_checklist"
+    },
+    {
+      "type": "varchar(160)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_checklist"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_checklist"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "completed",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_checklist"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "position",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_checklist"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_checklist"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_checklist"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_dancer_profiles"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "roster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_dancer_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "profile_photo_url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_dancer_profiles"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "grad_year",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_dancer_profiles"
+    },
+    {
+      "type": "double precision",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "gpa",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_dancer_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "studio",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_dancer_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "state",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_dancer_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "height",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_dancer_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 1,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dance_styles",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_dancer_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "bio",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_dancer_profiles"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "extra",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_dancer_profiles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_dancer_profiles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_dancer_profiles"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "type": "org_member_type",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "bib_number",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "first_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "type": "date",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expiration_date",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "csv_upload_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_video_categories"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_video_categories"
+    },
+    {
+      "type": "varchar(160)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_video_categories"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "sort_order",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_video_categories"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_video_categories"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_videos"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_videos"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "category_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_videos"
+    },
+    {
+      "type": "varchar(300)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_videos"
+    },
+    {
+      "type": "varchar(20)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "youtube_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_videos"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "sort_order",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_videos"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_videos"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_videos"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_events"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "org_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_events"
+    },
+    {
+      "type": "varchar(160)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_events"
+    },
+    {
+      "type": "date",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "start_date",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_events"
+    },
+    {
+      "type": "date",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "end_date",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "venue_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "venue_address",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "contact_email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_events"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "is_active",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "schedule_pdf_url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_events"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_callbacks"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_callbacks"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "showcase_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_callbacks"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "coach_roster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_callbacks"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dancer_roster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_callbacks"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_callbacks"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_callbacks"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_favorites"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_favorites"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "coach_roster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_favorites"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dancer_roster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_favorites"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_favorites"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_favorites"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_notes"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_notes"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "coach_roster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_notes"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dancer_roster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_notes"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "content",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_notes"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_notes"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_notes"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_ratings"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_ratings"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "coach_roster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_ratings"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dancer_roster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_ratings"
+    },
+    {
+      "type": "smallint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "rating",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_ratings"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_ratings"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_ratings"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_school_selections"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_school_selections"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dancer_roster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_school_selections"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "coach_roster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_school_selections"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_school_selections"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_showcases"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_showcases"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "number",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_showcases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'active'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_showcases"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "published_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_showcases"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_showcases"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "published_callbacks"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "showcase_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "published_callbacks"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "coach_roster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "published_callbacks"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dancer_roster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "published_callbacks"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "rank",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "published_callbacks"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "published_callbacks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "dancer_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "school_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "crv_submissions_dancer_id_school_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "crv_submissions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "school_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "crv_submissions_school_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "crv_submissions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "dancer_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "crv_videos_dancer_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "crv_videos"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "youtube_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "crv_videos_youtube_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "crv_videos"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "profile_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dancer_achievements_profile_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "dancer_achievements"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dancer_profiles_user_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "gpa",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dancer_profiles_gpa_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "location",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dancer_profiles_location_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "school_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dancer_interests_school_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "dancer_interests"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "profile_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dancer_references_profile_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "dancer_references"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dance_event_schedules_event_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "dance_event_schedules"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "school_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dance_events_school_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "start_datetime",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dance_events_start_datetime_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "tags",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "gin",
+      "concurrently": false,
+      "name": "dance_events_tags_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "start_datetime",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "global_dance_events_start_datetime_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "global_dance_events"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "feed_user_id_created_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "feed"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "feed_user_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "feed"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "feed_created_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "feed"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "video_library_created_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "video_library"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "category",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "video_library_category_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "video_library"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "slug",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "posts_slug_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "tags",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "gin",
+      "concurrently": false,
+      "name": "posts_tags_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "profile_images_user_id_created_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "profile_images"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "profile_images_user_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "profile_images"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "video_uploads_user_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "video_uploads"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "cloudflare_media_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "video_uploads_cloudflare_media_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "video_uploads"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "profile_videos_user_id_created_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "profile_videos"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "profile_videos_user_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "profile_videos"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "global_notifications_created_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "global_notifications"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "notifications_user_id_created_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "notifications"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "notifications_created_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "notifications"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "seen_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "(\"seen_at\" is null)",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "notifications_seen_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "notifications"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "outbox_type_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "outbox"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "published_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "(\"published_at\" is null)",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "outbox_published_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "outbox"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "org_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "email",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "org_dancer_invites_org_id_email_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "org_dancer_invites"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "token",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "org_dancer_invites_token_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "org_dancer_invites"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "org_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "org_memberships_user_id_org_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "org_memberships"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "org_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "org_memberships_org_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "org_memberships"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "org_memberships_user_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "org_memberships"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "slug",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organizations_slug_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "expires_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "premium_grants_user_id_expires_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "premium_grants"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "expires_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "premium_grants_expires_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "premium_grants"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "school_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "dancer_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "school_favorites_school_id_dancer_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "school_favorites"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "dancer_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "school_favorites_dancer_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "school_favorites"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "school_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "school_favorites_school_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "school_favorites"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "dancer_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "school_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dancer_follows_dancer_id_school_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "dancer_follows"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "school_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dancer_follows_school_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "dancer_follows"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "dancer_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dancer_follows_dancer_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "dancer_follows"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "dancer_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "school_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "profile_views_dancer_id_school_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "profile_views"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "email",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "school_invites_event_email",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "school_invites"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "token",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "school_invites_token_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "school_invites"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "school_profiles_user_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "gpa",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "school_profiles_gpa_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "division",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "school_profiles_division_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "location",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "school_profiles_location_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "team_selection",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "school_profiles_team_selection_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "competitive_circuit",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "school_profiles_competitive_circuit_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "suggested_claim_dismissals_user_roster",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "suggested_claim_dismissals"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "dancer_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dancer_skills_dancer_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "dancer_skills"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "school_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "school_skills_school_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "school_skills"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "category",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "profile_skills_category_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "profile_skills"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "dancer_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dancer_sports_dancer_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "dancer_sports"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "school_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "school_sports_school_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "school_sports"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "dancer_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dancer_styles_dancer_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "dancer_styles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "school_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "school_styles_school_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "school_styles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "user_subscriptions_user_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "user_subscriptions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "current_period_end",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "user_subscriptions_current_period_end_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "user_subscriptions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "user_platforms_user_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "user_platforms"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "platform_name",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "user_platforms_platform_name_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "user_platforms"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "user_activities_user_id_created_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "user_activities"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "event_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "user_activities_created_at_event_type_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "user_activities"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "users_created_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "csv_uploads_event_id_created_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "csv_uploads"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_audit_log_event_id_created_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_audit_log"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "parent_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_audit_log_parent_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_audit_log"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "actor_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_audit_log_actor_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_audit_log"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_checklist_event_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_checklist"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "email",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_rosters_event_id_email_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "bib_number",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "bib_number IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_rosters_bib_per_event",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_rosters_event_id_type_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_rosters_user_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_video_categories_event_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_video_categories"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "name",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_video_categories_event_id_name_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_video_categories"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_videos_event_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_videos"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "category_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_videos_category_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_videos"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "org_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "org_events_org_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "org_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "org_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "is_active = true",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "org_events_one_active_per_org",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "org_events"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "showcase_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "coach_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "dancer_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_callbacks_showcase_id_coach_roster_id_dancer_roster_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_callbacks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "dancer_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_callbacks_event_id_dancer_roster_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_callbacks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "coach_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_callbacks_coach_roster_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_callbacks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "coach_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "dancer_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_favorites_event_id_coach_roster_id_dancer_roster_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_favorites"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "coach_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_favorites_coach_roster_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_favorites"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "coach_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "dancer_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_notes_event_id_coach_roster_id_dancer_roster_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_notes"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "coach_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_notes_coach_roster_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_notes"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "coach_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "dancer_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_ratings_event_id_coach_roster_id_dancer_roster_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_ratings"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "coach_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_ratings_coach_roster_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_ratings"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "dancer_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "coach_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_school_selections_event_id_dancer_roster_id_coach_roster_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_school_selections"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "dancer_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_school_selections_event_id_dancer_roster_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_school_selections"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "coach_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_school_selections_event_id_coach_roster_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_school_selections"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "status = 'active'",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_showcases_one_active_per_event",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_showcases"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_showcases_event_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_showcases"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "showcase_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "coach_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "dancer_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "published_callbacks_showcase_id_coach_roster_id_dancer_roster_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "published_callbacks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "showcase_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "dancer_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "published_callbacks_showcase_id_dancer_roster_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "published_callbacks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "dancer_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "dancer_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "crv_submissions_dancer_id_dancer_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "crv_submissions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "school_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "school_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "crv_submissions_school_id_school_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "crv_submissions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "dancer_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "dancer_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "crv_videos_dancer_id_dancer_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "crv_videos"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "profile_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "dancer_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "dancer_achievements_profile_id_dancer_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "dancer_achievements"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "dancer_profiles_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "dancer_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "dancer_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "dancer_interests_dancer_id_dancer_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "dancer_interests"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "school_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "school_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "dancer_interests_school_id_school_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "dancer_interests"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "profile_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "dancer_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "dancer_references_profile_id_dancer_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "dancer_references"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "dance_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "dance_event_attendees_event_id_dance_events_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "dance_event_attendees"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "dance_event_attendees_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "dance_event_attendees"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "dance_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "dance_event_schedules_event_id_dance_events_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "dance_event_schedules"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "school_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "school_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "dance_events_school_id_school_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "global_dance_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "global_dance_event_attendees_VAnWZ7akpnDz_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "global_dance_event_attendees"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "global_dance_event_attendees_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "global_dance_event_attendees"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "feed_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "feed"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "profile_images_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "profile_images"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "video_uploads_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "video_uploads"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "video_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "profile_videos",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "video_uploads_video_id_profile_videos_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "video_uploads"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "profile_videos_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "profile_videos"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "notifications_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "notifications"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "org_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "org_dancer_invites_org_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "org_dancer_invites"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "org_memberships_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "org_memberships"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "org_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "org_memberships_org_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "org_memberships"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "premium_grants_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "premium_grants"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "school_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "school_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "school_favorites_school_id_school_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "school_favorites"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "dancer_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "dancer_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "school_favorites_dancer_id_dancer_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "school_favorites"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "source_org_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "school_favorites_source_org_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "school_favorites"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "dancer_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "dancer_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "dancer_follows_dancer_id_dancer_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "dancer_follows"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "school_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "school_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "dancer_follows_school_id_school_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "dancer_follows"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "dancer_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "dancer_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "profile_views_dancer_id_dancer_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "profile_views"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "school_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "school_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "profile_views_school_id_school_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "profile_views"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "school_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "school_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "school_applications_school_id_school_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "school_applications"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "org_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "school_invites_event_id_org_events_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "school_invites"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "school_profiles_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "suggested_claim_dismissals_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "suggested_claim_dismissals"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "roster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_rosters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "suggested_claim_dismissals_roster_id_event_rosters_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "suggested_claim_dismissals"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "dancer_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "dancer_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "dancers_to_skills_dancer_id_dancer_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "dancer_skills"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "skill_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "profile_skills",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "dancer_skills_skill_id_profile_skills_slug_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "dancer_skills"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "school_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "school_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "schools_to_skills_school_id_school_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "school_skills"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "skill_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "profile_skills",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "school_skills_skill_id_profile_skills_slug_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "school_skills"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "skill_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "profile_skills",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "skill_rarity_skill_id_profile_skills_slug_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "skill_rarity"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "dancer_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "dancer_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "dancer_sports_dancer_id_dancer_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "dancer_sports"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "sport_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "profile_sports",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "dancer_sports_sport_id_profile_sports_slug_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "dancer_sports"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "school_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "school_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "school_sports_school_id_school_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "school_sports"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "sport_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "profile_sports",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "school_sports_sport_id_profile_sports_slug_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "school_sports"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "dancer_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "dancer_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "dancers_to_styles_dancer_id_dancer_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "dancer_styles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "style_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "profile_styles",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "dancer_styles_style_id_profile_styles_slug_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "dancer_styles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "school_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "school_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "schools_to_styles_school_id_school_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "school_styles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "style_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "profile_styles",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "school_styles_style_id_profile_styles_slug_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "school_styles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_subscriptions_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_subscriptions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_platforms_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_platforms"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_activities_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_activities"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "org_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "csv_uploads_event_id_org_events_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "csv_uploads"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "uploaded_by"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "RESTRICT",
+      "name": "csv_uploads_uploaded_by_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "csv_uploads"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "org_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_audit_log_event_id_org_events_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_audit_log"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "actor_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "RESTRICT",
+      "name": "event_audit_log_actor_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_audit_log"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "parent_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_audit_log",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_audit_log_parent_id_event_audit_log_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_audit_log"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "org_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_checklist_event_id_org_events_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_checklist"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "roster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_rosters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_dancer_profiles_roster_id_event_rosters_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_dancer_profiles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "org_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_rosters_event_id_org_events_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "event_rosters_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "org_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_video_categories_event_id_org_events_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_video_categories"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "org_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_videos_event_id_org_events_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_videos"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "category_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_video_categories",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "RESTRICT",
+      "name": "event_videos_category_id_event_video_categories_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_videos"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "org_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "org_events_org_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "org_events"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "org_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_callbacks_event_id_org_events_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_callbacks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "showcase_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_showcases",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_callbacks_showcase_id_event_showcases_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_callbacks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "coach_roster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_rosters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_callbacks_coach_roster_id_event_rosters_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_callbacks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "dancer_roster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_rosters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_callbacks_dancer_roster_id_event_rosters_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_callbacks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "org_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_favorites_event_id_org_events_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_favorites"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "coach_roster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_rosters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_favorites_coach_roster_id_event_rosters_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_favorites"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "dancer_roster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_rosters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_favorites_dancer_roster_id_event_rosters_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_favorites"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "org_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_notes_event_id_org_events_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_notes"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "coach_roster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_rosters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_notes_coach_roster_id_event_rosters_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_notes"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "dancer_roster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_rosters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_notes_dancer_roster_id_event_rosters_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_notes"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "org_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_ratings_event_id_org_events_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_ratings"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "coach_roster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_rosters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_ratings_coach_roster_id_event_rosters_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_ratings"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "dancer_roster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_rosters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_ratings_dancer_roster_id_event_rosters_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_ratings"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "org_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_school_selections_event_id_org_events_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_school_selections"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "dancer_roster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_rosters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_school_selections_dancer_roster_id_event_rosters_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_school_selections"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "coach_roster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_rosters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_school_selections_coach_roster_id_event_rosters_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_school_selections"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "org_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_showcases_event_id_org_events_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_showcases"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "showcase_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_showcases",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "published_callbacks_showcase_id_event_showcases_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "published_callbacks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "coach_roster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_rosters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "published_callbacks_coach_roster_id_event_rosters_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "published_callbacks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "dancer_roster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_rosters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "published_callbacks_dancer_roster_id_event_rosters_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "published_callbacks"
+    },
+    {
+      "columns": [
+        "dancer_id",
+        "school_id"
+      ],
+      "nameExplicit": false,
+      "name": "dancer_interests_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "dancer_interests"
+    },
+    {
+      "columns": [
+        "user_id",
+        "event_id"
+      ],
+      "nameExplicit": false,
+      "name": "dance_event_attendees_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "dance_event_attendees"
+    },
+    {
+      "columns": [
+        "user_id",
+        "event_id"
+      ],
+      "nameExplicit": false,
+      "name": "global_dance_event_attendees_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "global_dance_event_attendees"
+    },
+    {
+      "columns": [
+        "dancer_id",
+        "skill_id"
+      ],
+      "nameExplicit": false,
+      "name": "dancers_to_skills_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "dancer_skills"
+    },
+    {
+      "columns": [
+        "school_id",
+        "skill_id"
+      ],
+      "nameExplicit": false,
+      "name": "schools_to_skills_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "school_skills"
+    },
+    {
+      "columns": [
+        "dancer_id",
+        "sport_id"
+      ],
+      "nameExplicit": false,
+      "name": "dancer_sports_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "dancer_sports"
+    },
+    {
+      "columns": [
+        "school_id",
+        "sport_id"
+      ],
+      "nameExplicit": false,
+      "name": "school_sports_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "school_sports"
+    },
+    {
+      "columns": [
+        "dancer_id",
+        "style_id"
+      ],
+      "nameExplicit": false,
+      "name": "dancers_to_styles_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "dancer_styles"
+    },
+    {
+      "columns": [
+        "school_id",
+        "style_id"
+      ],
+      "nameExplicit": false,
+      "name": "schools_to_styles_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "school_styles"
+    },
+    {
+      "columns": [
+        "user_id",
+        "platform_name"
+      ],
+      "nameExplicit": false,
+      "name": "user_platforms_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "user_platforms"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "crv_submissions_pkey",
+      "schema": "public",
+      "table": "crv_submissions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "crv_videos_pkey",
+      "schema": "public",
+      "table": "crv_videos",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "dancer_achievements_pkey",
+      "schema": "public",
+      "table": "dancer_achievements",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "dancer_profiles_pkey",
+      "schema": "public",
+      "table": "dancer_profiles",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "dancer_references_pkey",
+      "schema": "public",
+      "table": "dancer_references",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "dance_event_schedules_pkey",
+      "schema": "public",
+      "table": "dance_event_schedules",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "dance_events_pkey",
+      "schema": "public",
+      "table": "dance_events",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "global_dance_events_pkey",
+      "schema": "public",
+      "table": "global_dance_events",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "feed_pkey",
+      "schema": "public",
+      "table": "feed",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "video_library_pkey",
+      "schema": "public",
+      "table": "video_library",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "posts_pkey",
+      "schema": "public",
+      "table": "posts",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "profile_images_pkey",
+      "schema": "public",
+      "table": "profile_images",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "video_uploads_pkey",
+      "schema": "public",
+      "table": "video_uploads",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "profile_videos_pkey",
+      "schema": "public",
+      "table": "profile_videos",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "global_notifications_pkey",
+      "schema": "public",
+      "table": "global_notifications",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "notifications_pkey",
+      "schema": "public",
+      "table": "notifications",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "outbox_pkey",
+      "schema": "public",
+      "table": "outbox",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "event_id"
+      ],
+      "nameExplicit": false,
+      "name": "processed_events_pkey",
+      "schema": "public",
+      "table": "processed_events",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "org_dancer_invites_pkey",
+      "schema": "public",
+      "table": "org_dancer_invites",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "org_memberships_pkey",
+      "schema": "public",
+      "table": "org_memberships",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "organizations_pkey",
+      "schema": "public",
+      "table": "organizations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "premium_grants_pkey",
+      "schema": "public",
+      "table": "premium_grants",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "school_favorites_pkey",
+      "schema": "public",
+      "table": "school_favorites",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "dancer_follows_pkey",
+      "schema": "public",
+      "table": "dancer_follows",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "profile_views_pkey",
+      "schema": "public",
+      "table": "profile_views",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "school_applications_pkey",
+      "schema": "public",
+      "table": "school_applications",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "school_invites_pkey",
+      "schema": "public",
+      "table": "school_invites",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "school_profiles_pkey",
+      "schema": "public",
+      "table": "school_profiles",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "suggested_claim_dismissals_pkey",
+      "schema": "public",
+      "table": "suggested_claim_dismissals",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "skill_id"
+      ],
+      "nameExplicit": false,
+      "name": "skill_rarity_pkey",
+      "schema": "public",
+      "table": "skill_rarity",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "slug"
+      ],
+      "nameExplicit": false,
+      "name": "profile_skills_pkey",
+      "schema": "public",
+      "table": "profile_skills",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "slug"
+      ],
+      "nameExplicit": false,
+      "name": "profile_sports_pkey",
+      "schema": "public",
+      "table": "profile_sports",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "slug"
+      ],
+      "nameExplicit": false,
+      "name": "profile_styles_pkey",
+      "schema": "public",
+      "table": "profile_styles",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_subscriptions_pkey",
+      "schema": "public",
+      "table": "user_subscriptions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_activities_pkey",
+      "schema": "public",
+      "table": "user_activities",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "users_pkey",
+      "schema": "public",
+      "table": "users",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "csv_uploads_pkey",
+      "schema": "public",
+      "table": "csv_uploads",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "event_audit_log_pkey",
+      "schema": "public",
+      "table": "event_audit_log",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "event_checklist_pkey",
+      "schema": "public",
+      "table": "event_checklist",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "event_dancer_profiles_pkey",
+      "schema": "public",
+      "table": "event_dancer_profiles",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "event_rosters_pkey",
+      "schema": "public",
+      "table": "event_rosters",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "event_video_categories_pkey",
+      "schema": "public",
+      "table": "event_video_categories",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "event_videos_pkey",
+      "schema": "public",
+      "table": "event_videos",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "org_events_pkey",
+      "schema": "public",
+      "table": "org_events",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "event_callbacks_pkey",
+      "schema": "public",
+      "table": "event_callbacks",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "event_favorites_pkey",
+      "schema": "public",
+      "table": "event_favorites",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "event_notes_pkey",
+      "schema": "public",
+      "table": "event_notes",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "event_ratings_pkey",
+      "schema": "public",
+      "table": "event_ratings",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "event_school_selections_pkey",
+      "schema": "public",
+      "table": "event_school_selections",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "event_showcases_pkey",
+      "schema": "public",
+      "table": "event_showcases",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "published_callbacks_pkey",
+      "schema": "public",
+      "table": "published_callbacks",
+      "entityType": "pks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "dancer_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "crv_videos_dancer_id_key",
+      "schema": "public",
+      "table": "crv_videos",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "dancer_profiles_user_id_key",
+      "schema": "public",
+      "table": "dancer_profiles",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "url"
+      ],
+      "nullsNotDistinct": false,
+      "name": "video_library_url_key",
+      "schema": "public",
+      "table": "video_library",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "nullsNotDistinct": false,
+      "name": "posts_slug_key",
+      "schema": "public",
+      "table": "posts",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "media_url"
+      ],
+      "nullsNotDistinct": false,
+      "name": "profile_images_media_url_key",
+      "schema": "public",
+      "table": "profile_images",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "cloudflare_media_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "video_uploads_cloudflare_media_id_key",
+      "schema": "public",
+      "table": "video_uploads",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "media_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "profile_videos_media_id_key",
+      "schema": "public",
+      "table": "profile_videos",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "token"
+      ],
+      "nullsNotDistinct": false,
+      "name": "org_dancer_invites_token_key",
+      "schema": "public",
+      "table": "org_dancer_invites",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "nullsNotDistinct": false,
+      "name": "organizations_slug_key",
+      "schema": "public",
+      "table": "organizations",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "school_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "school_applications_school_id_key",
+      "schema": "public",
+      "table": "school_applications",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "token"
+      ],
+      "nullsNotDistinct": false,
+      "name": "school_invites_token_key",
+      "schema": "public",
+      "table": "school_invites",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "school_profiles_user_id_key",
+      "schema": "public",
+      "table": "school_profiles",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "name"
+      ],
+      "nullsNotDistinct": false,
+      "name": "school_profiles_name_key",
+      "schema": "public",
+      "table": "school_profiles",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "name"
+      ],
+      "nullsNotDistinct": false,
+      "name": "profile_skills_name_key",
+      "schema": "public",
+      "table": "profile_skills",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "name"
+      ],
+      "nullsNotDistinct": false,
+      "name": "profile_sports_name_key",
+      "schema": "public",
+      "table": "profile_sports",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "name"
+      ],
+      "nullsNotDistinct": false,
+      "name": "profile_styles_name_key",
+      "schema": "public",
+      "table": "profile_styles",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "user_subscriptions_user_id_key",
+      "schema": "public",
+      "table": "user_subscriptions",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "subscription_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "user_subscriptions_subscription_id_key",
+      "schema": "public",
+      "table": "user_subscriptions",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "username"
+      ],
+      "nullsNotDistinct": false,
+      "name": "users_username_key",
+      "schema": "public",
+      "table": "users",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "email"
+      ],
+      "nullsNotDistinct": false,
+      "name": "users_email_key",
+      "schema": "public",
+      "table": "users",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "roster_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "event_dancer_profiles_roster_id_key",
+      "schema": "public",
+      "table": "event_dancer_profiles",
+      "entityType": "uniques"
+    },
+    {
+      "value": "\"count\" <= 3",
+      "name": "count <= 3",
+      "entityType": "checks",
+      "schema": "public",
+      "table": "dancer_interests"
+    }
+  ],
+  "renames": []
+}

--- a/apps/backend/app/database/schema/event-features.ts
+++ b/apps/backend/app/database/schema/event-features.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import * as pg from "drizzle-orm/pg-core";
 import { timestamps } from "./helpers/columns.ts";
 import { orgEvents, eventRosters } from "./org-events.ts";
@@ -109,6 +110,55 @@ export const eventSchoolSelections = pg.pgTable(
   ]
 );
 
+export const eventShowcases = pg.pgTable(
+  "event_showcases",
+  {
+    id: pg.uuid().primaryKey().defaultRandom(),
+    eventId: pg
+      .uuid()
+      .notNull()
+      .references(() => orgEvents.id, { onDelete: "cascade" }),
+    number: pg.integer().notNull(),
+    status: pg.text().notNull().default("active"),
+    publishedAt: pg.timestamp({ withTimezone: true }),
+    createdAt: pg.timestamp({ withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    pg
+      .uniqueIndex("event_showcases_one_active_per_event")
+      .on(table.eventId)
+      .where(sql`status = 'active'`),
+    pg.index().on(table.eventId),
+  ]
+);
+
+export const publishedCallbacks = pg.pgTable(
+  "published_callbacks",
+  {
+    id: pg.uuid().primaryKey().defaultRandom(),
+    showcaseId: pg
+      .uuid()
+      .notNull()
+      .references(() => eventShowcases.id, { onDelete: "cascade" }),
+    coachRosterId: pg
+      .uuid()
+      .notNull()
+      .references(() => eventRosters.id, { onDelete: "cascade" }),
+    dancerRosterId: pg
+      .uuid()
+      .notNull()
+      .references(() => eventRosters.id, { onDelete: "cascade" }),
+    rank: pg.integer().notNull(),
+    createdAt: pg.timestamp({ withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    pg
+      .uniqueIndex()
+      .on(table.showcaseId, table.coachRosterId, table.dancerRosterId),
+    pg.index().on(table.showcaseId, table.dancerRosterId),
+  ]
+);
+
 export const eventCallbacks = pg.pgTable(
   "event_callbacks",
   {
@@ -117,6 +167,10 @@ export const eventCallbacks = pg.pgTable(
       .uuid()
       .notNull()
       .references(() => orgEvents.id, { onDelete: "cascade" }),
+    showcaseId: pg
+      .uuid()
+      .notNull()
+      .references(() => eventShowcases.id, { onDelete: "cascade" }),
     coachRosterId: pg
       .uuid()
       .notNull()
@@ -130,7 +184,7 @@ export const eventCallbacks = pg.pgTable(
   (table) => [
     pg
       .uniqueIndex()
-      .on(table.eventId, table.coachRosterId, table.dancerRosterId),
+      .on(table.showcaseId, table.coachRosterId, table.dancerRosterId),
     pg.index().on(table.eventId, table.dancerRosterId),
     pg.index().on(table.coachRosterId),
   ]

--- a/apps/backend/app/modules/orgs/scouting/callbacks/admin-board/controller.ts
+++ b/apps/backend/app/modules/orgs/scouting/callbacks/admin-board/controller.ts
@@ -1,11 +1,17 @@
 import { inject } from "@adonisjs/core";
 import type { HttpContext } from "@adonisjs/core/http";
 import { AdminCallbackBoardService } from "./service.ts";
+import { EnsureActiveShowcaseService } from "../../showcases/ensure-active/service.ts";
 
 export default class AdminCallbackBoardController {
   @inject()
-  async handle(ctx: HttpContext, service: AdminCallbackBoardService) {
-    const data = await service.execute(ctx.orgEvent!.id);
-    return ctx.response.ok(data);
+  async handle(
+    ctx: HttpContext,
+    service: AdminCallbackBoardService,
+    ensureShowcase: EnsureActiveShowcaseService
+  ) {
+    const showcase = await ensureShowcase.execute(ctx.orgEvent!.id);
+    const data = await service.execute(ctx.orgEvent!.id, showcase.id);
+    return ctx.response.ok({ ...data, showcase });
   }
 }

--- a/apps/backend/app/modules/orgs/scouting/callbacks/admin-board/service.ts
+++ b/apps/backend/app/modules/orgs/scouting/callbacks/admin-board/service.ts
@@ -8,7 +8,7 @@ import { asc, count, countDistinct, eq, sql } from "drizzle-orm";
 export class AdminCallbackBoardService {
   constructor(private db: DatabaseService = new DatabaseService()) {}
 
-  async execute(eventId: string) {
+  async execute(eventId: string, showcaseId: string) {
     const [bibs, stats] = await Promise.all([
       this.db.use((db) =>
         db
@@ -24,7 +24,7 @@ export class AdminCallbackBoardService {
             eventRosters,
             eq(eventRosters.id, eventCallbacks.dancerRosterId)
           )
-          .where(eq(eventCallbacks.eventId, eventId))
+          .where(eq(eventCallbacks.showcaseId, showcaseId))
           .groupBy(
             eventCallbacks.dancerRosterId,
             eventRosters.bibNumber,

--- a/apps/backend/app/modules/orgs/scouting/callbacks/create/controller.ts
+++ b/apps/backend/app/modules/orgs/scouting/callbacks/create/controller.ts
@@ -2,11 +2,16 @@ import { inject } from "@adonisjs/core";
 import type { HttpContext } from "@adonisjs/core/http";
 import transmit from "@adonisjs/transmit/services/main";
 import { CreateCallbackService } from "./service.ts";
+import { EnsureActiveShowcaseService } from "../../showcases/ensure-active/service.ts";
 import { schema } from "./validator.ts";
 
 export default class CreateCallbackController {
   @inject()
-  async handle(ctx: HttpContext, service: CreateCallbackService) {
+  async handle(
+    ctx: HttpContext,
+    service: CreateCallbackService,
+    ensureShowcase: EnsureActiveShowcaseService
+  ) {
     if (!ctx.orgRoster) {
       return ctx.response.conflict({
         message: "You must be registered in this event as a coach to scout.",
@@ -14,8 +19,17 @@ export default class CreateCallbackController {
     }
 
     const payload = await ctx.request.validateUsing(schema);
+    const showcase = await ensureShowcase.execute(ctx.orgEvent!.id);
+
+    if (showcase.status !== "active") {
+      return ctx.response.conflict({
+        message: "Cannot add callbacks — the current showcase has been published.",
+      });
+    }
+
     const row = await service.execute(
       ctx.orgEvent!.id,
+      showcase.id,
       ctx.orgRoster.id,
       payload.dancerRosterId
     );

--- a/apps/backend/app/modules/orgs/scouting/callbacks/create/service.ts
+++ b/apps/backend/app/modules/orgs/scouting/callbacks/create/service.ts
@@ -9,13 +9,14 @@ export class CreateCallbackService {
 
   async execute(
     eventId: string,
+    showcaseId: string,
     coachRosterId: string,
     dancerRosterId: string
   ) {
     const [row] = await this.db.use((db) =>
       db
         .insert(eventCallbacks)
-        .values({ eventId, coachRosterId, dancerRosterId })
+        .values({ eventId, showcaseId, coachRosterId, dancerRosterId })
         .onConflictDoNothing()
         .returning()
     );
@@ -28,7 +29,7 @@ export class CreateCallbackService {
         .from(eventCallbacks)
         .where(
           and(
-            eq(eventCallbacks.eventId, eventId),
+            eq(eventCallbacks.showcaseId, showcaseId),
             eq(eventCallbacks.coachRosterId, coachRosterId),
             eq(eventCallbacks.dancerRosterId, dancerRosterId)
           )

--- a/apps/backend/app/modules/orgs/scouting/callbacks/dancer-callbacks/controller.ts
+++ b/apps/backend/app/modules/orgs/scouting/callbacks/dancer-callbacks/controller.ts
@@ -1,0 +1,17 @@
+import { inject } from "@adonisjs/core";
+import type { HttpContext } from "@adonisjs/core/http";
+import { DancerCallbacksService } from "./service.ts";
+
+export default class DancerCallbacksController {
+  @inject()
+  async handle(ctx: HttpContext, service: DancerCallbacksService) {
+    if (!ctx.orgRoster) {
+      return ctx.response.conflict({
+        message: "You must be registered in this event as a dancer.",
+      });
+    }
+
+    const rows = await service.execute(ctx.orgEvent!.id, ctx.orgRoster.id);
+    return ctx.response.ok(rows);
+  }
+}

--- a/apps/backend/app/modules/orgs/scouting/callbacks/dancer-callbacks/service.ts
+++ b/apps/backend/app/modules/orgs/scouting/callbacks/dancer-callbacks/service.ts
@@ -1,0 +1,55 @@
+import { DatabaseService } from "#database/service";
+import {
+  eventShowcases,
+  publishedCallbacks,
+} from "#database/schema/event-features";
+import { eventRosters } from "#database/schema/org-events";
+import { inject } from "@adonisjs/core";
+import { and, desc, eq } from "drizzle-orm";
+
+@inject()
+export class DancerCallbacksService {
+  constructor(private db: DatabaseService = new DatabaseService()) {}
+
+  async execute(eventId: string, dancerRosterId: string) {
+    const [latestPublished] = await this.db.use((db) =>
+      db
+        .select()
+        .from(eventShowcases)
+        .where(
+          and(
+            eq(eventShowcases.eventId, eventId),
+            eq(eventShowcases.status, "published")
+          )
+        )
+        .orderBy(desc(eventShowcases.number))
+        .limit(1)
+    );
+
+    if (!latestPublished) {
+      return [];
+    }
+
+    return this.db.use((db) =>
+      db
+        .select({
+          coachRosterId: publishedCallbacks.coachRosterId,
+          firstName: eventRosters.firstName,
+          lastName: eventRosters.lastName,
+          organization: eventRosters.organization,
+        })
+        .from(publishedCallbacks)
+        .innerJoin(
+          eventRosters,
+          eq(eventRosters.id, publishedCallbacks.coachRosterId)
+        )
+        .where(
+          and(
+            eq(publishedCallbacks.showcaseId, latestPublished.id),
+            eq(publishedCallbacks.dancerRosterId, dancerRosterId)
+          )
+        )
+        .orderBy(publishedCallbacks.rank)
+    );
+  }
+}

--- a/apps/backend/app/modules/orgs/scouting/callbacks/delete/controller.ts
+++ b/apps/backend/app/modules/orgs/scouting/callbacks/delete/controller.ts
@@ -2,18 +2,31 @@ import { inject } from "@adonisjs/core";
 import type { HttpContext } from "@adonisjs/core/http";
 import transmit from "@adonisjs/transmit/services/main";
 import { DeleteCallbackService } from "./service.ts";
+import { EnsureActiveShowcaseService } from "../../showcases/ensure-active/service.ts";
 
 export default class DeleteCallbackController {
   @inject()
-  async handle(ctx: HttpContext, service: DeleteCallbackService) {
+  async handle(
+    ctx: HttpContext,
+    service: DeleteCallbackService,
+    ensureShowcase: EnsureActiveShowcaseService
+  ) {
     if (!ctx.orgRoster) {
       return ctx.response.conflict({
         message: "You must be registered in this event as a coach to scout.",
       });
     }
 
+    const showcase = await ensureShowcase.execute(ctx.orgEvent!.id);
+
+    if (showcase.status !== "active") {
+      return ctx.response.conflict({
+        message: "Cannot remove callbacks — the current showcase has been published.",
+      });
+    }
+
     const dancerRosterId = ctx.params.dancerRosterId as string;
-    await service.execute(ctx.orgEvent!.id, ctx.orgRoster.id, dancerRosterId);
+    await service.execute(showcase.id, ctx.orgRoster.id, dancerRosterId);
 
     transmit.broadcast(`orgs/${ctx.org!.slug}/callbacks`, {});
 

--- a/apps/backend/app/modules/orgs/scouting/callbacks/delete/service.ts
+++ b/apps/backend/app/modules/orgs/scouting/callbacks/delete/service.ts
@@ -8,7 +8,7 @@ export class DeleteCallbackService {
   constructor(private db: DatabaseService = new DatabaseService()) {}
 
   async execute(
-    eventId: string,
+    showcaseId: string,
     coachRosterId: string,
     dancerRosterId: string
   ) {
@@ -17,7 +17,7 @@ export class DeleteCallbackService {
         .delete(eventCallbacks)
         .where(
           and(
-            eq(eventCallbacks.eventId, eventId),
+            eq(eventCallbacks.showcaseId, showcaseId),
             eq(eventCallbacks.coachRosterId, coachRosterId),
             eq(eventCallbacks.dancerRosterId, dancerRosterId)
           )

--- a/apps/backend/app/modules/orgs/scouting/callbacks/list/controller.ts
+++ b/apps/backend/app/modules/orgs/scouting/callbacks/list/controller.ts
@@ -1,17 +1,23 @@
 import { inject } from "@adonisjs/core";
 import type { HttpContext } from "@adonisjs/core/http";
 import { ListCallbacksService } from "./service.ts";
+import { EnsureActiveShowcaseService } from "../../showcases/ensure-active/service.ts";
 
 export default class ListCallbacksController {
   @inject()
-  async handle(ctx: HttpContext, service: ListCallbacksService) {
+  async handle(
+    ctx: HttpContext,
+    service: ListCallbacksService,
+    ensureShowcase: EnsureActiveShowcaseService
+  ) {
     if (!ctx.orgRoster) {
       return ctx.response.conflict({
         message: "You must be registered in this event as a coach to scout.",
       });
     }
 
-    const rows = await service.execute(ctx.orgEvent!.id, ctx.orgRoster.id);
+    const showcase = await ensureShowcase.execute(ctx.orgEvent!.id);
+    const rows = await service.execute(showcase.id, ctx.orgRoster.id);
     return ctx.response.ok(rows);
   }
 }

--- a/apps/backend/app/modules/orgs/scouting/callbacks/list/service.ts
+++ b/apps/backend/app/modules/orgs/scouting/callbacks/list/service.ts
@@ -9,7 +9,7 @@ import { and, eq, sql } from "drizzle-orm";
 export class ListCallbacksService {
   constructor(private db: DatabaseService = new DatabaseService()) {}
 
-  async execute(eventId: string, coachRosterId: string) {
+  async execute(showcaseId: string, coachRosterId: string) {
     return this.db.use((db) =>
       db
         .select({
@@ -44,7 +44,7 @@ export class ListCallbacksService {
         )
         .where(
           and(
-            eq(eventCallbacks.eventId, eventId),
+            eq(eventCallbacks.showcaseId, showcaseId),
             eq(eventCallbacks.coachRosterId, coachRosterId)
           )
         )

--- a/apps/backend/app/modules/orgs/scouting/routes.ts
+++ b/apps/backend/app/modules/orgs/scouting/routes.ts
@@ -21,6 +21,11 @@ const CreateCallback = () => import("./callbacks/create/controller.ts");
 const DeleteCallback = () => import("./callbacks/delete/controller.ts");
 const AdminCallbackBoard = () => import("./callbacks/admin-board/controller.ts");
 
+const ListShowcases = () => import("./showcases/list/controller.ts");
+const PublishShowcase = () => import("./showcases/publish/controller.ts");
+const StartNextShowcase = () => import("./showcases/next/controller.ts");
+const DancerCallbacks = () => import("./callbacks/dancer-callbacks/controller.ts");
+
 router
   .group(() => {
     router.get(":slug/dancers", [ListDancersController]).openapi({
@@ -94,3 +99,35 @@ router
     middleware.orgFeature("callbacks"),
   ])
   .openapi({ tags: ["Org Admin Callbacks"] });
+
+router
+  .group(() => {
+    router.get(":slug/showcases", [ListShowcases]);
+    router.post(":slug/showcases/publish", [PublishShowcase]);
+    router.post(":slug/showcases/next", [StartNextShowcase]);
+  })
+  .prefix("orgs")
+  .use([
+    middleware.auth(),
+    middleware.org(),
+    middleware.orgEvent(),
+    middleware.orgMember(),
+    middleware.orgAdmin(),
+    middleware.orgFeature("callbacks"),
+  ])
+  .openapi({ tags: ["Org Admin Showcases"] });
+
+router
+  .group(() => {
+    router.get(":slug/dancer/callbacks", [DancerCallbacks]);
+  })
+  .prefix("orgs")
+  .use([
+    middleware.auth(),
+    middleware.org(),
+    middleware.orgEvent(),
+    middleware.orgMember(),
+    middleware.orgDancer(),
+    middleware.orgFeature("callbacks"),
+  ])
+  .openapi({ tags: ["Org Dancer Callbacks"] });

--- a/apps/backend/app/modules/orgs/scouting/showcases/ensure-active/service.ts
+++ b/apps/backend/app/modules/orgs/scouting/showcases/ensure-active/service.ts
@@ -1,0 +1,59 @@
+import { DatabaseService } from "#database/service";
+import { eventShowcases } from "#database/schema/event-features";
+import { inject } from "@adonisjs/core";
+import { and, eq, sql } from "drizzle-orm";
+
+@inject()
+export class EnsureActiveShowcaseService {
+  constructor(private db: DatabaseService = new DatabaseService()) {}
+
+  async execute(eventId: string) {
+    const [existing] = await this.db.use((db) =>
+      db
+        .select()
+        .from(eventShowcases)
+        .where(
+          and(
+            eq(eventShowcases.eventId, eventId),
+            eq(eventShowcases.status, "active")
+          )
+        )
+        .limit(1)
+    );
+
+    if (existing) return existing;
+
+    const maxNumber = await this.db.use((db) =>
+      db
+        .select({ max: sql<number>`COALESCE(MAX(${eventShowcases.number}), 0)` })
+        .from(eventShowcases)
+        .where(eq(eventShowcases.eventId, eventId))
+    );
+
+    const nextNumber = Number(maxNumber[0]?.max ?? 0) + 1;
+
+    const [row] = await this.db.use((db) =>
+      db
+        .insert(eventShowcases)
+        .values({ eventId, number: nextNumber, status: "active" })
+        .onConflictDoNothing()
+        .returning()
+    );
+
+    if (row) return row;
+
+    const [raced] = await this.db.use((db) =>
+      db
+        .select()
+        .from(eventShowcases)
+        .where(
+          and(
+            eq(eventShowcases.eventId, eventId),
+            eq(eventShowcases.status, "active")
+          )
+        )
+        .limit(1)
+    );
+    return raced!;
+  }
+}

--- a/apps/backend/app/modules/orgs/scouting/showcases/list/controller.ts
+++ b/apps/backend/app/modules/orgs/scouting/showcases/list/controller.ts
@@ -1,0 +1,11 @@
+import { inject } from "@adonisjs/core";
+import type { HttpContext } from "@adonisjs/core/http";
+import { ListShowcasesService } from "./service.ts";
+
+export default class ListShowcasesController {
+  @inject()
+  async handle(ctx: HttpContext, service: ListShowcasesService) {
+    const rows = await service.execute(ctx.orgEvent!.id);
+    return ctx.response.ok(rows);
+  }
+}

--- a/apps/backend/app/modules/orgs/scouting/showcases/list/service.ts
+++ b/apps/backend/app/modules/orgs/scouting/showcases/list/service.ts
@@ -1,0 +1,19 @@
+import { DatabaseService } from "#database/service";
+import { eventShowcases } from "#database/schema/event-features";
+import { inject } from "@adonisjs/core";
+import { asc, eq } from "drizzle-orm";
+
+@inject()
+export class ListShowcasesService {
+  constructor(private db: DatabaseService = new DatabaseService()) {}
+
+  async execute(eventId: string) {
+    return this.db.use((db) =>
+      db
+        .select()
+        .from(eventShowcases)
+        .where(eq(eventShowcases.eventId, eventId))
+        .orderBy(asc(eventShowcases.number))
+    );
+  }
+}

--- a/apps/backend/app/modules/orgs/scouting/showcases/next/controller.ts
+++ b/apps/backend/app/modules/orgs/scouting/showcases/next/controller.ts
@@ -1,0 +1,23 @@
+import { inject } from "@adonisjs/core";
+import type { HttpContext } from "@adonisjs/core/http";
+import transmit from "@adonisjs/transmit/services/main";
+import { StartNextShowcaseService } from "./service.ts";
+
+export default class StartNextShowcaseController {
+  @inject()
+  async handle(ctx: HttpContext, service: StartNextShowcaseService) {
+    try {
+      const showcase = await service.execute(ctx.orgEvent!.id);
+      transmit.broadcast(`orgs/${ctx.org!.slug}/callbacks`, {});
+      transmit.broadcast(`orgs/${ctx.org!.slug}/showcases`, {});
+      return ctx.response.created(showcase);
+    } catch (error) {
+      return ctx.response.conflict({
+        message:
+          error instanceof Error
+            ? error.message
+            : "Cannot start next showcase",
+      });
+    }
+  }
+}

--- a/apps/backend/app/modules/orgs/scouting/showcases/next/service.ts
+++ b/apps/backend/app/modules/orgs/scouting/showcases/next/service.ts
@@ -1,0 +1,55 @@
+import { DatabaseService } from "#database/service";
+import { eventShowcases } from "#database/schema/event-features";
+import { inject } from "@adonisjs/core";
+import { and, eq, sql } from "drizzle-orm";
+
+@inject()
+export class StartNextShowcaseService {
+  constructor(private db: DatabaseService = new DatabaseService()) {}
+
+  async execute(eventId: string) {
+    return this.db.tx(async (tx) => {
+      const [current] = await tx
+        .select()
+        .from(eventShowcases)
+        .where(
+          and(
+            eq(eventShowcases.eventId, eventId),
+            eq(eventShowcases.status, "published")
+          )
+        )
+        .orderBy(sql`${eventShowcases.number} DESC`)
+        .limit(1);
+
+      if (!current) {
+        throw new Error("No published showcase to follow");
+      }
+
+      const active = await tx
+        .select()
+        .from(eventShowcases)
+        .where(
+          and(
+            eq(eventShowcases.eventId, eventId),
+            eq(eventShowcases.status, "active")
+          )
+        )
+        .limit(1);
+
+      if (active.length > 0) {
+        throw new Error("An active showcase already exists");
+      }
+
+      const [next] = await tx
+        .insert(eventShowcases)
+        .values({
+          eventId,
+          number: current.number + 1,
+          status: "active",
+        })
+        .returning();
+
+      return next!;
+    });
+  }
+}

--- a/apps/backend/app/modules/orgs/scouting/showcases/publish/controller.ts
+++ b/apps/backend/app/modules/orgs/scouting/showcases/publish/controller.ts
@@ -1,0 +1,29 @@
+import { inject } from "@adonisjs/core";
+import type { HttpContext } from "@adonisjs/core/http";
+import transmit from "@adonisjs/transmit/services/main";
+import { PublishShowcaseService } from "./service.ts";
+import { EnsureActiveShowcaseService } from "../ensure-active/service.ts";
+
+export default class PublishShowcaseController {
+  @inject()
+  async handle(
+    ctx: HttpContext,
+    service: PublishShowcaseService,
+    ensureShowcase: EnsureActiveShowcaseService
+  ) {
+    const showcase = await ensureShowcase.execute(ctx.orgEvent!.id);
+
+    if (showcase.status !== "active") {
+      return ctx.response.conflict({
+        message: "Showcase has already been published.",
+      });
+    }
+
+    await service.execute(ctx.orgEvent!.id, showcase.id);
+
+    transmit.broadcast(`orgs/${ctx.org!.slug}/callbacks`, {});
+    transmit.broadcast(`orgs/${ctx.org!.slug}/showcases`, {});
+
+    return ctx.response.ok({ message: "Showcase published" });
+  }
+}

--- a/apps/backend/app/modules/orgs/scouting/showcases/publish/service.spec.ts
+++ b/apps/backend/app/modules/orgs/scouting/showcases/publish/service.spec.ts
@@ -1,0 +1,192 @@
+import { test } from "@japa/runner";
+import { db } from "#database/connection";
+import {
+  eventCallbacks,
+  eventRatings,
+  eventShowcases,
+  publishedCallbacks,
+} from "#database/schema/event-features";
+import { organizations } from "#database/schema/organizations";
+import { orgEvents, eventRosters } from "#database/schema/org-events";
+import { eq } from "drizzle-orm";
+import { PublishShowcaseService } from "./service.ts";
+
+async function setup() {
+  const [org] = await db
+    .insert(organizations)
+    .values({ name: "Test Org", slug: `test-${Date.now()}` })
+    .returning();
+
+  const [event] = await db
+    .insert(orgEvents)
+    .values({
+      orgId: org!.id,
+      name: "Test Event",
+      startDate: "2026-07-01",
+      endDate: "2026-07-02",
+      isActive: true,
+    })
+    .returning();
+
+  const [showcase] = await db
+    .insert(eventShowcases)
+    .values({ eventId: event!.id, number: 1, status: "active" })
+    .returning();
+
+  return { org: org!, event: event!, showcase: showcase! };
+}
+
+async function addCoach(eventId: string, name: string) {
+  const [roster] = await db
+    .insert(eventRosters)
+    .values({
+      eventId,
+      type: "coach",
+      email: `${name}@test.co`,
+      firstName: name,
+      lastName: "Coach",
+      organization: `${name} University`,
+    })
+    .returning();
+  return roster!;
+}
+
+async function addDancer(eventId: string, bib: number, name: string) {
+  const [roster] = await db
+    .insert(eventRosters)
+    .values({
+      eventId,
+      type: "dancer",
+      email: `dancer${bib}@test.co`,
+      firstName: name,
+      lastName: "Dancer",
+      bibNumber: bib,
+    })
+    .returning();
+  return roster!;
+}
+
+test.group("PublishShowcaseService", (group) => {
+  group.each.setup(async () => {
+    await db.delete(publishedCallbacks).execute();
+    await db.delete(eventCallbacks).execute();
+    await db.delete(eventRatings).execute();
+    await db.delete(eventShowcases).execute();
+    await db.delete(eventRosters).execute();
+    await db.delete(orgEvents).execute();
+  });
+
+  test("publishes top 5 per coach ranked by rating DESC then recency DESC", async ({
+    assert,
+  }) => {
+    const { event, showcase } = await setup();
+    const coach = await addCoach(event.id, "Alice");
+
+    const dancers = [];
+    for (let i = 1; i <= 7; i++) {
+      dancers.push(await addDancer(event.id, i, `D${i}`));
+    }
+
+    for (const d of dancers) {
+      await db.insert(eventCallbacks).values({
+        eventId: event.id,
+        showcaseId: showcase.id,
+        coachRosterId: coach.id,
+        dancerRosterId: d.id,
+      });
+    }
+
+    await db.insert(eventRatings).values([
+      {
+        eventId: event.id,
+        coachRosterId: coach.id,
+        dancerRosterId: dancers[0]!.id,
+        rating: 9,
+      },
+      {
+        eventId: event.id,
+        coachRosterId: coach.id,
+        dancerRosterId: dancers[1]!.id,
+        rating: 7,
+      },
+      {
+        eventId: event.id,
+        coachRosterId: coach.id,
+        dancerRosterId: dancers[2]!.id,
+        rating: 10,
+      },
+    ]);
+
+    const svc = new PublishShowcaseService();
+    await svc.execute(event.id, showcase.id);
+
+    const published = await db
+      .select()
+      .from(publishedCallbacks)
+      .where(eq(publishedCallbacks.showcaseId, showcase.id))
+      .orderBy(publishedCallbacks.rank);
+
+    assert.lengthOf(published, 5);
+
+    assert.equal(published[0]!.dancerRosterId, dancers[2]!.id);
+    assert.equal(published[0]!.rank, 1);
+
+    assert.equal(published[1]!.dancerRosterId, dancers[0]!.id);
+    assert.equal(published[1]!.rank, 2);
+
+    assert.equal(published[2]!.dancerRosterId, dancers[1]!.id);
+    assert.equal(published[2]!.rank, 3);
+
+    const updatedShowcase = await db
+      .select()
+      .from(eventShowcases)
+      .where(eq(eventShowcases.id, showcase.id));
+    assert.equal(updatedShowcase[0]!.status, "published");
+    assert.isNotNull(updatedShowcase[0]!.publishedAt);
+  });
+
+  test("coach with fewer than 5 callbacks gets all published", async ({
+    assert,
+  }) => {
+    const { event, showcase } = await setup();
+    const coach = await addCoach(event.id, "Bob");
+    const d1 = await addDancer(event.id, 10, "Solo");
+    const d2 = await addDancer(event.id, 11, "Duo");
+
+    await db.insert(eventCallbacks).values([
+      {
+        eventId: event.id,
+        showcaseId: showcase.id,
+        coachRosterId: coach.id,
+        dancerRosterId: d1.id,
+      },
+      {
+        eventId: event.id,
+        showcaseId: showcase.id,
+        coachRosterId: coach.id,
+        dancerRosterId: d2.id,
+      },
+    ]);
+
+    const svc = new PublishShowcaseService();
+    await svc.execute(event.id, showcase.id);
+
+    const published = await db
+      .select()
+      .from(publishedCallbacks)
+      .where(eq(publishedCallbacks.showcaseId, showcase.id));
+
+    assert.lengthOf(published, 2);
+  });
+
+  test("rejects publish if showcase is not active", async ({ assert }) => {
+    const { event, showcase } = await setup();
+    await db
+      .update(eventShowcases)
+      .set({ status: "published", publishedAt: new Date() })
+      .where(eq(eventShowcases.id, showcase.id));
+
+    const svc = new PublishShowcaseService();
+    await assert.rejects(() => svc.execute(event.id, showcase.id));
+  });
+});

--- a/apps/backend/app/modules/orgs/scouting/showcases/publish/service.ts
+++ b/apps/backend/app/modules/orgs/scouting/showcases/publish/service.ts
@@ -1,0 +1,93 @@
+import { DatabaseService } from "#database/service";
+import {
+  eventCallbacks,
+  eventRatings,
+  eventShowcases,
+  publishedCallbacks,
+} from "#database/schema/event-features";
+import { inject } from "@adonisjs/core";
+import { and, eq, sql } from "drizzle-orm";
+
+@inject()
+export class PublishShowcaseService {
+  constructor(private db: DatabaseService = new DatabaseService()) {}
+
+  async execute(eventId: string, showcaseId: string) {
+    return this.db.tx(async (tx) => {
+      const [showcase] = await tx
+        .select()
+        .from(eventShowcases)
+        .where(eq(eventShowcases.id, showcaseId))
+        .limit(1);
+
+      if (!showcase || showcase.status !== "active") {
+        throw new Error("Showcase is not active");
+      }
+
+      const callbacks = await tx
+        .select({
+          coachRosterId: eventCallbacks.coachRosterId,
+          dancerRosterId: eventCallbacks.dancerRosterId,
+          createdAt: eventCallbacks.createdAt,
+          rating: eventRatings.rating,
+        })
+        .from(eventCallbacks)
+        .leftJoin(
+          eventRatings,
+          and(
+            eq(eventRatings.eventId, eventId),
+            eq(eventRatings.coachRosterId, eventCallbacks.coachRosterId),
+            eq(eventRatings.dancerRosterId, eventCallbacks.dancerRosterId)
+          )
+        )
+        .where(eq(eventCallbacks.showcaseId, showcaseId));
+
+      const grouped = new Map<string, typeof callbacks>();
+      for (const cb of callbacks) {
+        const list = grouped.get(cb.coachRosterId) ?? [];
+        list.push(cb);
+        grouped.set(cb.coachRosterId, list);
+      }
+
+      const rows: {
+        showcaseId: string;
+        coachRosterId: string;
+        dancerRosterId: string;
+        rank: number;
+      }[] = [];
+
+      for (const [coachRosterId, cbs] of grouped) {
+        cbs.sort((a, b) => {
+          const rA = a.rating ?? -1;
+          const rB = b.rating ?? -1;
+          if (rB !== rA) return rB - rA;
+          return (
+            new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+          );
+        });
+
+        const top5 = cbs.slice(0, 5);
+        for (let i = 0; i < top5.length; i++) {
+          rows.push({
+            showcaseId,
+            coachRosterId,
+            dancerRosterId: top5[i]!.dancerRosterId,
+            rank: i + 1,
+          });
+        }
+      }
+
+      if (rows.length > 0) {
+        await tx.insert(publishedCallbacks).values(rows);
+      }
+
+      await tx
+        .update(eventShowcases)
+        .set({
+          status: "published",
+          publishedAt: sql`NOW()`,
+        })
+        .where(eq(eventShowcases.id, showcaseId));
+    });
+  }
+}

--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -2153,17 +2153,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "ids",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
           }
         ],
         "responses": {
@@ -2173,16 +2162,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OrgsIdEventsIdRostersResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
                 }
               }
             }
@@ -4611,6 +4590,152 @@
         ]
       }
     },
+    "/orgs/{slug}/showcases": {
+      "get": {
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrgsIdShowcasesResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Org Admin Showcases"
+        ]
+      }
+    },
+    "/orgs/{slug}/showcases/publish": {
+      "post": {
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrgsIdShowcasesPublishResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Unknown Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Org Admin Showcases"
+        ]
+      }
+    },
+    "/orgs/{slug}/showcases/next": {
+      "post": {
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrgsIdShowcasesNextResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Unknown Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Org Admin Showcases"
+        ]
+      }
+    },
+    "/orgs/{slug}/dancer/callbacks": {
+      "get": {
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrgsIdDancerCallbacksResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Unknown Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Org Dancer Callbacks"
+        ]
+      }
+    },
     "/orgs/{slug}/register": {
       "post": {
         "requestBody": {
@@ -6490,6 +6615,15 @@
     },
     "/events/{id}/unsave": {
       "delete": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EventsIdUnsaveRequest"
+              }
+            }
+          }
+        },
         "parameters": [
           {
             "name": "id",
@@ -6497,21 +6631,6 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
-          },
-          {
-            "name": "type",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ]
             }
           }
         ],
@@ -7824,23 +7943,15 @@
         "description": "Updates the user's account settings"
       },
       "delete": {
-        "parameters": [
-          {
-            "name": "feedback",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ]
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UsersAccountDeleteRequest"
+              }
             }
           }
-        ],
+        },
         "responses": {
           "204": {
             "description": "No Content"
@@ -9832,6 +9943,32 @@
               "profileId": {
                 "type": "string"
               },
+              "orgMemberships": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "orgSlug": {
+                      "type": "string"
+                    },
+                    "role": {
+                      "type": "string",
+                      "enum": [
+                        "admin",
+                        "member"
+                      ]
+                    },
+                    "type": {
+                      "$ref": "#/components/schemas/UploadKind"
+                    }
+                  },
+                  "required": [
+                    "orgSlug",
+                    "role",
+                    "type"
+                  ]
+                }
+              },
               "platforms": {
                 "type": "array",
                 "items": {
@@ -9855,6 +9992,7 @@
               "verified",
               "notifications",
               "profileId",
+              "orgMemberships",
               "platforms"
             ]
           },
@@ -9934,6 +10072,32 @@
           "profileId": {
             "type": "string"
           },
+          "orgMemberships": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "orgSlug": {
+                  "type": "string"
+                },
+                "role": {
+                  "type": "string",
+                  "enum": [
+                    "admin",
+                    "member"
+                  ]
+                },
+                "type": {
+                  "$ref": "#/components/schemas/UploadKind"
+                }
+              },
+              "required": [
+                "orgSlug",
+                "role",
+                "type"
+              ]
+            }
+          },
           "platforms": {
             "type": "array",
             "items": {
@@ -9957,6 +10121,7 @@
           "verified",
           "notifications",
           "profileId",
+          "orgMemberships",
           "platforms"
         ]
       },
@@ -13422,6 +13587,16 @@
             "lastName": {
               "type": "string"
             },
+            "username": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "isTopSchool": {
               "type": "boolean"
             }
@@ -13431,6 +13606,7 @@
             "organization",
             "firstName",
             "lastName",
+            "username",
             "isTopSchool"
           ]
         }
@@ -13608,6 +13784,44 @@
       "OrgsIdAdminCallbacksResponse": {
         "type": "object",
         "properties": {
+          "showcase": {
+            "type": "object",
+            "properties": {
+              "number": {
+                "type": "number"
+              },
+              "id": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              },
+              "createdAt": {
+                "type": "string"
+              },
+              "eventId": {
+                "type": "string"
+              },
+              "publishedAt": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "number",
+              "id",
+              "status",
+              "createdAt",
+              "eventId",
+              "publishedAt"
+            ]
+          },
           "totalSchools": {
             "type": "number"
           },
@@ -13656,11 +13870,135 @@
           }
         },
         "required": [
+          "showcase",
           "totalSchools",
           "totalDancers",
           "bibs",
           "uniqueCallbacks"
         ]
+      },
+      "OrgsIdShowcasesResponse": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "number": {
+              "type": "number"
+            },
+            "id": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            },
+            "createdAt": {
+              "type": "string"
+            },
+            "eventId": {
+              "type": "string"
+            },
+            "publishedAt": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "number",
+            "id",
+            "status",
+            "createdAt",
+            "eventId",
+            "publishedAt"
+          ]
+        }
+      },
+      "OrgsIdShowcasesPublishResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ]
+      },
+      "OrgsIdShowcasesNextResponse": {
+        "type": "object",
+        "properties": {
+          "number": {
+            "type": "number"
+          },
+          "id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "eventId": {
+            "type": "string"
+          },
+          "publishedAt": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "number",
+          "id",
+          "status",
+          "createdAt",
+          "eventId",
+          "publishedAt"
+        ]
+      },
+      "OrgsIdDancerCallbacksResponse": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "coachRosterId": {
+              "type": "string"
+            },
+            "firstName": {
+              "type": "string"
+            },
+            "lastName": {
+              "type": "string"
+            },
+            "organization": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "coachRosterId",
+            "firstName",
+            "lastName",
+            "organization"
+          ]
+        }
       },
       "OrgsIdRegisterRequest": {
         "type": "object",
@@ -16215,6 +16553,21 @@
           }
         }
       },
+      "EventsIdUnsaveRequest": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      },
       "ImagesRequest": {
         "type": "object",
         "properties": {
@@ -17999,6 +18352,21 @@
                   "number",
                   "boolean"
                 ]
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      },
+      "UsersAccountDeleteRequest": {
+        "type": "object",
+        "properties": {
+          "feedback": {
+            "oneOf": [
+              {
+                "type": "string"
               },
               {
                 "type": "null"

--- a/apps/frontend/src/features/org/api/scouting-queries.ts
+++ b/apps/frontend/src/features/org/api/scouting-queries.ts
@@ -45,4 +45,12 @@ export const scoutingQueries = {
     $api.queryOptions("get", "/orgs/{slug}/admin/callbacks", {
       params: { path: { slug } },
     }),
+  showcases: (slug: string) =>
+    $api.queryOptions("get", "/orgs/{slug}/showcases", {
+      params: { path: { slug } },
+    }),
+  dancerCallbacks: (slug: string) =>
+    $api.queryOptions("get", "/orgs/{slug}/dancer/callbacks", {
+      params: { path: { slug } },
+    }),
 };

--- a/apps/frontend/src/features/org/components/dancer-sidebar.tsx
+++ b/apps/frontend/src/features/org/components/dancer-sidebar.tsx
@@ -23,13 +23,17 @@ import {
   MenuTrigger,
 } from "@/components/ui/menu";
 import { useOrg } from "@/features/org/context/use-org";
+import { scoutingQueries } from "@/features/org/api/scouting-queries";
+import { useTransmitSubscription } from "@/features/org/hooks/use-transmit";
 import { useSession } from "@/lib/session";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useLocation, useNavigate, useParams } from "@tanstack/react-router";
 import {
   CheckIcon,
   ChevronDownIcon,
   EyeIcon,
   LogOutIcon,
+  Megaphone,
   MonitorIcon,
   MoonIcon,
   PlayCircleIcon,
@@ -46,28 +50,60 @@ const dashboardItem = {
   exact: false,
 };
 
-const navSections: {
-  title: string;
-  items: { label: string; icon: any; to: string }[];
-}[] = [
-  {
-    title: "Explore",
-    items: [
-      {
-        label: "Schools",
-        icon: SchoolIcon,
-        to: "/o/$orgSlug/dancer/schools" as const,
-      },
-    ],
-  },
-];
-
 export function DancerSidebar() {
   const session = useSession();
-  const { org, membership } = useOrg();
+  const { org, membership, hasFeature } = useOrg();
   const { orgSlug } = useParams({ strict: false }) as { orgSlug: string };
   const location = useLocation();
   const navigate = useNavigate();
+  const qc = useQueryClient();
+
+  const { data: dancerCallbacks } = useQuery({
+    ...scoutingQueries.dancerCallbacks(orgSlug),
+    enabled: hasFeature("callbacks"),
+  });
+
+  useTransmitSubscription(
+    hasFeature("callbacks") ? `orgs/${orgSlug}/showcases` : null,
+    () => {
+      qc.invalidateQueries({
+        queryKey: scoutingQueries.dancerCallbacks(orgSlug).queryKey,
+      });
+    },
+  );
+
+  const hasCallbacks =
+    Array.isArray(dancerCallbacks) && dancerCallbacks.length > 0;
+
+  const navSections: {
+    title: string;
+    items: { label: string; icon: any; to: string }[];
+  }[] = [
+    ...(hasCallbacks
+      ? [
+          {
+            title: "Event",
+            items: [
+              {
+                label: "Callbacks",
+                icon: Megaphone,
+                to: "/o/$orgSlug/dancer/callbacks" as const,
+              },
+            ],
+          },
+        ]
+      : []),
+    {
+      title: "Explore",
+      items: [
+        {
+          label: "Schools",
+          icon: SchoolIcon,
+          to: "/o/$orgSlug/dancer/schools" as const,
+        },
+      ],
+    },
+  ];
   const { ternaryDarkMode, setTernaryDarkMode } = useTernaryDarkMode({
     localStorageKey: "theme",
   });

--- a/apps/frontend/src/lib/api/types.d.ts
+++ b/apps/frontend/src/lib/api/types.d.ts
@@ -2405,9 +2405,7 @@ export interface paths {
         post?: never;
         delete: {
             parameters: {
-                query: {
-                    ids: string[];
-                };
+                query?: never;
                 header?: never;
                 path: {
                     slug: string;
@@ -2424,15 +2422,6 @@ export interface paths {
                     };
                     content: {
                         "application/json": components["schemas"]["OrgsIdEventsIdRostersResponse"];
-                    };
-                };
-                /** @description Unprocessable Entity */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
                     };
                 };
             };
@@ -4467,6 +4456,181 @@ export interface paths {
                     };
                     content: {
                         "application/json": components["schemas"]["OrgsIdAdminCallbacksResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/orgs/{slug}/showcases": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    slug: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["OrgsIdShowcasesResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/orgs/{slug}/showcases/publish": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    slug: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["OrgsIdShowcasesPublishResponse"];
+                    };
+                };
+                /** @description Unknown Response */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/orgs/{slug}/showcases/next": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    slug: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["OrgsIdShowcasesNextResponse"];
+                    };
+                };
+                /** @description Unknown Response */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/orgs/{slug}/dancer/callbacks": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    slug: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["OrgsIdDancerCallbacksResponse"];
+                    };
+                };
+                /** @description Unknown Response */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
                     };
                 };
             };
@@ -6705,16 +6869,18 @@ export interface paths {
          */
         delete: {
             parameters: {
-                query?: {
-                    type?: string | null;
-                };
+                query?: never;
                 header?: never;
                 path: {
                     id: string;
                 };
                 cookie?: never;
             };
-            requestBody?: never;
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["EventsIdUnsaveRequest"];
+                };
+            };
             responses: {
                 /** @description No Content */
                 204: {
@@ -8168,14 +8334,16 @@ export interface paths {
          */
         delete: {
             parameters: {
-                query?: {
-                    feedback?: string | null;
-                };
+                query?: never;
                 header?: never;
                 path?: never;
                 cookie?: never;
             };
-            requestBody?: never;
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["UsersAccountDeleteRequest"];
+                };
+            };
             responses: {
                 /** @description No Content */
                 204: {
@@ -8875,6 +9043,12 @@ export interface components {
                 verified: boolean;
                 notifications: boolean;
                 profileId: string;
+                orgMemberships: {
+                    orgSlug: string;
+                    /** @enum {string} */
+                    role: "admin" | "member";
+                    type: components["schemas"]["UploadKind"];
+                }[];
                 platforms: ("core" | "prodigy")[];
             };
             token: string;
@@ -8897,14 +9071,13 @@ export interface components {
             verified: boolean;
             notifications: boolean;
             profileId: string;
-            platforms: ("core" | "prodigy")[];
             orgMemberships: {
                 orgSlug: string;
                 /** @enum {string} */
                 role: "admin" | "member";
-                /** @enum {string} */
-                type: "coach" | "dancer";
+                type: components["schemas"]["UploadKind"];
             }[];
+            platforms: ("core" | "prodigy")[];
         };
         AuthPasswordChangeRequest: {
             currentPassword: string;
@@ -9532,6 +9705,8 @@ export interface components {
             organization: string | null;
             firstName: string;
             lastName: string;
+            username: string | null;
+            isTopSchool: boolean;
         }[];
         OrgsIdMyselectionsResponse: {
             id: string;
@@ -9564,6 +9739,14 @@ export interface components {
             dancerRosterId: string;
         };
         OrgsIdAdminCallbacksResponse: {
+            showcase: {
+                number: number;
+                id: string;
+                status: string;
+                createdAt: string;
+                eventId: string;
+                publishedAt: string | null;
+            };
             totalSchools: number;
             totalDancers: number;
             bibs: {
@@ -9575,6 +9758,31 @@ export interface components {
             }[];
             uniqueCallbacks: number;
         };
+        OrgsIdShowcasesResponse: {
+            number: number;
+            id: string;
+            status: string;
+            createdAt: string;
+            eventId: string;
+            publishedAt: string | null;
+        }[];
+        OrgsIdShowcasesPublishResponse: {
+            message: string;
+        };
+        OrgsIdShowcasesNextResponse: {
+            number: number;
+            id: string;
+            status: string;
+            createdAt: string;
+            eventId: string;
+            publishedAt: string | null;
+        };
+        OrgsIdDancerCallbacksResponse: {
+            coachRosterId: string;
+            firstName: string;
+            lastName: string;
+            organization: string | null;
+        }[];
         OrgsIdRegisterRequest: {
             firstName: string;
             lastName: string;
@@ -10037,6 +10245,9 @@ export interface components {
         EventsIdSaveRequest: {
             type?: string | null;
         };
+        EventsIdUnsaveRequest: {
+            type?: string | null;
+        };
         ImagesRequest: {
             key: string;
         };
@@ -10334,6 +10545,9 @@ export interface components {
             lastName?: string | null;
             phone?: string | null;
             notifications?: (string | number | boolean) | null;
+        };
+        UsersAccountDeleteRequest: {
+            feedback?: string | null;
         };
         UsersAvatarRequest: {
             key: string;

--- a/apps/frontend/src/routeTree.gen.ts
+++ b/apps/frontend/src/routeTree.gen.ts
@@ -72,6 +72,7 @@ import { Route as OrgOOrgSlugAuthenticatedCoachIndexRouteImport } from './routes
 import { Route as OrgOOrgSlugAuthenticatedAdminIndexRouteImport } from './routes/_org/o/$orgSlug/_authenticated/admin/index'
 import { Route as OrgOOrgSlugAuthenticatedDancerVideoLibraryRouteImport } from './routes/_org/o/$orgSlug/_authenticated/dancer/video-library'
 import { Route as OrgOOrgSlugAuthenticatedDancerSchoolsRouteImport } from './routes/_org/o/$orgSlug/_authenticated/dancer/schools'
+import { Route as OrgOOrgSlugAuthenticatedDancerCallbacksRouteImport } from './routes/_org/o/$orgSlug/_authenticated/dancer/callbacks'
 import { Route as OrgOOrgSlugAuthenticatedCoachEventInfoRouteImport } from './routes/_org/o/$orgSlug/_authenticated/coach/event-info'
 import { Route as OrgOOrgSlugAuthenticatedAdminVideoLibraryRouteImport } from './routes/_org/o/$orgSlug/_authenticated/admin/video-library'
 import { Route as OrgOOrgSlugAuthenticatedAdminUploadsRouteImport } from './routes/_org/o/$orgSlug/_authenticated/admin/uploads'
@@ -423,6 +424,12 @@ const OrgOOrgSlugAuthenticatedDancerSchoolsRoute =
     path: '/schools',
     getParentRoute: () => OrgOOrgSlugAuthenticatedDancerRouteRoute,
   } as any)
+const OrgOOrgSlugAuthenticatedDancerCallbacksRoute =
+  OrgOOrgSlugAuthenticatedDancerCallbacksRouteImport.update({
+    id: '/callbacks',
+    path: '/callbacks',
+    getParentRoute: () => OrgOOrgSlugAuthenticatedDancerRouteRoute,
+  } as any)
 const OrgOOrgSlugAuthenticatedCoachEventInfoRoute =
   OrgOOrgSlugAuthenticatedCoachEventInfoRouteImport.update({
     id: '/event-info',
@@ -540,6 +547,7 @@ export interface FileRoutesByFullPath {
   '/o/$orgSlug/admin/uploads': typeof OrgOOrgSlugAuthenticatedAdminUploadsRoute
   '/o/$orgSlug/admin/video-library': typeof OrgOOrgSlugAuthenticatedAdminVideoLibraryRoute
   '/o/$orgSlug/coach/event-info': typeof OrgOOrgSlugAuthenticatedCoachEventInfoRoute
+  '/o/$orgSlug/dancer/callbacks': typeof OrgOOrgSlugAuthenticatedDancerCallbacksRoute
   '/o/$orgSlug/dancer/schools': typeof OrgOOrgSlugAuthenticatedDancerSchoolsRoute
   '/o/$orgSlug/dancer/video-library': typeof OrgOOrgSlugAuthenticatedDancerVideoLibraryRoute
   '/o/$orgSlug/admin/': typeof OrgOOrgSlugAuthenticatedAdminIndexRoute
@@ -603,6 +611,7 @@ export interface FileRoutesByTo {
   '/o/$orgSlug/admin/uploads': typeof OrgOOrgSlugAuthenticatedAdminUploadsRoute
   '/o/$orgSlug/admin/video-library': typeof OrgOOrgSlugAuthenticatedAdminVideoLibraryRoute
   '/o/$orgSlug/coach/event-info': typeof OrgOOrgSlugAuthenticatedCoachEventInfoRoute
+  '/o/$orgSlug/dancer/callbacks': typeof OrgOOrgSlugAuthenticatedDancerCallbacksRoute
   '/o/$orgSlug/dancer/schools': typeof OrgOOrgSlugAuthenticatedDancerSchoolsRoute
   '/o/$orgSlug/dancer/video-library': typeof OrgOOrgSlugAuthenticatedDancerVideoLibraryRoute
   '/o/$orgSlug/admin': typeof OrgOOrgSlugAuthenticatedAdminIndexRoute
@@ -678,6 +687,7 @@ export interface FileRoutesById {
   '/_org/o/$orgSlug/_authenticated/admin/uploads': typeof OrgOOrgSlugAuthenticatedAdminUploadsRoute
   '/_org/o/$orgSlug/_authenticated/admin/video-library': typeof OrgOOrgSlugAuthenticatedAdminVideoLibraryRoute
   '/_org/o/$orgSlug/_authenticated/coach/event-info': typeof OrgOOrgSlugAuthenticatedCoachEventInfoRoute
+  '/_org/o/$orgSlug/_authenticated/dancer/callbacks': typeof OrgOOrgSlugAuthenticatedDancerCallbacksRoute
   '/_org/o/$orgSlug/_authenticated/dancer/schools': typeof OrgOOrgSlugAuthenticatedDancerSchoolsRoute
   '/_org/o/$orgSlug/_authenticated/dancer/video-library': typeof OrgOOrgSlugAuthenticatedDancerVideoLibraryRoute
   '/_org/o/$orgSlug/_authenticated/admin/': typeof OrgOOrgSlugAuthenticatedAdminIndexRoute
@@ -749,6 +759,7 @@ export interface FileRouteTypes {
     | '/o/$orgSlug/admin/uploads'
     | '/o/$orgSlug/admin/video-library'
     | '/o/$orgSlug/coach/event-info'
+    | '/o/$orgSlug/dancer/callbacks'
     | '/o/$orgSlug/dancer/schools'
     | '/o/$orgSlug/dancer/video-library'
     | '/o/$orgSlug/admin/'
@@ -812,6 +823,7 @@ export interface FileRouteTypes {
     | '/o/$orgSlug/admin/uploads'
     | '/o/$orgSlug/admin/video-library'
     | '/o/$orgSlug/coach/event-info'
+    | '/o/$orgSlug/dancer/callbacks'
     | '/o/$orgSlug/dancer/schools'
     | '/o/$orgSlug/dancer/video-library'
     | '/o/$orgSlug/admin'
@@ -886,6 +898,7 @@ export interface FileRouteTypes {
     | '/_org/o/$orgSlug/_authenticated/admin/uploads'
     | '/_org/o/$orgSlug/_authenticated/admin/video-library'
     | '/_org/o/$orgSlug/_authenticated/coach/event-info'
+    | '/_org/o/$orgSlug/_authenticated/dancer/callbacks'
     | '/_org/o/$orgSlug/_authenticated/dancer/schools'
     | '/_org/o/$orgSlug/_authenticated/dancer/video-library'
     | '/_org/o/$orgSlug/_authenticated/admin/'
@@ -1345,6 +1358,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof OrgOOrgSlugAuthenticatedDancerSchoolsRouteImport
       parentRoute: typeof OrgOOrgSlugAuthenticatedDancerRouteRoute
     }
+    '/_org/o/$orgSlug/_authenticated/dancer/callbacks': {
+      id: '/_org/o/$orgSlug/_authenticated/dancer/callbacks'
+      path: '/callbacks'
+      fullPath: '/o/$orgSlug/dancer/callbacks'
+      preLoaderRoute: typeof OrgOOrgSlugAuthenticatedDancerCallbacksRouteImport
+      parentRoute: typeof OrgOOrgSlugAuthenticatedDancerRouteRoute
+    }
     '/_org/o/$orgSlug/_authenticated/coach/event-info': {
       id: '/_org/o/$orgSlug/_authenticated/coach/event-info'
       path: '/event-info'
@@ -1650,6 +1670,7 @@ const OrgOOrgSlugAuthenticatedCoachRouteRouteWithChildren =
   )
 
 interface OrgOOrgSlugAuthenticatedDancerRouteRouteChildren {
+  OrgOOrgSlugAuthenticatedDancerCallbacksRoute: typeof OrgOOrgSlugAuthenticatedDancerCallbacksRoute
   OrgOOrgSlugAuthenticatedDancerSchoolsRoute: typeof OrgOOrgSlugAuthenticatedDancerSchoolsRoute
   OrgOOrgSlugAuthenticatedDancerVideoLibraryRoute: typeof OrgOOrgSlugAuthenticatedDancerVideoLibraryRoute
   OrgOOrgSlugAuthenticatedDancerIndexRoute: typeof OrgOOrgSlugAuthenticatedDancerIndexRoute
@@ -1657,6 +1678,8 @@ interface OrgOOrgSlugAuthenticatedDancerRouteRouteChildren {
 
 const OrgOOrgSlugAuthenticatedDancerRouteRouteChildren: OrgOOrgSlugAuthenticatedDancerRouteRouteChildren =
   {
+    OrgOOrgSlugAuthenticatedDancerCallbacksRoute:
+      OrgOOrgSlugAuthenticatedDancerCallbacksRoute,
     OrgOOrgSlugAuthenticatedDancerSchoolsRoute:
       OrgOOrgSlugAuthenticatedDancerSchoolsRoute,
     OrgOOrgSlugAuthenticatedDancerVideoLibraryRoute:

--- a/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/admin/callbacks.tsx
+++ b/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/admin/callbacks.tsx
@@ -1,21 +1,42 @@
 import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, useParams } from "@tanstack/react-router";
-import { Megaphone } from "lucide-react";
+import { Megaphone, SendIcon, SkipForwardIcon } from "lucide-react";
 import { useState } from "react";
 
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Tabs, TabsContent, TabsList, TabsTab } from "@/components/ui/tabs";
 import { cn } from "@/components/utils/cn";
 import { scoutingQueries } from "@/features/org/api/scouting-queries";
-import { LivePulse, StatCell } from "@/features/org/components/dashboard-shared";
+import {
+  LivePulse,
+  StatCell,
+} from "@/features/org/components/dashboard-shared";
 import { DancerSheet } from "@/features/org/components/dancer-sheet";
 import {
   type TransmitStatus,
   useTransmitStatus,
   useTransmitSubscription,
 } from "@/features/org/hooks/use-transmit";
+import { $api } from "@/lib/api/client";
 
 export const Route = createFileRoute(
   "/_org/o/$orgSlug/_authenticated/admin/callbacks",
 )({
+  loader: ({ context, params }) => {
+    context.queryClient.ensureQueryData(
+      scoutingQueries.showcases(params.orgSlug),
+    );
+  },
   component: AdminCallbacksPage,
 });
 
@@ -54,6 +75,9 @@ function AdminCallbacksPage() {
     from: "/_org/o/$orgSlug/_authenticated/admin/callbacks",
   });
   const { data } = useSuspenseQuery(scoutingQueries.adminCallbacks(orgSlug));
+  const { data: showcases } = useSuspenseQuery(
+    scoutingQueries.showcases(orgSlug),
+  );
   const qc = useQueryClient();
   const sseStatus = useTransmitStatus();
   const [sheetRosterId, setSheetRosterId] = useState<string | null>(null);
@@ -62,7 +86,55 @@ function AdminCallbacksPage() {
     qc.invalidateQueries({
       queryKey: scoutingQueries.adminCallbacks(orgSlug).queryKey,
     });
+    qc.invalidateQueries({
+      queryKey: scoutingQueries.showcases(orgSlug).queryKey,
+    });
   });
+
+  useTransmitSubscription(`orgs/${orgSlug}/showcases`, () => {
+    qc.invalidateQueries({
+      queryKey: scoutingQueries.adminCallbacks(orgSlug).queryKey,
+    });
+    qc.invalidateQueries({
+      queryKey: scoutingQueries.showcases(orgSlug).queryKey,
+    });
+  });
+
+  const showcase = data.showcase;
+  const isPublished = showcase?.status === "published";
+  const publishedShowcases = showcases.filter(
+    (s: { status: string }) => s.status === "published",
+  );
+
+  const publishMutation = $api.useMutation(
+    "post",
+    "/orgs/{slug}/showcases/publish",
+    {
+      onSuccess: () => {
+        qc.invalidateQueries({
+          queryKey: scoutingQueries.adminCallbacks(orgSlug).queryKey,
+        });
+        qc.invalidateQueries({
+          queryKey: scoutingQueries.showcases(orgSlug).queryKey,
+        });
+      },
+    },
+  );
+
+  const nextMutation = $api.useMutation(
+    "post",
+    "/orgs/{slug}/showcases/next",
+    {
+      onSuccess: () => {
+        qc.invalidateQueries({
+          queryKey: scoutingQueries.adminCallbacks(orgSlug).queryKey,
+        });
+        qc.invalidateQueries({
+          queryKey: scoutingQueries.showcases(orgSlug).queryKey,
+        });
+      },
+    },
+  );
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
@@ -70,10 +142,41 @@ function AdminCallbacksPage() {
       <header className="flex items-center justify-between px-4 py-4">
         <div className="flex items-center gap-3">
           <h1 className="text-lg font-semibold tracking-tight">Callbacks</h1>
-          <span className="text-muted-foreground flex items-center gap-1.5 text-xs">
-            <LivePulse />
-            Live — updating as coaches select
-          </span>
+          {showcase && (
+            <Badge variant={isPublished ? "success" : "info"} size="lg">
+              Showcase {showcase.number} (
+              {isPublished ? "Published" : "Active"})
+            </Badge>
+          )}
+          {!isPublished && (
+            <span className="text-muted-foreground flex items-center gap-1.5 text-xs">
+              <LivePulse />
+              Live
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          {!isPublished && (
+            <PublishDialog
+              disabled={data.uniqueCallbacks === 0}
+              loading={publishMutation.isPending}
+              onConfirm={() =>
+                publishMutation.mutate({
+                  params: { path: { slug: orgSlug } },
+                })
+              }
+            />
+          )}
+          {isPublished && (
+            <StartNextDialog
+              loading={nextMutation.isPending}
+              onConfirm={() =>
+                nextMutation.mutate({
+                  params: { path: { slug: orgSlug } },
+                })
+              }
+            />
+          )}
         </div>
       </header>
 
@@ -91,58 +194,57 @@ function AdminCallbacksPage() {
         />
       </section>
 
-      {/* Bib grid */}
-      <div className="flex-1 p-4">
-        {data.bibs.length === 0 ? (
-          <div className="text-muted-foreground flex flex-col items-center justify-center gap-2 py-24">
-            <Megaphone className="size-8 opacity-40" />
-            <p className="text-sm">No callbacks yet.</p>
-            <p className="text-xs opacity-60">
-              Bib numbers will appear here as coaches make selections.
-            </p>
-          </div>
-        ) : (
-          <div className="grid grid-cols-[repeat(auto-fill,minmax(88px,1fr))] gap-2">
-            {data.bibs.map(
-              (bib: {
-                dancerRosterId: string;
-                bibNumber: number | null;
-                firstName: string;
-                lastName: string;
-                coachCount: number;
-              }) => (
-                <button
-                  type="button"
-                  key={bib.dancerRosterId}
-                  onClick={() => setSheetRosterId(bib.dancerRosterId)}
-                  className="bg-muted hover:bg-accent flex cursor-pointer flex-col items-center justify-center rounded-lg px-3 py-2.5 transition-colors"
-                >
-                  <span className="text-xl font-bold tabular-nums leading-none">
-                    {bib.bibNumber != null
-                      ? String(bib.bibNumber).padStart(2, "0")
-                      : "—"}
-                  </span>
-                  <span className="text-muted-foreground mt-1 max-w-full truncate text-[10px]">
-                    {bib.firstName} {bib.lastName?.[0]}.
-                  </span>
-                  {Number(bib.coachCount) > 1 && (
-                    <span className="text-muted-foreground mt-0.5 text-[10px] opacity-60">
-                      {bib.coachCount} coaches
-                    </span>
-                  )}
-                </button>
-              ),
-            )}
-          </div>
+      {/* Tabs */}
+      <Tabs defaultValue="current" className="flex-1">
+        {publishedShowcases.length > 0 && (
+          <TabsList className="w-full justify-start px-4 pt-2">
+            <TabsTab value="current">Current</TabsTab>
+            <TabsTab value="previous">Previous</TabsTab>
+          </TabsList>
         )}
-      </div>
+
+        <TabsContent value="current" className="flex-1">
+          <CallbackBibGrid
+            bibs={data.bibs}
+            onSelectDancer={setSheetRosterId}
+          />
+        </TabsContent>
+
+        {publishedShowcases.length > 0 && (
+          <TabsContent value="previous" className="p-4">
+            <div className="space-y-3">
+              {publishedShowcases.map(
+                (s: {
+                  id: string;
+                  number: number;
+                  publishedAt: string | null;
+                }) => (
+                  <div key={s.id} className="bg-muted rounded-lg border p-4">
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm font-semibold">
+                        Showcase {s.number}
+                      </span>
+                      <span className="text-muted-foreground text-xs">
+                        Published{" "}
+                        {s.publishedAt
+                          ? new Date(s.publishedAt).toLocaleDateString()
+                          : ""}
+                      </span>
+                    </div>
+                  </div>
+                ),
+              )}
+            </div>
+          </TabsContent>
+        )}
+      </Tabs>
 
       {/* Footer */}
       {data.bibs.length > 0 && (
         <footer className="border-border text-muted-foreground flex items-center justify-between border-t px-4 py-3 text-xs">
           <span>
-            {data.uniqueCallbacks} number{data.uniqueCallbacks === 1 ? "" : "s"}{" "}
-            · no repeats
+            {data.uniqueCallbacks} number
+            {data.uniqueCallbacks === 1 ? "" : "s"} · no repeats
           </span>
           <span
             className={cn(
@@ -173,5 +275,132 @@ function AdminCallbacksPage() {
         readOnly
       />
     </div>
+  );
+}
+
+function CallbackBibGrid({
+  bibs,
+  onSelectDancer,
+}: {
+  bibs: {
+    dancerRosterId: string;
+    bibNumber: number | null;
+    firstName: string;
+    lastName: string;
+    coachCount: number;
+  }[];
+  onSelectDancer: (rosterId: string) => void;
+}) {
+  if (bibs.length === 0) {
+    return (
+      <div className="text-muted-foreground flex flex-col items-center justify-center gap-2 py-24">
+        <Megaphone className="size-8 opacity-40" />
+        <p className="text-sm">No callbacks yet.</p>
+        <p className="text-xs opacity-60">
+          Bib numbers will appear here as coaches make selections.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4">
+      <div className="grid grid-cols-[repeat(auto-fill,minmax(88px,1fr))] gap-2">
+        {bibs.map((bib) => (
+          <button
+            type="button"
+            key={bib.dancerRosterId}
+            onClick={() => onSelectDancer(bib.dancerRosterId)}
+            className="bg-muted hover:bg-accent flex cursor-pointer flex-col items-center justify-center rounded-lg px-3 py-2.5 transition-colors"
+          >
+            <span className="text-xl font-bold tabular-nums leading-none">
+              {bib.bibNumber != null
+                ? String(bib.bibNumber).padStart(2, "0")
+                : "—"}
+            </span>
+            <span className="text-muted-foreground mt-1 max-w-full truncate text-[10px]">
+              {bib.firstName} {bib.lastName?.[0]}.
+            </span>
+            {Number(bib.coachCount) > 1 && (
+              <span className="text-muted-foreground mt-0.5 text-[10px] opacity-60">
+                {bib.coachCount} coaches
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function PublishDialog({
+  disabled,
+  loading,
+  onConfirm,
+}: {
+  disabled: boolean;
+  loading: boolean;
+  onConfirm: () => void;
+}) {
+  return (
+    <Dialog>
+      <DialogTrigger
+        render={
+          <Button size="sm" disabled={disabled || loading}>
+            <SendIcon className="size-3.5" />
+            Publish Callbacks
+          </Button>
+        }
+      />
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Publish Callbacks</DialogTitle>
+          <DialogDescription>
+            This will lock in the top 5 callbacks per coach (ranked by rating,
+            then recency) and make them visible to dancers.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button onClick={onConfirm} disabled={loading}>
+            {loading ? "Publishing..." : "Publish"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function StartNextDialog({
+  loading,
+  onConfirm,
+}: {
+  loading: boolean;
+  onConfirm: () => void;
+}) {
+  return (
+    <Dialog>
+      <DialogTrigger
+        render={
+          <Button size="sm" variant="outline" disabled={loading}>
+            <SkipForwardIcon className="size-3.5" />
+            Start Next Showcase
+          </Button>
+        }
+      />
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Start Next Showcase</DialogTitle>
+          <DialogDescription>
+            This will archive the current showcase and start a fresh round.
+            Coaches will have an empty callback list.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button onClick={onConfirm} disabled={loading}>
+            {loading ? "Starting..." : "Start Next Showcase"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/dancer/callbacks.tsx
+++ b/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/dancer/callbacks.tsx
@@ -1,0 +1,76 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { createFileRoute, redirect, useParams } from "@tanstack/react-router";
+import { SchoolIcon } from "lucide-react";
+
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { scoutingQueries } from "@/features/org/api/scouting-queries";
+
+export const Route = createFileRoute(
+  "/_org/o/$orgSlug/_authenticated/dancer/callbacks",
+)({
+  loader: async ({ context, params }) => {
+    const data = await context.queryClient.ensureQueryData(
+      scoutingQueries.dancerCallbacks(params.orgSlug),
+    );
+    if (!data || (Array.isArray(data) && data.length === 0)) {
+      throw redirect({ to: "/o/$orgSlug/dancer", params });
+    }
+  },
+  component: DancerCallbacksPage,
+});
+
+function DancerCallbacksPage() {
+  const { orgSlug } = useParams({
+    from: "/_org/o/$orgSlug/_authenticated/dancer/callbacks",
+  });
+  const { data: callbacks } = useSuspenseQuery(
+    scoutingQueries.dancerCallbacks(orgSlug),
+  );
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+      <header className="flex items-center gap-3 px-4 py-4">
+        <h1 className="text-lg font-semibold tracking-tight">Callbacks</h1>
+        <span className="text-muted-foreground text-xs">
+          {(callbacks as any[]).length} school
+          {(callbacks as any[]).length === 1 ? "" : "s"} called you back
+        </span>
+      </header>
+
+      <div className="flex-1 p-4">
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {(
+            callbacks as {
+              coachRosterId: string;
+              firstName: string;
+              lastName: string;
+              organization: string | null;
+            }[]
+          ).map((cb) => (
+            <div
+              key={cb.coachRosterId}
+              className="bg-card flex items-center gap-3 rounded-xl border p-4"
+            >
+              <Avatar className="size-10">
+                <AvatarFallback className="bg-primary/10 text-primary text-sm font-semibold">
+                  {cb.organization
+                    ? cb.organization.charAt(0).toUpperCase()
+                    : "?"}
+                </AvatarFallback>
+              </Avatar>
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-semibold">
+                  {cb.organization || "Unknown School"}
+                </p>
+                <p className="text-muted-foreground truncate text-xs">
+                  {cb.firstName} {cb.lastName}
+                </p>
+              </div>
+              <SchoolIcon className="text-muted-foreground size-4 shrink-0 opacity-40" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add showcase-based lifecycle to event callbacks — admins publish callbacks (locking top 5 per coach ranked by rating/recency) and start new showcases
- Two new DB tables (`event_showcases`, `published_callbacks`) + `showcaseId` FK on `event_callbacks`; all existing callback endpoints scoped to active showcase
- New backend endpoints: list showcases, publish showcase, start next showcase, dancer callbacks
- Admin callbacks page gets publish/next controls with confirmation dialogs, showcase badge, and previous showcases tab
- Dancer sidebar conditionally shows Callbacks nav when published; new dancer callbacks page shows school cards

## Test plan
- [x] Backend typecheck passes
- [x] PublishShowcaseService tests pass (3/3): top-5 ranking, fewer-than-5, reject non-active
- [ ] Admin opens callbacks page — showcase auto-created, bib grid works
- [ ] Coach sends callbacks — scoped to active showcase
- [ ] Admin publishes — top 5 computed, "Start Next Showcase" appears
- [ ] Dancer sees Callbacks in sidebar after publish, page shows school cards
- [ ] Admin starts next showcase — fresh empty round
- [ ] Admin publishes again — dancer sees updated callbacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)