### PR TITLE
fix(events): timezone-correct check-in open time

### DIFF
--- a/apps/backend/app/utils/event-time.spec.ts
+++ b/apps/backend/app/utils/event-time.spec.ts
@@ -1,29 +1,62 @@
 import { test } from "@japa/runner";
-import { hasEventStarted, toEventStartUtc } from "./event-time.ts";
+import {
+  hasEventStarted,
+  isCheckInOpen,
+  toEventStartUtc,
+} from "./event-time.ts";
 
 test.group("toEventStartUtc", () => {
-  test("converts Eastern time to correct UTC", ({ assert }) => {
-    const utc = toEventStartUtc("2026-06-15", "09:00", "America/New_York");
-    assert.equal(utc.toISOString(), "2026-06-15T13:00:00.000Z");
-  });
+  const cases = [
+    [
+      "America/New_York",
+      "2026-01-15T14:00:00.000Z",
+      "2026-07-15T13:00:00.000Z",
+    ],
+    ["America/Chicago", "2026-01-15T15:00:00.000Z", "2026-07-15T14:00:00.000Z"],
+    [
+      "America/Los_Angeles",
+      "2026-01-15T17:00:00.000Z",
+      "2026-07-15T16:00:00.000Z",
+    ],
+    ["UTC", "2026-01-15T09:00:00.000Z", "2026-07-15T09:00:00.000Z"],
+    ["Asia/Kolkata", "2026-01-15T03:30:00.000Z", "2026-07-15T03:30:00.000Z"],
+  ] as const;
 
-  test("converts Central time to correct UTC", ({ assert }) => {
-    const utc = toEventStartUtc("2026-06-15", "09:00", "America/Chicago");
-    assert.equal(utc.toISOString(), "2026-06-15T14:00:00.000Z");
-  });
+  for (const [timezone, januaryUtc, julyUtc] of cases) {
+    test(`converts ${timezone} to exact UTC instants across DST seasons`, ({
+      assert,
+    }) => {
+      assert.equal(
+        toEventStartUtc("2026-01-15", "09:00", timezone).toISOString(),
+        januaryUtc
+      );
+      assert.equal(
+        toEventStartUtc("2026-07-15", "09:00", timezone).toISOString(),
+        julyUtc
+      );
+    });
+  }
 
-  test("converts Pacific time to correct UTC", ({ assert }) => {
-    const utc = toEventStartUtc("2026-06-15", "09:00", "America/Los_Angeles");
-    assert.equal(utc.toISOString(), "2026-06-15T16:00:00.000Z");
+  test("falls back to the date-only behavior for an invalid timezone", ({
+    assert,
+  }) => {
+    assert.equal(
+      toEventStartUtc("2026-07-15", "09:00", "Not/A_Timezone").getTime(),
+      new Date(2026, 6, 15).getTime()
+    );
   });
 });
 
 test.group("hasEventStarted", () => {
-  test("falls back to date check when startTime is null (past date)", ({ assert }) => {
+  test("falls back to date check when startTime is null (past date)", ({
+    assert,
+  }) => {
     assert.isTrue(hasEventStarted("2020-01-01", null, null));
   });
 
-  test("falls back to date check when startTime is null (future date)", ({ assert }) => {
+  test("falls back to date check when startTime is null (future date)", ({
+    assert,
+  }) => {
     assert.isFalse(hasEventStarted("2099-12-31", null, null));
   });
 
@@ -37,5 +70,51 @@ test.group("hasEventStarted", () => {
 
   test("returns false for a future event start", ({ assert }) => {
     assert.isFalse(hasEventStarted("2099-12-31", "23:59", "America/New_York"));
+  });
+
+  test("uses the timezone-correct event instant", ({ assert }) => {
+    const originalNow = Date.now;
+    Date.now = () => Date.parse("2026-07-15T12:59:59.999Z");
+
+    try {
+      assert.isFalse(
+        hasEventStarted("2026-07-15", "09:00", "America/New_York")
+      );
+      Date.now = () => Date.parse("2026-07-15T13:00:00.000Z");
+      assert.isTrue(hasEventStarted("2026-07-15", "09:00", "America/New_York"));
+    } finally {
+      Date.now = originalNow;
+    }
+  });
+});
+
+test.group("isCheckInOpen", () => {
+  test("opens exactly one hour before the timezone-correct event instant", ({
+    assert,
+  }) => {
+    const originalNow = Date.now;
+    Date.now = () => Date.parse("2026-07-15T11:59:59.999Z");
+
+    try {
+      assert.isFalse(isCheckInOpen("2026-07-15", "09:00", "America/New_York"));
+      Date.now = () => Date.parse("2026-07-15T12:00:00.000Z");
+      assert.isTrue(isCheckInOpen("2026-07-15", "09:00", "America/New_York"));
+    } finally {
+      Date.now = originalNow;
+    }
+  });
+
+  test("keeps the date-only fallback when timezone is missing", ({
+    assert,
+  }) => {
+    const originalNow = Date.now;
+    const startOfDay = new Date(2026, 6, 15).getTime();
+    Date.now = () => startOfDay - 60 * 60 * 1000;
+
+    try {
+      assert.isTrue(isCheckInOpen("2026-07-15", "09:00", null));
+    } finally {
+      Date.now = originalNow;
+    }
   });
 });

--- a/apps/backend/app/utils/event-time.ts
+++ b/apps/backend/app/utils/event-time.ts
@@ -1,29 +1,37 @@
+import { DateTime } from "luxon";
+
+function fallbackEventStart(startDate: string): Date {
+  const [y, m, d] = startDate.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
 export function toEventStartUtc(
   startDate: string,
   startTime: string,
-  timezone: string,
+  timezone: string
 ): Date {
-  const [y, m, d] = startDate.split("-").map(Number);
-  const [h, min] = startTime.split(":").map(Number);
-  const utcGuess = new Date(Date.UTC(y, m - 1, d, h, min));
-  const inTz = new Date(
-    utcGuess.toLocaleString("en-US", { timeZone: timezone }),
+  const eventStart = DateTime.fromFormat(
+    `${startDate} ${startTime}`,
+    "yyyy-MM-dd HH:mm",
+    { zone: timezone }
   );
-  const offset = utcGuess.getTime() - inTz.getTime();
-  return new Date(utcGuess.getTime() + offset);
+
+  return eventStart.isValid
+    ? eventStart.toUTC().toJSDate()
+    : fallbackEventStart(startDate);
 }
 
 export function hasEventStarted(
   startDate: string,
   startTime: string | null,
-  timezone: string | null,
+  timezone: string | null
 ): boolean {
   if (startTime && timezone) {
-    return Date.now() >= toEventStartUtc(startDate, startTime, timezone).getTime();
+    return (
+      Date.now() >= toEventStartUtc(startDate, startTime, timezone).getTime()
+    );
   }
-  const [y, m, d] = startDate.split("-").map(Number);
-  const startOfDay = new Date(y, m - 1, d);
-  return Date.now() >= startOfDay.getTime();
+  return Date.now() >= fallbackEventStart(startDate).getTime();
 }
 
 const CHECK_IN_LEAD_MS = 60 * 60 * 1000;
@@ -31,12 +39,16 @@ const CHECK_IN_LEAD_MS = 60 * 60 * 1000;
 export function isCheckInOpen(
   startDate: string,
   startTime: string | null,
-  timezone: string | null,
+  timezone: string | null
 ): boolean {
   if (startTime && timezone) {
-    return Date.now() >= toEventStartUtc(startDate, startTime, timezone).getTime() - CHECK_IN_LEAD_MS;
+    return (
+      Date.now() >=
+      toEventStartUtc(startDate, startTime, timezone).getTime() -
+        CHECK_IN_LEAD_MS
+    );
   }
-  const [y, m, d] = startDate.split("-").map(Number);
-  const startOfDay = new Date(y, m - 1, d);
-  return Date.now() >= startOfDay.getTime() - CHECK_IN_LEAD_MS;
+  return (
+    Date.now() >= fallbackEventStart(startDate).getTime() - CHECK_IN_LEAD_MS
+  );
 }

--- a/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/dancer/event-info.tsx
+++ b/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/dancer/event-info.tsx
@@ -124,6 +124,7 @@ function DancerDashboard({
               status={status ?? null}
               isLoading={statusLoading}
               checkIn={checkIn}
+              eventStartDate={event.startDate}
             />
           )}
           <QuickNavPanel
@@ -155,10 +156,12 @@ function CheckInPanel({
   status,
   isLoading,
   checkIn,
+  eventStartDate,
 }: {
   status: CheckInStatus | null;
   isLoading: boolean;
   checkIn: ReturnType<typeof useDancerCheckIn>;
+  eventStartDate: string;
 }) {
   return (
     <div className="border-border flex max-h-72 min-h-0 w-full flex-col overflow-y-auto rounded-md border">
@@ -183,7 +186,11 @@ function CheckInPanel({
             Check-in is not available.
           </p>
         ) : (
-          <CheckInContent status={status} checkIn={checkIn} />
+          <CheckInContent
+            status={status}
+            checkIn={checkIn}
+            eventStartDate={eventStartDate}
+          />
         )}
       </div>
     </div>
@@ -193,9 +200,11 @@ function CheckInPanel({
 function CheckInContent({
   status,
   checkIn,
+  eventStartDate,
 }: {
   status: CheckInStatus;
   checkIn: ReturnType<typeof useDancerCheckIn>;
+  eventStartDate: string;
 }) {
   if (status.checkedInAt) {
     const checkedInTime = new Date(status.checkedInAt).toLocaleTimeString(
@@ -260,17 +269,14 @@ function CheckInContent({
     );
   }
 
-  const opensAt = status.eventStartTime
-    ? (() => {
-        const d = new Date(`1970-01-01T${status.eventStartTime}`);
-        d.setHours(d.getHours() - 1);
-        return d.toLocaleTimeString("en-US", {
-          hour: "numeric",
-          minute: "2-digit",
-          hour12: true,
-        });
-      })()
-    : null;
+  const opensAt =
+    status.eventStartTime && status.timezone
+      ? formatCheckInOpenTime(
+          eventStartDate,
+          status.eventStartTime,
+          status.timezone,
+        )
+      : null;
 
   return (
     <div className="flex items-start gap-3">
@@ -282,13 +288,64 @@ function CheckInContent({
           Check-in not yet open
         </span>
         <span className="text-muted-foreground text-[11px] 2xl:text-xs">
-          {opensAt
-            ? `Opens at ${opensAt} ${status.timezone}`
-            : "Opens on event day"}
+          {opensAt ? `Opens at ${opensAt}` : "Opens on event day"}
         </span>
       </div>
     </div>
   );
+}
+
+function formatCheckInOpenTime(
+  startDate: string,
+  startTime: string,
+  timezone: string,
+): string | null {
+  const [year, month, day] = startDate.split("-").map(Number);
+  const [hour, minute] = startTime.split(":").map(Number);
+  const eventWallTime = Date.UTC(year, month - 1, day, hour, minute);
+
+  try {
+    const partsFormatter = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hourCycle: "h23",
+    });
+    const getOffset = (instant: number) => {
+      const parts = Object.fromEntries(
+        partsFormatter
+          .formatToParts(new Date(instant))
+          .filter((part) => part.type !== "literal")
+          .map((part) => [part.type, part.value]),
+      );
+      const zonedWallTime = Date.UTC(
+        Number(parts.year),
+        Number(parts.month) - 1,
+        Number(parts.day),
+        Number(parts.hour),
+        Number(parts.minute),
+        Number(parts.second),
+      );
+      return zonedWallTime - instant;
+    };
+
+    let eventInstant = eventWallTime - getOffset(eventWallTime);
+    eventInstant = eventWallTime - getOffset(eventInstant);
+
+    return new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      hour: "numeric",
+      minute: "2-digit",
+      hour12: true,
+      timeZoneName: "short",
+    }).format(new Date(eventInstant - 60 * 60 * 1000));
+  } catch {
+    return null;
+  }
 }
 
 function QuickNavPanel({


### PR DESCRIPTION
## Summary

Check-in time conversion parsed a timezone-less localized string in the Node process timezone, producing incorrect UTC instants whenever the host was not UTC. This prevented check-in from opening one hour before timezone-configured events.

## Changes

- Replaced manual conversion with Luxon’s timezone-aware UTC conversion.
- Preserved date-only fallback behavior for missing or invalid timezones.
- Added host-TZ-independent tests across five zones, January/July DST offsets, and the exact one-hour check-in boundary.
- Updated the dancer check-in card to display the opening time in the event timezone with its zone abbreviation.

## Verification

- `pnpm --filter backend typecheck` — passed.
- `node ace test --files "app/utils/event-time.spec.ts"` — 14 passed.
- `TZ=America/Los_Angeles node ace test --files "app/utils/event-time.spec.ts"` — 14 passed.
- `node ace test --files "app/modules/orgs/events/check-in/**/*.test.ts"` — no matching tests.
- `node ace test --files "app/modules/orgs/events/check-in/service.spec.ts"` — 5 passed.
- `pnpm --filter frontend build` — passed.
- Targeted backend and frontend lint for changed files — passed.
- `pnpm --filter backend lint` — repository baseline failure: 132 existing errors outside changed files.
- `pnpm --filter frontend lint` — repository baseline failure: 169 existing issues outside changed files.

## Notes/risks

- Events without a timezone retain their existing behavior.
- Invalid timezone strings defensively use the same date-only fallback.
- No dependencies or database schema changes were added.
- Committed locally as `1744bf5 fix(events): timezone-correct check-in open time computation`.
- The pre-existing `.env.test` worktree modification was not committed.

---
_Part of the July 2026 bug-fix wave (6 draft PRs). T1/T4/T6 are independent; the email/coach stack merges in order T3 → T5 → T2._

🤖 Generated with [Claude Code](https://claude.com/claude-code)