### PR TITLE
fix(org): throttle roster invite emails under SES rate limit

### DIFF
--- a/apps/backend/app/modules/orgs/events/rosters/resend-invites/service.ts
+++ b/apps/backend/app/modules/orgs/events/rosters/resend-invites/service.ts
@@ -1,10 +1,14 @@
 import { DatabaseService } from "#database/service";
 import { inject } from "@adonisjs/core";
 import { randomBytes } from "node:crypto";
-import { setTimeout as sleep } from "node:timers/promises";
 import { eventRosters, orgEvents } from "#database/schema/org-events";
 import { dancerInvites, organizations } from "#database/schema/organizations";
 import { sendOrgInviteEmailOrThrow } from "#shared/org/invite-email";
+import {
+  EMAIL_SEND_PACING_MS,
+  sendThrottledEmails,
+  type EmailSendTask,
+} from "#shared/org/throttled-email-sender";
 import { and, eq, inArray, isNull } from "drizzle-orm";
 import type { Validator } from "./validator.ts";
 import type { AuditContext } from "#database/audit";
@@ -20,7 +24,7 @@ export interface ResendInvitesResult {
 }
 
 // Exposed for tests: allows disabling the per-item delay.
-export const RESEND_PACING_MS = 100;
+export const RESEND_PACING_MS = EMAIL_SEND_PACING_MS;
 
 @inject()
 export class ResendInvitesService {
@@ -77,52 +81,58 @@ export class ResendInvitesService {
       return { sent: 0, skipped: input.ids.length, failed: [] };
     }
 
-    let sent = 0;
     const failed: Array<{ id: string; reason: string }> = [];
+    const rowIdsByTask = new Map<EmailSendTask, string>();
+    const tasks = rows.map((row) => {
+      const token = randomToken();
+      const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 14);
+      let invitePrepared = false;
+      const task: EmailSendTask = {
+        recipient: row.email,
+        send: async () => {
+          if (!invitePrepared) {
+            await this.db.tx(async (tx) => {
+              await tx
+                .delete(dancerInvites)
+                .where(
+                  and(
+                    eq(dancerInvites.orgId, org.id),
+                    eq(dancerInvites.email, row.email)
+                  )
+                );
+              await tx.insert(dancerInvites).values({
+                orgId: org.id,
+                email: row.email,
+                token,
+                expiresAt,
+              });
+            });
+            invitePrepared = true;
+          }
 
-    for (let i = 0; i < rows.length; i++) {
-      const row = rows[i]!;
-      try {
-        const token = randomToken();
-        const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 14);
-        await this.db.tx(async (tx) => {
-          await tx
-            .delete(dancerInvites)
-            .where(
-              and(
-                eq(dancerInvites.orgId, org.id),
-                eq(dancerInvites.email, row.email)
-              )
-            );
-          await tx.insert(dancerInvites).values({
-            orgId: org.id,
+          await sendOrgInviteEmailOrThrow({
+            org,
+            event,
             email: row.email,
+            firstName: row.firstName,
+            type: "dancer",
             token,
-            expiresAt,
           });
-        });
+        },
+      };
+      rowIdsByTask.set(task, row.id);
+      return task;
+    });
 
-        await sendOrgInviteEmailOrThrow({
-          org,
-          event,
-          email: row.email,
-          firstName: row.firstName,
-          type: "dancer",
-          token,
-        });
-
-        sent += 1;
-      } catch (err) {
+    const { sent } = await sendThrottledEmails(tasks, {
+      pacingMs,
+      onTerminalFailure: (task, error) => {
         failed.push({
-          id: row.id,
-          reason: err instanceof Error ? err.message : String(err),
+          id: rowIdsByTask.get(task)!,
+          reason: error instanceof Error ? error.message : String(error),
         });
-      }
-
-      if (pacingMs > 0 && i < rows.length - 1) {
-        await sleep(pacingMs);
-      }
-    }
+      },
+    });
 
     // Log a single audit entry summarizing the resend operation
     await this.db.withAudit(auditCtx, async (_tx, auditLog) => {

--- a/apps/backend/app/modules/orgs/events/upload-coaches/service.ts
+++ b/apps/backend/app/modules/orgs/events/upload-coaches/service.ts
@@ -9,12 +9,17 @@ import {
 } from "#database/schema/org-events";
 import { organizations, orgMemberships } from "#database/schema/organizations";
 import { normalizeRowEmails, parseCoachCsv } from "#shared/org/csv-parser";
-import { sendOrgRosterAddedEmail } from "#shared/org/roster-added-email";
-import { sendSchoolAccountInviteEmail } from "#shared/org/school-account-invite-email";
+import { sendOrgRosterAddedEmailOrThrow } from "#shared/org/roster-added-email";
+import { sendSchoolAccountInviteEmailOrThrow } from "#shared/org/school-account-invite-email";
+import {
+  sendThrottledEmails,
+  type EmailSendTask,
+} from "#shared/org/throttled-email-sender";
 import { enforceEmailRole } from "#shared/org/role-guard";
 import { verifyPreviewToken } from "#shared/org/preview-token";
 import { and, eq, inArray, isNull } from "drizzle-orm";
 import { randomBytes } from "node:crypto";
+import logger from "@adonisjs/core/services/logger";
 
 @inject()
 export class UploadCoachesService {
@@ -253,7 +258,9 @@ export class UploadCoachesService {
       }
     );
 
-    // Fire-and-forget token-linked invite emails for unmatched rows (after transaction)
+    const emailTasks: EmailSendTask[] = [];
+
+    // Queue token-linked invite emails for unmatched rows (after transaction).
     if (org && rows.length > 0) {
       const uploadId = result.uploadId;
       const unmatchedRows = await this.db
@@ -280,31 +287,63 @@ export class UploadCoachesService {
               )
             )
         )
-        .catch(() => []);
+        .catch((error: unknown) => {
+          logger.error(
+            { orgId, eventId, err: error },
+            "Failed to load coach roster invite recipients"
+          );
+          return [];
+        });
 
       for (const row of unmatchedRows) {
         if (!row.token) continue;
-        sendSchoolAccountInviteEmail({
-          org,
-          event: event ?? null,
-          email: row.email,
-          firstName: row.firstName,
-          token: row.token,
-        }).catch(() => {});
+        const token = row.token;
+        emailTasks.push({
+          recipient: row.email,
+          send: () =>
+            sendSchoolAccountInviteEmailOrThrow({
+              org,
+              event: event ?? null,
+              email: row.email,
+              firstName: row.firstName,
+              token,
+            }),
+        });
       }
     }
 
-    // Fire-and-forget notification emails for matched-new rows.
+    // Queue notification emails for matched-new rows.
     if (org && matchedNotifications.length > 0) {
       for (const { email, firstName } of matchedNotifications) {
-        sendOrgRosterAddedEmail({
-          org,
-          event: event ?? null,
-          email,
-          firstName,
-          type: "coach",
-        }).catch(() => {});
+        emailTasks.push({
+          recipient: email,
+          send: () =>
+            sendOrgRosterAddedEmailOrThrow({
+              org,
+              event: event ?? null,
+              email,
+              firstName,
+              type: "coach",
+            }),
+        });
       }
+    }
+
+    // Keep the HTTP response immediate while pacing the detached batch.
+    if (emailTasks.length > 0) {
+      void sendThrottledEmails(emailTasks)
+        .then(({ sent, failed }) => {
+          logger.info(
+            { orgId, eventId, sent, failed },
+            "Coach roster email batch completed"
+          );
+        })
+        .catch((error: unknown) => {
+          logger.error(
+            { orgId, eventId, err: error },
+            "Coach roster email batch stopped unexpectedly"
+          );
+        });
     }
 
     return {

--- a/apps/backend/app/modules/orgs/events/upload-dancers/service.ts
+++ b/apps/backend/app/modules/orgs/events/upload-dancers/service.ts
@@ -14,12 +14,17 @@ import {
   csvUploads,
 } from "#database/schema/org-events";
 import { normalizeRowEmails, parseDancerCsv } from "#shared/org/csv-parser";
-import { sendOrgInviteEmail } from "#shared/org/invite-email";
-import { sendFreeTierInviteEmail } from "#shared/org/free-tier-invite-email";
-import { sendOrgRosterAddedEmail } from "#shared/org/roster-added-email";
+import { sendOrgInviteEmailOrThrow } from "#shared/org/invite-email";
+import { sendFreeTierInviteEmailOrThrow } from "#shared/org/free-tier-invite-email";
+import { sendOrgRosterAddedEmailOrThrow } from "#shared/org/roster-added-email";
+import {
+  sendThrottledEmails,
+  type EmailSendTask,
+} from "#shared/org/throttled-email-sender";
 import { enforceEmailRole } from "#shared/org/role-guard";
 import { verifyPreviewToken } from "#shared/org/preview-token";
 import { and, eq, inArray } from "drizzle-orm";
+import logger from "@adonisjs/core/services/logger";
 
 function randomToken(): string {
   return randomBytes(32).toString("base64url");
@@ -199,11 +204,13 @@ export class UploadDancersService {
           for (const r of rowsToProcess) {
             const userId = byEmail.get(r.email.toLowerCase()) ?? null;
 
-            const rowExpiration = userId ? (() => {
-              const d = new Date(event!.endDate);
-              d.setMonth(d.getMonth() + tierExpiryMonths);
-              return d.toISOString().split("T")[0]!;
-            })() : null;
+            const rowExpiration = userId
+              ? (() => {
+                  const d = new Date(event!.endDate);
+                  d.setMonth(d.getMonth() + tierExpiryMonths);
+                  return d.toISOString().split("T")[0]!;
+                })()
+              : null;
 
             const [existing] = await tx
               .select()
@@ -269,7 +276,6 @@ export class UploadDancersService {
                 .onConflictDoNothing({
                   target: [orgMemberships.userId, orgMemberships.orgId],
                 });
-
             } else {
               // Create dancer invite for unmatched rows
               const token = randomToken();
@@ -359,47 +365,79 @@ export class UploadDancersService {
       }
     );
 
-    // Fire-and-forget invite emails for unmatched rows (after transaction)
+    const emailTasks: EmailSendTask[] = [];
+
+    // Queue invite emails for unmatched rows (after transaction).
     if (org && inviteTokens.length > 0) {
-      const upgradeUrl = freeTier
-        ? (orgSettings.free_tier_upgrade_url as string | undefined) ?? null
-        : null;
+      const configuredUpgradeUrl = orgSettings.free_tier_upgrade_url as
+        | string
+        | undefined;
+      const upgradeUrl = freeTier ? (configuredUpgradeUrl ?? null) : null;
 
       for (const { email, firstName, token, paid } of inviteTokens) {
         if (freeTier && paid === false && upgradeUrl) {
-          sendFreeTierInviteEmail({
-            org,
-            event: event ?? null,
-            email,
-            firstName,
-            token,
-            upgradeUrl,
-            tierExpiryMonths,
-          }).catch(() => {});
+          emailTasks.push({
+            recipient: email,
+            send: () =>
+              sendFreeTierInviteEmailOrThrow({
+                org,
+                event: event ?? null,
+                email,
+                firstName,
+                token,
+                upgradeUrl,
+                tierExpiryMonths,
+              }),
+          });
         } else {
-          sendOrgInviteEmail({
-            org,
-            event: event ?? null,
-            email,
-            firstName,
-            type: "dancer",
-            token,
-          }).catch(() => {});
+          emailTasks.push({
+            recipient: email,
+            send: () =>
+              sendOrgInviteEmailOrThrow({
+                org,
+                event: event ?? null,
+                email,
+                firstName,
+                type: "dancer",
+                token,
+              }),
+          });
         }
       }
     }
 
-    // Fire-and-forget notification emails for matched-new rows.
+    // Queue notification emails for matched-new rows.
     if (org && matchedNotifications.length > 0) {
       for (const { email, firstName } of matchedNotifications) {
-        sendOrgRosterAddedEmail({
-          org,
-          event: event ?? null,
-          email,
-          firstName,
-          type: "dancer",
-        }).catch(() => {});
+        emailTasks.push({
+          recipient: email,
+          send: () =>
+            sendOrgRosterAddedEmailOrThrow({
+              org,
+              event: event ?? null,
+              email,
+              firstName,
+              type: "dancer",
+            }),
+        });
       }
+    }
+
+    // Keep the HTTP response immediate while pacing the detached batch.
+    if (emailTasks.length > 0) {
+      void sendThrottledEmails(emailTasks)
+        .then(({ sent, failed }) => {
+          logger.info(
+            { orgId, eventId, sent, failed },
+            "Dancer roster email batch completed"
+          );
+        })
+        .catch((error: unknown) => {
+          logger.error(
+            { orgId, eventId, err: error },
+            "Dancer roster email batch stopped unexpectedly"
+          );
+        });
     }
 
     return {

--- a/apps/backend/app/shared/org/free-tier-invite-email.ts
+++ b/apps/backend/app/shared/org/free-tier-invite-email.ts
@@ -15,7 +15,7 @@ interface FreeTierInviteMailData {
   upgradeUrl: string;
   contactEmail: string | null;
   tierExpiryMonths: number;
-  vaultName: string | null;
+  brandName: string | null;
   brandColor: string | null;
   welcomeVideoUrl: string | null;
   logoUrl: string | null;
@@ -26,7 +26,8 @@ class FreeTierInviteMail extends BaseMail {
 
   constructor(private data: FreeTierInviteMailData) {
     super();
-    this.subject = "You're officially in The Vault";
+    const brand = data.brandName?.trim() || data.orgName;
+    this.subject = `You're officially in ${brand}`;
   }
 
   async prepare() {
@@ -41,7 +42,7 @@ class FreeTierInviteMail extends BaseMail {
       upgradeUrl: this.data.upgradeUrl,
       contactEmail: this.data.contactEmail,
       tierExpiryMonths: this.data.tierExpiryMonths,
-      vaultName: this.data.vaultName,
+      brandName: this.data.brandName,
       brandColor: this.data.brandColor,
       welcomeVideoUrl: this.data.welcomeVideoUrl,
       logoUrl: this.data.logoUrl,
@@ -76,7 +77,9 @@ export async function sendFreeTierInviteEmailOrThrow(opts: {
       upgradeUrl,
       contactEmail: event?.contactEmail ?? null,
       tierExpiryMonths,
-      vaultName:
+      // "free_tier_vault_name" is a legacy persisted settings key; renaming it
+      // requires migrating org settings JSON.
+      brandName:
         (org.settings as { free_tier_vault_name?: string })
           ?.free_tier_vault_name ?? null,
       brandColor: org.primaryColor ?? null,

--- a/apps/backend/app/shared/org/throttled-email-sender.spec.ts
+++ b/apps/backend/app/shared/org/throttled-email-sender.spec.ts
@@ -1,0 +1,152 @@
+import { test } from "@japa/runner";
+import { sendThrottledEmails } from "./throttled-email-sender.ts";
+
+test.group("sendThrottledEmails", () => {
+  test("sends sequentially with pacing between recipients", async ({
+    assert,
+  }) => {
+    const events: string[] = [];
+
+    const result = await sendThrottledEmails(
+      [
+        {
+          recipient: "first@example.com",
+          send: async () => {
+            events.push("send:first");
+          },
+        },
+        {
+          recipient: "second@example.com",
+          send: async () => {
+            events.push("send:second");
+          },
+        },
+        {
+          recipient: "third@example.com",
+          send: async () => {
+            events.push("send:third");
+          },
+        },
+      ],
+      {
+        pacingMs: 100,
+        sleep: async (milliseconds) => {
+          events.push(`sleep:${milliseconds}`);
+        },
+      }
+    );
+
+    assert.deepEqual(events, [
+      "send:first",
+      "sleep:100",
+      "send:second",
+      "sleep:100",
+      "send:third",
+    ]);
+    assert.deepEqual(result, { sent: 3, failed: 0 });
+  });
+
+  test("retries SES throttling errors with exponential backoff", async ({
+    assert,
+  }) => {
+    let attempts = 0;
+    const delays: number[] = [];
+
+    const result = await sendThrottledEmails(
+      [
+        {
+          recipient: "retry@example.com",
+          send: async () => {
+            attempts += 1;
+            if (attempts < 3) {
+              const error = new Error("Rate exceeded");
+              error.name = "Throttling";
+              throw error;
+            }
+          },
+        },
+      ],
+      {
+        pacingMs: 0,
+        retryBackoffMs: 250,
+        sleep: async (milliseconds) => {
+          delays.push(milliseconds);
+        },
+      }
+    );
+
+    assert.equal(attempts, 3);
+    assert.deepEqual(delays, [250, 500]);
+    assert.deepEqual(result, { sent: 1, failed: 0 });
+  });
+
+  test("does not retry terminal errors and collects the failure", async ({
+    assert,
+  }) => {
+    const terminalError = new Error("Mailbox rejected");
+    const failures: Array<{ recipient: string; error: unknown }> = [];
+    let failedAttempts = 0;
+
+    const result = await sendThrottledEmails(
+      [
+        {
+          recipient: "failed@example.com",
+          send: async () => {
+            failedAttempts += 1;
+            throw terminalError;
+          },
+        },
+        {
+          recipient: "sent@example.com",
+          send: async () => {},
+        },
+      ],
+      {
+        pacingMs: 0,
+        sleep: async () => {},
+        onTerminalFailure: (task, error) => {
+          failures.push({ recipient: task.recipient, error });
+        },
+      }
+    );
+
+    assert.equal(failedAttempts, 1);
+    assert.deepEqual(failures, [
+      { recipient: "failed@example.com", error: terminalError },
+    ]);
+    assert.deepEqual(result, { sent: 1, failed: 1 });
+  });
+
+  test("collects throttling failures after retries are exhausted", async ({
+    assert,
+  }) => {
+    let attempts = 0;
+    const recipients: string[] = [];
+
+    const result = await sendThrottledEmails(
+      [
+        {
+          recipient: "throttled@example.com",
+          send: async () => {
+            attempts += 1;
+            throw Object.assign(new Error("Too many requests"), {
+              name: "TooManyRequestsException",
+            });
+          },
+        },
+      ],
+      {
+        pacingMs: 0,
+        maxRetries: 2,
+        sleep: async () => {},
+        onTerminalFailure: (task) => {
+          recipients.push(task.recipient);
+        },
+      }
+    );
+
+    assert.equal(attempts, 3);
+    assert.deepEqual(recipients, ["throttled@example.com"]);
+    assert.deepEqual(result, { sent: 0, failed: 1 });
+  });
+});

--- a/apps/backend/app/shared/org/throttled-email-sender.ts
+++ b/apps/backend/app/shared/org/throttled-email-sender.ts
@@ -1,0 +1,102 @@
+import logger from "@adonisjs/core/services/logger";
+import { setTimeout as sleep } from "node:timers/promises";
+
+export const EMAIL_SEND_PACING_MS = 100;
+export const EMAIL_SEND_MAX_RETRIES = 2;
+export const EMAIL_SEND_RETRY_BACKOFF_MS = 250;
+
+export interface EmailSendTask {
+  recipient: string;
+  send: () => Promise<void>;
+}
+
+export interface ThrottledEmailResult {
+  sent: number;
+  failed: number;
+}
+
+interface ThrottledEmailOptions {
+  pacingMs?: number;
+  maxRetries?: number;
+  retryBackoffMs?: number;
+  sleep?: (milliseconds: number) => Promise<void>;
+  onTerminalFailure?: (task: EmailSendTask, error: unknown) => void;
+}
+
+function errorProperty(error: unknown, property: string): unknown {
+  if (typeof error !== "object" || error === null) return undefined;
+  return Reflect.get(error, property);
+}
+
+export function isSesThrottlingError(error: unknown): boolean {
+  let current: unknown = error;
+
+  for (let depth = 0; current && depth < 4; depth += 1) {
+    const name = errorProperty(current, "name");
+    const code = errorProperty(current, "code");
+    const message = errorProperty(current, "message");
+    const metadata = errorProperty(current, "$metadata");
+    const statusCode = errorProperty(metadata, "httpStatusCode");
+    const searchable = [name, code, message]
+      .filter((value): value is string => typeof value === "string")
+      .join(" ");
+
+    if (
+      statusCode === 429 ||
+      /throttl|too\s*many\s*requests|TooManyRequestsException/i.test(searchable)
+    ) {
+      return true;
+    }
+
+    current = errorProperty(current, "cause");
+  }
+
+  return false;
+}
+
+export async function sendThrottledEmails(
+  tasks: readonly EmailSendTask[],
+  {
+    pacingMs = EMAIL_SEND_PACING_MS,
+    maxRetries = EMAIL_SEND_MAX_RETRIES,
+    retryBackoffMs = EMAIL_SEND_RETRY_BACKOFF_MS,
+    sleep: wait = sleep,
+    onTerminalFailure,
+  }: ThrottledEmailOptions = {}
+): Promise<ThrottledEmailResult> {
+  let sent = 0;
+  let failed = 0;
+
+  for (let index = 0; index < tasks.length; index += 1) {
+    const task = tasks[index]!;
+    let retryCount = 0;
+
+    while (true) {
+      try {
+        await task.send();
+        sent += 1;
+        break;
+      } catch (error) {
+        if (isSesThrottlingError(error) && retryCount < maxRetries) {
+          await wait(retryBackoffMs * 2 ** retryCount);
+          retryCount += 1;
+          continue;
+        }
+
+        failed += 1;
+        logger.error(
+          { recipient: task.recipient, err: error },
+          "Email send failed after retries"
+        );
+        onTerminalFailure?.(task, error);
+        break;
+      }
+    }
+
+    if (pacingMs > 0 && index < tasks.length - 1) {
+      await wait(pacingMs);
+    }
+  }
+
+  return { sent, failed };
+}

--- a/apps/frontend/src/features/admin/orgs/components/edit-org-dialog.tsx
+++ b/apps/frontend/src/features/admin/orgs/components/edit-org-dialog.tsx
@@ -249,16 +249,17 @@ export function EditOrgDialog({ org, onOpenChange }: EditOrgDialogProps) {
       if (FEATURE_MANAGED_SETTINGS.has(k)) parsed[k] = v;
     }
     for (const [k, v] of Object.entries(settings)) {
-      if (v === "") continue;
-      const num = Number(v);
-      if (!isNaN(num) && v.trim() !== "") {
+      const value = k === "free_tier_vault_name" ? v.trim() : v;
+      if (value === "") continue;
+      const num = Number(value);
+      if (!isNaN(num) && value.trim() !== "") {
         parsed[k] = num;
-      } else if (v === "true") {
+      } else if (value === "true") {
         parsed[k] = true;
-      } else if (v === "false") {
+      } else if (value === "false") {
         parsed[k] = false;
       } else {
-        parsed[k] = v;
+        parsed[k] = value;
       }
     }
     updateOrg(

--- a/apps/frontend/src/features/admin/orgs/components/edit-org-dialog.tsx
+++ b/apps/frontend/src/features/admin/orgs/components/edit-org-dialog.tsx
@@ -520,7 +520,7 @@ export function EditOrgDialog({ org, onOpenChange }: EditOrgDialogProps) {
                       Free-Tier Upgrade URL
                     </label>
                     <p className="text-muted-foreground text-xs">
-                      External link for the &ldquo;Unlock My Full Vault
+                      External link for the &ldquo;Unlock My Full
                       Profile&rdquo; button in free-tier invite emails
                     </p>
                     <Input
@@ -542,9 +542,9 @@ export function EditOrgDialog({ org, onOpenChange }: EditOrgDialogProps) {
                       Free-Tier Brand Name
                     </label>
                     <p className="text-muted-foreground text-xs">
-                      Name used in free-tier emails (e.g. &ldquo;The
-                      Vault&rdquo;). Defaults to &ldquo;the platform&rdquo; if
-                      empty.
+                      Org brand name used in free-tier invite emails and their
+                      subject line. Defaults to the org name in subjects and
+                      &ldquo;the platform&rdquo; in body copy if empty.
                     </p>
                     <Input
                       value={settings.free_tier_vault_name ?? ""}
@@ -554,7 +554,7 @@ export function EditOrgDialog({ org, onOpenChange }: EditOrgDialogProps) {
                           free_tier_vault_name: e.target.value,
                         }))
                       }
-                      placeholder="The Vault"
+                      placeholder="Your brand name"
                       className="text-sm"
                     />
                   </div>

--- a/packages/emails/src/templates/FreeTierInviteEmail.tsx
+++ b/packages/emails/src/templates/FreeTierInviteEmail.tsx
@@ -18,7 +18,7 @@ export interface FreeTierInviteEmailProps {
   upgradeUrl: string;
   contactEmail?: string | null;
   tierExpiryMonths?: number;
-  vaultName?: string | null;
+  brandName?: string | null;
   brandColor?: string | null;
   welcomeVideoUrl?: string | null;
   logoUrl?: string | null;
@@ -35,17 +35,17 @@ export function FreeTierInviteEmail({
   upgradeUrl,
   contactEmail,
   tierExpiryMonths = 3,
-  vaultName: rawVaultName,
+  brandName: rawBrandName,
   brandColor,
   welcomeVideoUrl,
   logoUrl,
 }: FreeTierInviteEmailProps) {
   const accent = brandColor || colors.primary;
-  const vault = rawVaultName?.trim() || "the platform";
-  const hasCustomVaultName = Boolean(rawVaultName?.trim());
+  const brand = rawBrandName?.trim() || "the platform";
+  const hasCustomBrandName = Boolean(rawBrandName?.trim());
   const previewText = eventName
-    ? `You're officially in ${vault} — ${eventName}`
-    : `You're officially in ${vault} — complete your free profile`;
+    ? `You're officially in ${brand} — ${eventName}`
+    : `You're officially in ${brand} — complete your free profile`;
 
   const checkItems = [
     "Dance videos",
@@ -140,7 +140,7 @@ export function FreeTierInviteEmail({
             lineHeight: "1.3",
           }}
         >
-          You&apos;re officially in {vault}.
+          You&apos;re officially in {brand}.
         </Text>
         <Text style={paragraphStyle}>
           Right now, coaches can only see your basic registration information.
@@ -156,10 +156,10 @@ export function FreeTierInviteEmail({
           Want to stand out?
         </Text>
         <Text style={{ ...paragraphStyle, margin: "0 0 24px" }}>
-          {hasCustomVaultName ? (
-            <>Unlock your full {vault} profile</>
+          {hasCustomBrandName ? (
+            <>Unlock your full {brand} profile</>
           ) : (
-            <>Unlock your full profile on {vault}</>
+            <>Unlock your full profile on {brand}</>
           )}{" "}
           to give college coaches a complete picture of who you are as a dancer.
         </Text>
@@ -257,10 +257,10 @@ export function FreeTierInviteEmail({
             when the event does.
           </Text>
           <Text style={{ ...paragraphStyle, margin: "0 0 16px" }}>
-            {hasCustomVaultName ? (
-              <>Your {vault} profile</>
+            {hasCustomBrandName ? (
+              <>Your {brand} profile</>
             ) : (
-              <>Your profile on {vault}</>
+              <>Your profile on {brand}</>
             )}{" "}
             remains active for{" "}
             <strong>{tierExpiryMonths} months</strong>, giving college coaches
@@ -444,7 +444,7 @@ export function FreeTierInviteEmail({
         <Text style={paragraphStyle}>
           We&apos;re excited to help you maximize your recruiting opportunities
           and get the most out of your{" "}
-          {hasCustomVaultName ? `${vault} experience` : `experience on ${vault}`}.
+          {hasCustomBrandName ? `${brand} experience` : `experience on ${brand}`}.
         </Text>
         <Text
           style={{

--- a/packages/emails/src/templates/FreeTierInviteEmail.tsx
+++ b/packages/emails/src/templates/FreeTierInviteEmail.tsx
@@ -41,7 +41,8 @@ export function FreeTierInviteEmail({
   logoUrl,
 }: FreeTierInviteEmailProps) {
   const accent = brandColor || colors.primary;
-  const vault = rawVaultName || "the platform";
+  const vault = rawVaultName?.trim() || "the platform";
+  const hasCustomVaultName = Boolean(rawVaultName?.trim());
   const previewText = eventName
     ? `You're officially in ${vault} — ${eventName}`
     : `You're officially in ${vault} — complete your free profile`;
@@ -155,8 +156,12 @@ export function FreeTierInviteEmail({
           Want to stand out?
         </Text>
         <Text style={{ ...paragraphStyle, margin: "0 0 24px" }}>
-          Unlock your full {vault} profile to give college coaches a complete
-          picture of who you are as a dancer.
+          {hasCustomVaultName ? (
+            <>Unlock your full {vault} profile</>
+          ) : (
+            <>Unlock your full profile on {vault}</>
+          )}{" "}
+          to give college coaches a complete picture of who you are as a dancer.
         </Text>
 
         {/* ── Complete Your Free Profile ── */}
@@ -252,7 +257,12 @@ export function FreeTierInviteEmail({
             when the event does.
           </Text>
           <Text style={{ ...paragraphStyle, margin: "0 0 16px" }}>
-            Your {vault} profile remains active for{" "}
+            {hasCustomVaultName ? (
+              <>Your {vault} profile</>
+            ) : (
+              <>Your profile on {vault}</>
+            )}{" "}
+            remains active for{" "}
             <strong>{tierExpiryMonths} months</strong>, giving college coaches
             additional time to:
           </Text>
@@ -433,7 +443,8 @@ export function FreeTierInviteEmail({
         {/* ── Closing ── */}
         <Text style={paragraphStyle}>
           We&apos;re excited to help you maximize your recruiting opportunities
-          and get the most out of your {vault} experience.
+          and get the most out of your{" "}
+          {hasCustomVaultName ? `${vault} experience` : `experience on ${vault}`}.
         </Text>
         <Text
           style={{

--- a/packages/emails/src/templates/SubscriptionEndedEmail.tsx
+++ b/packages/emails/src/templates/SubscriptionEndedEmail.tsx
@@ -20,9 +20,9 @@ export function SubscriptionEndedEmail({
     <Layout preview="Your Studio 2 Stadium Premium subscription has expired">
       <Text style={paragraphStyle}>Hi {firstName},</Text>
       <Text style={paragraphStyle}>
-        Your 3-month Vault subscription has officially expired. We hope you
-        enjoyed your time as a premium member and found value in the enhanced
-        features.
+        Your Studio 2 Stadium Premium subscription has officially expired. We
+        hope you enjoyed your time as a premium member and found value in the
+        enhanced features.
       </Text>
       <Text style={paragraphStyle}>
         As a reminder, premium members get access to:


### PR DESCRIPTION
## Summary

Throttle roster invitation emails beneath the SES rate limit and harden free-tier vault copy.

## Changes

- Added a shared sequential email sender with 100ms pacing, two throttling retries with exponential backoff, terminal failure logging, and sent/failed counts.
- Applied detached batching to dancer and coach CSV uploads.
- Refactored mass resend to use the shared sender.
- Trimmed vault names on save and added whitespace-safe template fallbacks.
- Added four focused sender unit tests.
- Committed as `48f226ba fix(org): throttle roster invite emails under SES rate limit`.

## Verification

- `pnpm --filter backend typecheck` — passed.
- Changed backend files lint — passed.
- Helper tests — 4/4 passed.
- Coach upload tests — 3/3 passed.
- Resend tests — 2/2 passed.
- Dancer upload tests — 4/5 passed; existing unrelated assertion expects a null expiration date, while current service behavior sets `2026-09-14`.
- `pnpm --filter @stos/emails build` — passed.
- `pnpm --filter frontend build` — passed.
- Changed frontend file lint — passed when excluding its pre-existing `react-hooks/set-state-in-effect` violation.
- Repository-wide backend lint remains blocked by 134 pre-existing formatting errors.
- Repository-wide frontend lint remains blocked by 156 pre-existing errors and 13 warnings.
- The requested `**/*.test.ts` org pattern executed no tests because existing tests use `.spec.ts`.

## Final email sentence text

With vault name:

> Unlock your full Vault profile to give college coaches a complete picture of who you are as a dancer.

Without vault name:

> Unlock your full profile on the platform to give college coaches a complete picture of who you are as a dancer.

## Notes/risks

- Detached batches can be lost if the process restarts; admins can use mass resend as agreed.
- No queue, migrations, schema changes, dependencies, pushes, or PRs were added.
- The existing `.env.test` modification remains unstaged and was not committed.

---
_Part of the July 2026 bug-fix wave (6 draft PRs). T1/T4/T6 are independent; the email/coach stack merges in order T3 → T5 → T2._

🤖 Generated with [Claude Code](https://claude.com/claude-code)