### PR TITLE
feat(org): resend coach invitations from admin roster

### DIFF
--- a/apps/backend/app/modules/orgs/events/rosters/resend-invites/service.spec.ts
+++ b/apps/backend/app/modules/orgs/events/rosters/resend-invites/service.spec.ts
@@ -9,6 +9,7 @@ import {
   orgEvents,
 } from "#database/schema/org-events";
 import { dancerInvites, organizations } from "#database/schema/organizations";
+import { schoolInvites } from "#database/schema/schools";
 import mail from "@adonisjs/mail/services/main";
 import { ResendInvitesService } from "./service.ts";
 
@@ -52,6 +53,7 @@ test.group("ResendInvitesService", (group) => {
     await db.delete(eventAuditLog).execute();
     await db.delete(eventDancerProfiles).execute();
     await db.delete(eventRosters).execute();
+    await db.delete(schoolInvites).execute();
     await db.delete(orgEvents).execute();
     await db.delete(dancerInvites).execute();
     await db.delete(users).execute();
@@ -123,46 +125,125 @@ test.group("ResendInvitesService", (group) => {
     assert.lengthOf(newInvites, 2);
   });
 
-  test("skips coaches, active dancers, and unknown ids", async ({ assert }) => {
+  test("reissues a fresh unconsumed invite for a pending coach", async ({
+    assert,
+  }) => {
+    const actor = await makeActorUser();
+    const { org, event } = await makeOrgAndEvent();
+    const [coach] = await db
+      .insert(eventRosters)
+      .values({
+        eventId: event.id,
+        type: "coach",
+        email: "coach@example.com",
+        firstName: "Coach",
+        lastName: "Pending",
+        organization: "Example University",
+      })
+      .returning();
+    const oldExpiresAt = new Date(Date.now() - 86400000);
+    await db.insert(schoolInvites).values({
+      eventId: event.id,
+      email: coach!.email,
+      organization: coach!.organization,
+      token: "old_coach_token",
+      expiresAt: oldExpiresAt,
+      consumedAt: new Date(),
+    });
+
+    const service = new ResendInvitesService();
+    const result = await service.execute(
+      org.slug,
+      event.id,
+      { ids: [coach!.id] },
+      { eventId: event.id, actorId: actor.id },
+      { pacingMs: 0 }
+    );
+
+    assert.equal(result.sent, 1);
+    assert.equal(result.skipped, 0);
+    assert.lengthOf(result.failed, 0);
+
+    const invites = await db
+      .select()
+      .from(schoolInvites)
+      .where(eq(schoolInvites.eventId, event.id));
+    assert.lengthOf(invites, 1);
+    assert.notEqual(invites[0]!.token, "old_coach_token");
+    assert.isNull(invites[0]!.consumedAt);
+    assert.isAbove(invites[0]!.expiresAt.getTime(), Date.now() + 13 * 86400000);
+  });
+
+  test("skips a registered coach", async ({ assert }) => {
     const actor = await makeActorUser();
     const { org, event } = await makeOrgAndEvent();
     const [user] = await db
       .insert(users)
       .values({
         username: `u_${Date.now()}_${Math.random()}`,
-        email: "active@example.com",
-        displayEmail: "active@example.com",
-        firstName: "Act",
-        lastName: "Ive",
+        email: "registered-coach@example.com",
+        displayEmail: "registered-coach@example.com",
+        firstName: "Registered",
+        lastName: "Coach",
         password: "h",
         role: "user",
-        type: "dancer",
+        type: "school",
       })
       .returning();
+    const [coach] = await db
+      .insert(eventRosters)
+      .values({
+        eventId: event.id,
+        type: "coach",
+        email: user!.email,
+        firstName: user!.firstName,
+        lastName: user!.lastName,
+        userId: user!.id,
+      })
+      .returning();
+
+    const service = new ResendInvitesService();
+    const result = await service.execute(
+      org.slug,
+      event.id,
+      { ids: [coach!.id] },
+      { eventId: event.id, actorId: actor.id },
+      { pacingMs: 0 }
+    );
+
+    assert.equal(result.sent, 0);
+    assert.equal(result.skipped, 1);
+    assert.lengthOf(result.failed, 0);
+
+    const invites = await db
+      .select()
+      .from(schoolInvites)
+      .where(eq(schoolInvites.eventId, event.id));
+    assert.lengthOf(invites, 0);
+  });
+
+  test("resends dancer and coach invites in a mixed batch", async ({
+    assert,
+  }) => {
+    const actor = await makeActorUser();
+    const { org, event } = await makeOrgAndEvent();
     const rows = await db
       .insert(eventRosters)
       .values([
         {
           eventId: event.id,
           type: "dancer",
-          email: "active@example.com",
-          firstName: "Act",
-          lastName: "Ive",
-          userId: user!.id,
+          email: "mixed-dancer@example.com",
+          firstName: "Mixed",
+          lastName: "Dancer",
         },
         {
           eventId: event.id,
           type: "coach",
-          email: "coach@example.com",
-          firstName: "C",
-          lastName: "C",
-        },
-        {
-          eventId: event.id,
-          type: "dancer",
-          email: "pending@example.com",
-          firstName: "P",
-          lastName: "P",
+          email: "mixed-coach@example.com",
+          firstName: "Mixed",
+          lastName: "Coach",
+          organization: "Mixed University",
         },
       ])
       .returning();
@@ -171,19 +252,25 @@ test.group("ResendInvitesService", (group) => {
     const result = await service.execute(
       org.slug,
       event.id,
-      {
-        ids: [
-          rows[0]!.id, // active dancer
-          rows[1]!.id, // coach
-          rows[2]!.id, // pending dancer
-          "00000000-0000-0000-0000-000000000000", // unknown
-        ],
-      },
+      { ids: rows.map((row) => row.id) },
       { eventId: event.id, actorId: actor.id },
       { pacingMs: 0 }
     );
 
-    assert.equal(result.sent, 1);
-    assert.equal(result.skipped, 3);
+    assert.equal(result.sent, 2);
+    assert.equal(result.skipped, 0);
+    assert.lengthOf(result.failed, 0);
+
+    const dancerRows = await db
+      .select()
+      .from(dancerInvites)
+      .where(eq(dancerInvites.email, "mixed-dancer@example.com"));
+    const coachRows = await db
+      .select()
+      .from(schoolInvites)
+      .where(eq(schoolInvites.email, "mixed-coach@example.com"));
+    assert.lengthOf(dancerRows, 1);
+    assert.lengthOf(coachRows, 1);
+    assert.isNull(coachRows[0]!.consumedAt);
   });
 });

--- a/apps/backend/app/modules/orgs/events/rosters/resend-invites/service.ts
+++ b/apps/backend/app/modules/orgs/events/rosters/resend-invites/service.ts
@@ -4,7 +4,9 @@ import { randomBytes } from "node:crypto";
 import { setTimeout as sleep } from "node:timers/promises";
 import { eventRosters, orgEvents } from "#database/schema/org-events";
 import { dancerInvites, organizations } from "#database/schema/organizations";
+import { schoolInvites } from "#database/schema/schools";
 import { sendOrgInviteEmailOrThrow } from "#shared/org/invite-email";
+import { sendSchoolAccountInviteEmailOrThrow } from "#shared/org/school-account-invite-email";
 import { and, eq, inArray, isNull } from "drizzle-orm";
 import type { Validator } from "./validator.ts";
 import type { AuditContext } from "#database/audit";
@@ -33,19 +35,20 @@ export class ResendInvitesService {
     auditCtx: AuditContext,
     { pacingMs = RESEND_PACING_MS }: { pacingMs?: number } = {}
   ): Promise<ResendInvitesResult> {
-    // Load matching rows: pending dancers only, scoped to event
+    // Load matching pending roster rows, scoped to event
     const rows = await this.db.use((db) =>
       db
         .select({
           id: eventRosters.id,
           email: eventRosters.email,
           firstName: eventRosters.firstName,
+          organization: eventRosters.organization,
+          type: eventRosters.type,
         })
         .from(eventRosters)
         .where(
           and(
             eq(eventRosters.eventId, eventId),
-            eq(eventRosters.type, "dancer"),
             isNull(eventRosters.userId),
             inArray(eventRosters.id, input.ids)
           )
@@ -83,33 +86,64 @@ export class ResendInvitesService {
     for (let i = 0; i < rows.length; i++) {
       const row = rows[i]!;
       try {
-        const token = randomToken();
         const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 14);
-        await this.db.tx(async (tx) => {
-          await tx
-            .delete(dancerInvites)
-            .where(
-              and(
-                eq(dancerInvites.orgId, org.id),
-                eq(dancerInvites.email, row.email)
-              )
-            );
-          await tx.insert(dancerInvites).values({
-            orgId: org.id,
-            email: row.email,
-            token,
-            expiresAt,
+        if (row.type === "dancer") {
+          const token = randomToken();
+          await this.db.tx(async (tx) => {
+            await tx
+              .delete(dancerInvites)
+              .where(
+                and(
+                  eq(dancerInvites.orgId, org.id),
+                  eq(dancerInvites.email, row.email)
+                )
+              );
+            await tx.insert(dancerInvites).values({
+              orgId: org.id,
+              email: row.email,
+              token,
+              expiresAt,
+            });
           });
-        });
 
-        await sendOrgInviteEmailOrThrow({
-          org,
-          event,
-          email: row.email,
-          firstName: row.firstName,
-          type: "dancer",
-          token,
-        });
+          await sendOrgInviteEmailOrThrow({
+            org,
+            event,
+            email: row.email,
+            firstName: row.firstName,
+            type: "dancer",
+            token,
+          });
+        } else {
+          const token = randomBytes(32).toString("hex");
+          await this.db.use((db) =>
+            db
+              .insert(schoolInvites)
+              .values({
+                eventId,
+                email: row.email,
+                organization: row.organization,
+                token,
+                expiresAt,
+              })
+              .onConflictDoUpdate({
+                target: [schoolInvites.eventId, schoolInvites.email],
+                set: {
+                  token,
+                  expiresAt,
+                  consumedAt: null,
+                },
+              })
+          );
+
+          await sendSchoolAccountInviteEmailOrThrow({
+            org,
+            event,
+            email: row.email,
+            firstName: row.firstName,
+            token,
+          });
+        }
 
         sent += 1;
       } catch (err) {
@@ -131,6 +165,7 @@ export class ResendInvitesService {
         resource: "invite",
         metadata: {
           ids: input.ids,
+          rosterTypes: rows.map((row) => ({ id: row.id, type: row.type })),
           sent,
           skipped,
           failed,

--- a/apps/frontend/src/features/org/components/roster-detail-sheet.tsx
+++ b/apps/frontend/src/features/org/components/roster-detail-sheet.tsx
@@ -164,7 +164,7 @@ export function RosterDetailSheet({
   };
 
   const handleResendInvite = async () => {
-    if (!entry || entry.type !== "dancer") return;
+    if (!entry) return;
     try {
       const result = await resendMutation.mutateAsync({
         params: { path: { slug: orgSlug, id: eventId } },
@@ -513,7 +513,7 @@ export function RosterDetailSheet({
           </SheetContent>
           <SheetFooter>
             <div className="flex w-full items-center justify-end gap-2">
-              {!isActive && isDancer && (
+              {!isActive && (
                 <Button
                   type="button"
                   variant="ghost"

--- a/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/admin/coaches.tsx
+++ b/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/admin/coaches.tsx
@@ -7,6 +7,7 @@ import {
   downloadRosterCsv,
   rosterQueries,
   useDeleteRosters,
+  useResendInvites,
   useUpdateRoster,
 } from "@/features/org/api/roster-queries";
 import { DataGrid, StatusBadge } from "@/features/org/components/data-grid";
@@ -134,6 +135,7 @@ function CoachesPage() {
 
   const updateMutation = useUpdateRoster();
   const deleteMutation = useDeleteRosters();
+  const resendMutation = useResendInvites();
 
   const handleRowClick = (row: RosterEntry) => {
     setSelectedEntry(row);
@@ -203,6 +205,32 @@ function CoachesPage() {
 
   const bulkActions = rosterBulkActions({
     onExport: handleExport,
+    onResendInvite: async (ids: string[]) => {
+      if (!active) return;
+      toastManager.add({
+        title: `Resending invites to ${ids.length} coach${ids.length === 1 ? "" : "es"}…`,
+        type: "info",
+      });
+      try {
+        const result = await resendMutation.mutateAsync({
+          params: { path: { slug: orgSlug, id: active.id } },
+          body: { ids },
+        });
+        if (result.failed.length > 0) {
+          toastManager.add({
+            title: `Resent ${result.sent}, ${result.failed.length} failed`,
+            type: "warning",
+          });
+        } else {
+          toastManager.add({
+            title: `Resent ${result.sent} invite${result.sent === 1 ? "" : "s"}${result.skipped ? ` (${result.skipped} skipped)` : ""}`,
+            type: "success",
+          });
+        }
+      } catch {
+        toastManager.add({ title: "Failed to resend invites", type: "error" });
+      }
+    },
     onDelete: async (ids: string[]) => {
       if (!active) return;
       try {


### PR DESCRIPTION
## Summary

Adds coach invitation resend support to the existing admin roster workflow while preserving dancer behavior and mixed-batch handling.

## Changes

- Reissues fresh, unconsumed 14-day `schoolInvites` tokens for pending coaches.
- Sends coach invitations through the school account invite email flow.
- Preserves sequential pacing and `{ sent, failed, skipped }` responses.
- Adds roster ID/type details to resend audit metadata.
- Adds coach bulk and per-row resend actions matching dancer UX.
- Adds coverage for coach reissue, registered-coach skipping, mixed batches, and dancer-only behavior.
- Committed as `cfd8c0b feat(org): resend coach invitations from admin roster`.

## Verification

- `pnpm --filter backend typecheck` — passed.
- Changed backend files ESLint — passed.
- Targeted resend service tests — 4 passed.
- `node ace test --files "app/modules/orgs/**/*.test.ts"` — exited successfully but reported no tests; org tests use `.spec.ts`.
- `pnpm --filter frontend build` — passed.
- `pnpm --filter frontend lint` — passed.
- `pnpm --filter backend lint` — blocked by 140 pre-existing Prettier violations in unrelated files.

## Notes/risks

- Tests fake Adonis mail; no real email was sent.
- The pre-existing uncommitted `apps/backend/.env.test` modification was not included in the commit.
- No schema, migration, dependency, or parallel-ticket-owned files were changed.

---
**Stacked on the T3 email-throttling branch.** The overlap in `resend-invites/service.ts` was resolved by hand: coach/dancer branching now runs on the shared throttled sender (verified: resend spec 4/4 + typecheck post-merge).

---
_Part of the July 2026 bug-fix wave (6 draft PRs). T1/T4/T6 are independent; the email/coach stack merges in order T3 → T5 → T2._

🤖 Generated with [Claude Code](https://claude.com/claude-code)