### PR TITLE
feat(feed): organizations stories rail + hamburger sidebar trigger

### DIFF
--- a/apps/frontend/src/components/shared/org-dashboard-link.ts
+++ b/apps/frontend/src/components/shared/org-dashboard-link.ts
@@ -1,0 +1,13 @@
+import type { ApiSchemas } from "@/lib/api/client";
+
+export type MyOrg = ApiSchemas["UsersMeOrgsResponse"][number];
+
+export function dashboardLink(org: MyOrg) {
+  if (org.role === "admin") {
+    return { to: "/o/$orgSlug/admin" as const, label: "Admin" };
+  }
+  if (org.type === "coach") {
+    return { to: "/o/$orgSlug/coach" as const, label: "Coach" };
+  }
+  return { to: "/o/$orgSlug/dancer" as const, label: "Dancer" };
+}

--- a/apps/frontend/src/components/shared/org-stories-rail.tsx
+++ b/apps/frontend/src/components/shared/org-stories-rail.tsx
@@ -1,0 +1,67 @@
+import { dashboardLink } from "@/components/shared/org-dashboard-link";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { $api } from "@/lib/api/client";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+
+function getInitials(name: string) {
+  return (
+    name
+      .trim()
+      .split(/\s+/)
+      .slice(0, 2)
+      .map((word) => word[0])
+      .join("")
+      .toUpperCase() || "OR"
+  );
+}
+
+export function OrgStoriesRail() {
+  const { data, isError } = useQuery({
+    ...$api.queryOptions("get", "/users/me/orgs"),
+    retry: false,
+    throwOnError: false,
+  });
+
+  if (isError || !data || data.length === 0) return null;
+
+  return (
+    <section className="flex flex-col gap-2 border-b pb-3">
+      <h2 className="text-muted-foreground text-xs font-medium">
+        Organizations
+      </h2>
+      <div className="scrollbar-none flex gap-2 overflow-x-auto pb-1">
+        {data.map((org) => {
+          const target = dashboardLink(org);
+
+          return (
+            <Link
+              key={org.id}
+              to={target.to}
+              params={{ orgSlug: org.slug }}
+              preload={false}
+              className="focus-visible:ring-ring/50 flex w-16 shrink-0 flex-col items-center gap-1.5 rounded-md outline-none focus-visible:ring-2"
+            >
+              <Avatar
+                className="size-14 border-2"
+                style={
+                  org.primaryColor
+                    ? { borderColor: org.primaryColor }
+                    : undefined
+                }
+              >
+                <AvatarImage src={org.logoUrl ?? undefined} alt={org.name} />
+                <AvatarFallback className="text-sm font-semibold">
+                  {getInitials(org.name)}
+                </AvatarFallback>
+              </Avatar>
+              <span className="w-full truncate text-center text-xs">
+                {org.name}
+              </span>
+            </Link>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/apps/frontend/src/components/shared/profile-organizations.tsx
+++ b/apps/frontend/src/components/shared/profile-organizations.tsx
@@ -1,18 +1,10 @@
 import { OrgList } from "@/components/shared/org-list";
-import { $api, type ApiSchemas } from "@/lib/api/client";
+import {
+  dashboardLink,
+  type MyOrg,
+} from "@/components/shared/org-dashboard-link";
+import { $api } from "@/lib/api/client";
 import { useQuery } from "@tanstack/react-query";
-
-type MyOrg = ApiSchemas["UsersMeOrgsResponse"][number];
-
-function dashboardLink(org: MyOrg) {
-  if (org.role === "admin") {
-    return { to: "/o/$orgSlug/admin" as const, label: "Admin" };
-  }
-  if (org.type === "coach") {
-    return { to: "/o/$orgSlug/coach" as const, label: "Coach" };
-  }
-  return { to: "/o/$orgSlug/dancer" as const, label: "Dancer" };
-}
 
 export function ProfileOrganizations() {
   const { data, isError } = useQuery({

--- a/apps/frontend/src/components/ui/sidebar.tsx
+++ b/apps/frontend/src/components/ui/sidebar.tsx
@@ -1,7 +1,7 @@
 import { mergeProps } from "@base-ui/react/merge-props";
 import { useRender } from "@base-ui/react/use-render";
 import { cva, type VariantProps } from "class-variance-authority";
-import { PanelLeftIcon } from "lucide-react";
+import { MenuIcon } from "lucide-react";
 import * as React from "react";
 
 import { Button } from "@/components/ui/button";
@@ -270,7 +270,7 @@ function SidebarTrigger({
       variant="ghost"
       {...props}
     >
-      <PanelLeftIcon />
+      <MenuIcon />
       <span className="sr-only">Toggle Sidebar</span>
     </Button>
   );

--- a/apps/frontend/src/features/feed/page.tsx
+++ b/apps/frontend/src/features/feed/page.tsx
@@ -1,4 +1,5 @@
 import { SidebarLayout } from "@/components/layouts/sidebar-layout";
+import { OrgStoriesRail } from "@/components/shared/org-stories-rail";
 import { FeedSidebar } from "@/features/feed/components/sidebar/sidebar";
 
 import { useSession } from "@/lib/session";
@@ -17,6 +18,8 @@ export function FeedPage() {
       tabs={{ contentLabel: "Feed", sidebarLabel: "Discover" }}
     >
       <div className="flex flex-col gap-2 lg:gap-4">
+        <OrgStoriesRail />
+
         <div className="hidden lg:block">
           <h1 className="text-2xl leading-none font-bold tracking-tight">
             Welcome back, {session.firstName}!


### PR DESCRIPTION
## Summary

Added a hamburger sidebar trigger and an Instagram-Stories-style Organizations rail above the feed.

## Changes

- Replaced `PanelLeftIcon` with Lucide’s `MenuIcon` in the shared `SidebarTrigger`.
  - Appears in the admin, coach, and dancer organization dashboard headers.
  - Behavior remains unchanged.
  - The Resources tab’s `HiBookOpen` icon was untouched.
- Added a shared Organizations rail at the top of `FeedPage` for all sessions and viewport sizes.
  - Uses `/users/me/orgs`.
  - Includes circular avatars, initials fallbacks, optional organization-color rings, truncated names, and horizontal scrolling.
  - Renders nothing while loading, on errors, or for an empty organization list.
- Extracted the existing role-based `dashboardLink` logic for reuse while preserving `ProfileOrganizations`.

## Verification

- `pnpm --filter frontend build` — passed.
- `pnpm --filter frontend lint` — blocked by the existing repository baseline: 169 problems (156 errors, 13 warnings) across unrelated files.
- Targeted ESLint for the new rail, helper, profile integration, and feed page — passed.
- Prettier and `git diff --check` — passed.

## Notes/risks

- No browser or screenshot verification was performed, as requested.
- Existing unrelated `apps/backend/.env.test` changes were left untouched and uncommitted.
- Local commits:
  - `d16f9d1 fix(nav): use hamburger sidebar trigger`
  - `0b7ad3f feat(feed): add organizations stories rail`

---
**Post-review additions confirmed:** empty org list hides the entire section; rail is overflow-x scrollable with fixed-width items on mobile.

---
_Part of the July 2026 bug-fix wave (6 draft PRs). T1/T4/T6 are independent; the email/coach stack merges in order T3 → T5 → T2._

🤖 Generated with [Claude Code](https://claude.com/claude-code)