### PR TITLE
reland(scouting): coach resend invites + coach access decoupling

### DIFF
--- a/apps/backend/app/middleware/routes/org-event-dancer.ts
+++ b/apps/backend/app/middleware/routes/org-event-dancer.ts
@@ -1,0 +1,43 @@
+import { db } from "#database/connection";
+import { eventRosters } from "#database/schema/org-events";
+import type { HttpContext } from "@adonisjs/core/http";
+import type { NextFn } from "@adonisjs/core/types/http";
+import { and, eq } from "drizzle-orm";
+
+/** Ensures scouting mutations only target a dancer on the active event. */
+export default class OrgEventDancerMiddleware {
+  async handle(ctx: HttpContext, next: NextFn) {
+    if (!ctx.orgEvent) {
+      return ctx.response.notFound({ message: "No active event." });
+    }
+
+    const dancerRosterId =
+      (ctx.params.dancerRosterId as string | undefined) ??
+      (ctx.request.input("dancerRosterId") as string | undefined);
+    if (!dancerRosterId) {
+      return ctx.response.unprocessableEntity({
+        message: "Dancer roster is required.",
+      });
+    }
+
+    const [dancer] = await db
+      .select({ id: eventRosters.id })
+      .from(eventRosters)
+      .where(
+        and(
+          eq(eventRosters.id, dancerRosterId),
+          eq(eventRosters.eventId, ctx.orgEvent.id),
+          eq(eventRosters.type, "dancer")
+        )
+      )
+      .limit(1);
+
+    if (!dancer) {
+      return ctx.response.forbidden({
+        message: "Dancer is not on the active event.",
+      });
+    }
+
+    return next();
+  }
+}

--- a/apps/backend/app/middleware/routes/org-event.ts
+++ b/apps/backend/app/middleware/routes/org-event.ts
@@ -3,7 +3,7 @@ import { orgEvents, eventRosters } from "#database/schema/org-events";
 import { orgMemberships } from "#database/schema/organizations";
 import type { HttpContext } from "@adonisjs/core/http";
 import type { NextFn } from "@adonisjs/core/types/http";
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, sql } from "drizzle-orm";
 
 declare module "@adonisjs/core/http" {
   interface HttpContext {
@@ -13,7 +13,7 @@ declare module "@adonisjs/core/http" {
 }
 
 export default class OrgEventMiddleware {
-  async handle(ctx: HttpContext, next: NextFn) {
+  async handle(ctx: HttpContext, next: NextFn, mode?: "coachDancerRead") {
     if (!ctx.org) {
       return ctx.response.notFound({ message: "Org not resolved." });
     }
@@ -24,11 +24,11 @@ export default class OrgEventMiddleware {
       .where(and(eq(orgEvents.orgId, ctx.org.id), eq(orgEvents.isActive, true)))
       .limit(1);
 
-    if (!ev) {
+    if (!ev && mode !== "coachDancerRead") {
       return ctx.response.notFound({ message: "No active event." });
     }
 
-    ctx.orgEvent = ev;
+    if (ev) ctx.orgEvent = ev;
 
     // Attach roster row if user is authenticated (soft — not a hard failure).
     try {
@@ -42,26 +42,28 @@ export default class OrgEventMiddleware {
       const actAsType =
         actAs === "coach" || actAs === "dancer" ? actAs : undefined;
 
-      const [roster] = await db
-        .select()
-        .from(eventRosters)
-        .where(
-          and(
-            eq(eventRosters.eventId, ev.id),
-            eq(eventRosters.userId, user.id),
-            ...(actAsType ? [eq(eventRosters.type, actAsType)] : [])
-          )
-        )
-        // Deterministic tiebreaker if an admin has multiple staff rosters and
-        // no acting type was supplied.
-        .orderBy(desc(eventRosters.createdAt))
-        .limit(1);
+      const [roster] = ev
+        ? await db
+            .select()
+            .from(eventRosters)
+            .where(
+              and(
+                eq(eventRosters.eventId, ev.id),
+                eq(eventRosters.userId, user.id),
+                ...(actAsType ? [eq(eventRosters.type, actAsType)] : [])
+              )
+            )
+            // Deterministic tiebreaker if an admin has multiple staff rosters and
+            // no acting type was supplied.
+            .orderBy(desc(eventRosters.createdAt))
+            .limit(1)
+        : [];
       if (roster) ctx.orgRoster = roster;
 
       // Non-admin members must have a roster entry for the active event
       if (!roster && user.role !== "admin") {
         const [membership] = await db
-          .select({ role: orgMemberships.role })
+          .select({ role: orgMemberships.role, type: orgMemberships.type })
           .from(orgMemberships)
           .where(
             and(
@@ -70,7 +72,23 @@ export default class OrgEventMiddleware {
             )
           )
           .limit(1);
-        if (!membership || membership.role !== "admin") {
+        const browseRosters =
+          mode === "coachDancerRead" && membership?.type === "coach"
+            ? await db
+                .select({ exists: sql<boolean>`true` })
+                .from(eventRosters)
+                .innerJoin(orgEvents, eq(orgEvents.id, eventRosters.eventId))
+                .where(
+                  and(
+                    eq(orgEvents.orgId, ctx.org.id),
+                    eq(eventRosters.userId, user.id),
+                    eq(eventRosters.type, "coach")
+                  )
+                )
+                .limit(1)
+            : [];
+        const canBrowseDancers = browseRosters.length > 0;
+        if ((!membership || membership.role !== "admin") && !canBrowseDancers) {
           return ctx.response.forbidden({
             message: "Not on event roster.",
           });

--- a/apps/backend/app/modules/orgs/events/rosters/resend-invites/service.spec.ts
+++ b/apps/backend/app/modules/orgs/events/rosters/resend-invites/service.spec.ts
@@ -9,6 +9,7 @@ import {
   orgEvents,
 } from "#database/schema/org-events";
 import { dancerInvites, organizations } from "#database/schema/organizations";
+import { schoolInvites } from "#database/schema/schools";
 import mail from "@adonisjs/mail/services/main";
 import { ResendInvitesService } from "./service.ts";
 
@@ -52,6 +53,7 @@ test.group("ResendInvitesService", (group) => {
     await db.delete(eventAuditLog).execute();
     await db.delete(eventDancerProfiles).execute();
     await db.delete(eventRosters).execute();
+    await db.delete(schoolInvites).execute();
     await db.delete(orgEvents).execute();
     await db.delete(dancerInvites).execute();
     await db.delete(users).execute();
@@ -123,46 +125,125 @@ test.group("ResendInvitesService", (group) => {
     assert.lengthOf(newInvites, 2);
   });
 
-  test("skips coaches, active dancers, and unknown ids", async ({ assert }) => {
+  test("reissues a fresh unconsumed invite for a pending coach", async ({
+    assert,
+  }) => {
+    const actor = await makeActorUser();
+    const { org, event } = await makeOrgAndEvent();
+    const [coach] = await db
+      .insert(eventRosters)
+      .values({
+        eventId: event.id,
+        type: "coach",
+        email: "coach@example.com",
+        firstName: "Coach",
+        lastName: "Pending",
+        organization: "Example University",
+      })
+      .returning();
+    const oldExpiresAt = new Date(Date.now() - 86400000);
+    await db.insert(schoolInvites).values({
+      eventId: event.id,
+      email: coach!.email,
+      organization: coach!.organization,
+      token: "old_coach_token",
+      expiresAt: oldExpiresAt,
+      consumedAt: new Date(),
+    });
+
+    const service = new ResendInvitesService();
+    const result = await service.execute(
+      org.slug,
+      event.id,
+      { ids: [coach!.id] },
+      { eventId: event.id, actorId: actor.id },
+      { pacingMs: 0 }
+    );
+
+    assert.equal(result.sent, 1);
+    assert.equal(result.skipped, 0);
+    assert.lengthOf(result.failed, 0);
+
+    const invites = await db
+      .select()
+      .from(schoolInvites)
+      .where(eq(schoolInvites.eventId, event.id));
+    assert.lengthOf(invites, 1);
+    assert.notEqual(invites[0]!.token, "old_coach_token");
+    assert.isNull(invites[0]!.consumedAt);
+    assert.isAbove(invites[0]!.expiresAt.getTime(), Date.now() + 13 * 86400000);
+  });
+
+  test("skips a registered coach", async ({ assert }) => {
     const actor = await makeActorUser();
     const { org, event } = await makeOrgAndEvent();
     const [user] = await db
       .insert(users)
       .values({
         username: `u_${Date.now()}_${Math.random()}`,
-        email: "active@example.com",
-        displayEmail: "active@example.com",
-        firstName: "Act",
-        lastName: "Ive",
+        email: "registered-coach@example.com",
+        displayEmail: "registered-coach@example.com",
+        firstName: "Registered",
+        lastName: "Coach",
         password: "h",
         role: "user",
-        type: "dancer",
+        type: "school",
       })
       .returning();
+    const [coach] = await db
+      .insert(eventRosters)
+      .values({
+        eventId: event.id,
+        type: "coach",
+        email: user!.email,
+        firstName: user!.firstName,
+        lastName: user!.lastName,
+        userId: user!.id,
+      })
+      .returning();
+
+    const service = new ResendInvitesService();
+    const result = await service.execute(
+      org.slug,
+      event.id,
+      { ids: [coach!.id] },
+      { eventId: event.id, actorId: actor.id },
+      { pacingMs: 0 }
+    );
+
+    assert.equal(result.sent, 0);
+    assert.equal(result.skipped, 1);
+    assert.lengthOf(result.failed, 0);
+
+    const invites = await db
+      .select()
+      .from(schoolInvites)
+      .where(eq(schoolInvites.eventId, event.id));
+    assert.lengthOf(invites, 0);
+  });
+
+  test("resends dancer and coach invites in a mixed batch", async ({
+    assert,
+  }) => {
+    const actor = await makeActorUser();
+    const { org, event } = await makeOrgAndEvent();
     const rows = await db
       .insert(eventRosters)
       .values([
         {
           eventId: event.id,
           type: "dancer",
-          email: "active@example.com",
-          firstName: "Act",
-          lastName: "Ive",
-          userId: user!.id,
+          email: "mixed-dancer@example.com",
+          firstName: "Mixed",
+          lastName: "Dancer",
         },
         {
           eventId: event.id,
           type: "coach",
-          email: "coach@example.com",
-          firstName: "C",
-          lastName: "C",
-        },
-        {
-          eventId: event.id,
-          type: "dancer",
-          email: "pending@example.com",
-          firstName: "P",
-          lastName: "P",
+          email: "mixed-coach@example.com",
+          firstName: "Mixed",
+          lastName: "Coach",
+          organization: "Mixed University",
         },
       ])
       .returning();
@@ -171,19 +252,25 @@ test.group("ResendInvitesService", (group) => {
     const result = await service.execute(
       org.slug,
       event.id,
-      {
-        ids: [
-          rows[0]!.id, // active dancer
-          rows[1]!.id, // coach
-          rows[2]!.id, // pending dancer
-          "00000000-0000-0000-0000-000000000000", // unknown
-        ],
-      },
+      { ids: rows.map((row) => row.id) },
       { eventId: event.id, actorId: actor.id },
       { pacingMs: 0 }
     );
 
-    assert.equal(result.sent, 1);
-    assert.equal(result.skipped, 3);
+    assert.equal(result.sent, 2);
+    assert.equal(result.skipped, 0);
+    assert.lengthOf(result.failed, 0);
+
+    const dancerRows = await db
+      .select()
+      .from(dancerInvites)
+      .where(eq(dancerInvites.email, "mixed-dancer@example.com"));
+    const coachRows = await db
+      .select()
+      .from(schoolInvites)
+      .where(eq(schoolInvites.email, "mixed-coach@example.com"));
+    assert.lengthOf(dancerRows, 1);
+    assert.lengthOf(coachRows, 1);
+    assert.isNull(coachRows[0]!.consumedAt);
   });
 });

--- a/apps/backend/app/modules/orgs/events/rosters/resend-invites/service.ts
+++ b/apps/backend/app/modules/orgs/events/rosters/resend-invites/service.ts
@@ -4,7 +4,9 @@ import { randomBytes } from "node:crypto";
 import { setTimeout as sleep } from "node:timers/promises";
 import { eventRosters, orgEvents } from "#database/schema/org-events";
 import { dancerInvites, organizations } from "#database/schema/organizations";
+import { schoolInvites } from "#database/schema/schools";
 import { sendOrgInviteEmailOrThrow } from "#shared/org/invite-email";
+import { sendSchoolAccountInviteEmailOrThrow } from "#shared/org/school-account-invite-email";
 import { and, eq, inArray, isNull } from "drizzle-orm";
 import type { Validator } from "./validator.ts";
 import type { AuditContext } from "#database/audit";
@@ -33,19 +35,20 @@ export class ResendInvitesService {
     auditCtx: AuditContext,
     { pacingMs = RESEND_PACING_MS }: { pacingMs?: number } = {}
   ): Promise<ResendInvitesResult> {
-    // Load matching rows: pending dancers only, scoped to event
+    // Load matching pending roster rows, scoped to event
     const rows = await this.db.use((db) =>
       db
         .select({
           id: eventRosters.id,
           email: eventRosters.email,
           firstName: eventRosters.firstName,
+          organization: eventRosters.organization,
+          type: eventRosters.type,
         })
         .from(eventRosters)
         .where(
           and(
             eq(eventRosters.eventId, eventId),
-            eq(eventRosters.type, "dancer"),
             isNull(eventRosters.userId),
             inArray(eventRosters.id, input.ids)
           )
@@ -83,33 +86,64 @@ export class ResendInvitesService {
     for (let i = 0; i < rows.length; i++) {
       const row = rows[i]!;
       try {
-        const token = randomToken();
         const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 14);
-        await this.db.tx(async (tx) => {
-          await tx
-            .delete(dancerInvites)
-            .where(
-              and(
-                eq(dancerInvites.orgId, org.id),
-                eq(dancerInvites.email, row.email)
-              )
-            );
-          await tx.insert(dancerInvites).values({
-            orgId: org.id,
-            email: row.email,
-            token,
-            expiresAt,
+        if (row.type === "dancer") {
+          const token = randomToken();
+          await this.db.tx(async (tx) => {
+            await tx
+              .delete(dancerInvites)
+              .where(
+                and(
+                  eq(dancerInvites.orgId, org.id),
+                  eq(dancerInvites.email, row.email)
+                )
+              );
+            await tx.insert(dancerInvites).values({
+              orgId: org.id,
+              email: row.email,
+              token,
+              expiresAt,
+            });
           });
-        });
 
-        await sendOrgInviteEmailOrThrow({
-          org,
-          event,
-          email: row.email,
-          firstName: row.firstName,
-          type: "dancer",
-          token,
-        });
+          await sendOrgInviteEmailOrThrow({
+            org,
+            event,
+            email: row.email,
+            firstName: row.firstName,
+            type: "dancer",
+            token,
+          });
+        } else {
+          const token = randomBytes(32).toString("hex");
+          await this.db.use((db) =>
+            db
+              .insert(schoolInvites)
+              .values({
+                eventId,
+                email: row.email,
+                organization: row.organization,
+                token,
+                expiresAt,
+              })
+              .onConflictDoUpdate({
+                target: [schoolInvites.eventId, schoolInvites.email],
+                set: {
+                  token,
+                  expiresAt,
+                  consumedAt: null,
+                },
+              })
+          );
+
+          await sendSchoolAccountInviteEmailOrThrow({
+            org,
+            event,
+            email: row.email,
+            firstName: row.firstName,
+            token,
+          });
+        }
 
         sent += 1;
       } catch (err) {
@@ -131,6 +165,7 @@ export class ResendInvitesService {
         resource: "invite",
         metadata: {
           ids: input.ids,
+          rosterTypes: rows.map((row) => ({ id: row.id, type: row.type })),
           sent,
           skipped,
           failed,

--- a/apps/backend/app/modules/orgs/events/rosters/resend-invites/service.ts
+++ b/apps/backend/app/modules/orgs/events/rosters/resend-invites/service.ts
@@ -5,6 +5,7 @@ import { eventRosters, orgEvents } from "#database/schema/org-events";
 import { dancerInvites, organizations } from "#database/schema/organizations";
 import { schoolInvites } from "#database/schema/schools";
 import { sendOrgInviteEmailOrThrow } from "#shared/org/invite-email";
+import { schoolInviteExpiry } from "#shared/org/school-invite-expiry";
 import { sendSchoolAccountInviteEmailOrThrow } from "#shared/org/school-account-invite-email";
 import {
   EMAIL_SEND_PACING_MS,
@@ -87,12 +88,12 @@ export class ResendInvitesService {
     const failed: Array<{ id: string; reason: string }> = [];
     const rowIdsByTask = new Map<EmailSendTask, string>();
     const tasks = rows.map((row) => {
-      const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 14);
       let invitePrepared = false;
       let task: EmailSendTask;
 
       if (row.type === "dancer") {
         const token = randomToken();
+        const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 14);
         task = {
           recipient: row.email,
           send: async () => {
@@ -128,6 +129,8 @@ export class ResendInvitesService {
         };
       } else {
         const token = randomBytes(32).toString("hex");
+        // Coach invites must outlive far-future events, matching upload-coaches.
+        const expiresAt = schoolInviteExpiry(event?.startDate);
         task = {
           recipient: row.email,
           send: async () => {

--- a/apps/backend/app/modules/orgs/events/upload-coaches/service.spec.ts
+++ b/apps/backend/app/modules/orgs/events/upload-coaches/service.spec.ts
@@ -1,7 +1,7 @@
 import { test } from "@japa/runner";
 import { db } from "#database/connection";
 import { users } from "#database/schema/users";
-import { schoolProfiles } from "#database/schema/schools";
+import { schoolInvites, schoolProfiles } from "#database/schema/schools";
 import { organizations, orgMemberships } from "#database/schema/organizations";
 import {
   orgEvents,
@@ -198,5 +198,36 @@ good@x.co,Good,Row,UCLA`;
       .from(eventRosters)
       .where(eq(eventRosters.eventId, event.id));
     assert.lengthOf(rosters, 0);
+  });
+
+  test("far-future coach invites expire seven days after the event starts", async ({
+    assert,
+  }) => {
+    const futureStart = new Date();
+    futureStart.setDate(futureStart.getDate() + 90);
+    const startDate = futureStart.toISOString().slice(0, 10);
+    const futureEnd = new Date(futureStart);
+    futureEnd.setDate(futureEnd.getDate() + 2);
+    await db
+      .update(orgEvents)
+      .set({ startDate, endDate: futureEnd.toISOString().slice(0, 10) })
+      .where(eq(orgEvents.id, event.id));
+
+    await new UploadCoachesService().execute({
+      orgId: summit.id,
+      eventId: event.id,
+      uploaderId: uploader.id,
+      fileUrl: "test://future.csv",
+      csv: `email,firstName,lastName,organization
+future-invite@example.com,Future,Coach,Review U`,
+    });
+
+    const [invite] = await db
+      .select()
+      .from(schoolInvites)
+      .where(eq(schoolInvites.email, "future-invite@example.com"));
+    const expected = new Date(`${startDate}T00:00:00`);
+    expected.setDate(expected.getDate() + 7);
+    assert.equal(invite!.expiresAt.getTime(), expected.getTime());
   });
 });

--- a/apps/backend/app/modules/orgs/events/upload-coaches/service.ts
+++ b/apps/backend/app/modules/orgs/events/upload-coaches/service.ts
@@ -9,6 +9,7 @@ import {
 } from "#database/schema/org-events";
 import { organizations, orgMemberships } from "#database/schema/organizations";
 import { normalizeRowEmails, parseCoachCsv } from "#shared/org/csv-parser";
+import { schoolInviteExpiry } from "#shared/org/school-invite-expiry";
 import { sendOrgRosterAddedEmailOrThrow } from "#shared/org/roster-added-email";
 import { sendSchoolAccountInviteEmailOrThrow } from "#shared/org/school-account-invite-email";
 import {
@@ -189,12 +190,7 @@ export class UploadCoachesService {
             } else {
               // Mint a school invite for unmatched rows; UPSERT on re-upload
               const token = randomBytes(32).toString("hex");
-              const minimumExpiry = new Date(Date.now() + 14 * 86400000);
-              const eventExpiry = new Date(`${event.startDate}T00:00:00`);
-              eventExpiry.setDate(eventExpiry.getDate() + 7);
-              const expiresAt = new Date(
-                Math.max(minimumExpiry.getTime(), eventExpiry.getTime())
-              );
+              const expiresAt = schoolInviteExpiry(event.startDate);
               await tx
                 .insert(schoolInvites)
                 .values({

--- a/apps/backend/app/modules/orgs/events/upload-coaches/service.ts
+++ b/apps/backend/app/modules/orgs/events/upload-coaches/service.ts
@@ -184,7 +184,12 @@ export class UploadCoachesService {
             } else {
               // Mint a school invite for unmatched rows; UPSERT on re-upload
               const token = randomBytes(32).toString("hex");
-              const expiresAt = new Date(Date.now() + 14 * 86400000);
+              const minimumExpiry = new Date(Date.now() + 14 * 86400000);
+              const eventExpiry = new Date(`${event.startDate}T00:00:00`);
+              eventExpiry.setDate(eventExpiry.getDate() + 7);
+              const expiresAt = new Date(
+                Math.max(minimumExpiry.getTime(), eventExpiry.getTime())
+              );
               await tx
                 .insert(schoolInvites)
                 .values({

--- a/apps/backend/app/modules/orgs/get-org/service.spec.ts
+++ b/apps/backend/app/modules/orgs/get-org/service.spec.ts
@@ -1,7 +1,12 @@
 import { test } from "@japa/runner";
 import { db } from "#database/connection";
-import { organizations } from "#database/schema/organizations";
+import { organizations, orgMemberships } from "#database/schema/organizations";
 import { seedOrganizations } from "#commands/backfill-organizations";
+import { users } from "#database/schema/users";
+import { eventRosters, orgEvents } from "#database/schema/org-events";
+import { GetOrgService } from "./service.ts";
+import { DatabaseService } from "#database/service";
+import { eq } from "drizzle-orm";
 
 test.group("GET /orgs/:slug", (group) => {
   group.each.setup(async () => {
@@ -39,5 +44,83 @@ test.group("GET /orgs/:slug", (group) => {
     const response = await client.get("/orgs/core");
     response.assertStatus(200);
     assert.equal(response.body().slug, "core");
+  });
+
+  test("myRoster resolves to the nearest upcoming event when no active-event roster exists", async ({
+    assert,
+  }) => {
+    const [org] = await db
+      .select()
+      .from(organizations)
+      .where(eq(organizations.slug, "summit"));
+    const [coach] = await db
+      .insert(users)
+      .values({
+        username: `multi_event_coach_${Date.now()}`,
+        email: `multi_event_coach_${Date.now()}@example.com`,
+        displayEmail: "multi-event@example.com",
+        firstName: "Multi",
+        lastName: "Coach",
+        password: "hashed",
+        role: "user",
+        type: "school",
+        verified: true,
+      })
+      .returning();
+    await db.insert(orgMemberships).values({
+      orgId: org!.id,
+      userId: coach!.id,
+      role: "member",
+      type: "coach",
+    });
+    const today = new Date();
+    const dateFromToday = (days: number) => {
+      const date = new Date(today);
+      date.setDate(date.getDate() + days);
+      return date.toISOString().slice(0, 10);
+    };
+    const [farFuture, nearestFuture, past] = await db
+      .insert(orgEvents)
+      .values([
+        {
+          orgId: org!.id,
+          name: "Far Future",
+          startDate: dateFromToday(60),
+          endDate: dateFromToday(62),
+        },
+        {
+          orgId: org!.id,
+          name: "Nearest Future",
+          startDate: dateFromToday(10),
+          endDate: dateFromToday(12),
+        },
+        {
+          orgId: org!.id,
+          name: "Past",
+          startDate: dateFromToday(-30),
+          endDate: dateFromToday(-28),
+        },
+      ])
+      .returning();
+    await db.insert(eventRosters).values(
+      [farFuture, nearestFuture, past].map((event) => ({
+        eventId: event!.id,
+        userId: coach!.id,
+        type: "coach" as const,
+        email: coach!.email,
+        firstName: "Multi",
+        lastName: "Coach",
+      }))
+    );
+
+    const result = await new GetOrgService(new DatabaseService()).execute(
+      org!.slug,
+      coach!.id
+    );
+
+    assert.equal(result?.myRoster?.eventId, nearestFuture!.id);
+    assert.equal(result?.myRoster?.eventName, "Nearest Future");
+    assert.isFalse(result?.myRoster?.isActive);
+    assert.isFalse(result?.myRoster?.hasStarted);
   });
 });

--- a/apps/backend/app/modules/orgs/get-org/service.ts
+++ b/apps/backend/app/modules/orgs/get-org/service.ts
@@ -1,8 +1,9 @@
 import { DatabaseService } from "#database/service";
 import { organizations, orgMemberships } from "#database/schema/organizations";
 import { eventRosters, orgEvents } from "#database/schema/org-events";
+import { hasEventStarted } from "#utils/event-time";
 import { inject } from "@adonisjs/core";
-import { and, eq } from "drizzle-orm";
+import { and, asc, desc, eq, sql } from "drizzle-orm";
 
 export interface GetOrgResult {
   org: typeof organizations.$inferSelect;
@@ -14,6 +15,11 @@ export interface GetOrgResult {
     id: string;
     eventId: string;
     type: "coach" | "dancer";
+    eventName: string;
+    eventStartDate: string;
+    eventEndDate: string;
+    isActive: boolean;
+    hasStarted: boolean;
   } | null;
 }
 
@@ -56,36 +62,53 @@ export class GetOrgService {
           };
         }
 
-        const [activeEvent] = await db
-          .select({ id: orgEvents.id })
-          .from(orgEvents)
+        const today = new Date().toISOString().slice(0, 10);
+        const [roster] = await db
+          .select({
+            id: eventRosters.id,
+            eventId: eventRosters.eventId,
+            type: eventRosters.type,
+            eventName: orgEvents.name,
+            eventStartDate: orgEvents.startDate,
+            eventEndDate: orgEvents.endDate,
+            eventStartTime: orgEvents.startTime,
+            eventTimezone: orgEvents.timezone,
+            isActive: orgEvents.isActive,
+          })
+          .from(eventRosters)
+          .innerJoin(orgEvents, eq(orgEvents.id, eventRosters.eventId))
           .where(
-            and(eq(orgEvents.orgId, org.id), eq(orgEvents.isActive, true))
+            and(eq(orgEvents.orgId, org.id), eq(eventRosters.userId, userId))
+          )
+          .orderBy(
+            desc(orgEvents.isActive),
+            asc(
+              sql`CASE WHEN ${orgEvents.startDate} >= ${today} THEN 0 ELSE 1 END`
+            ),
+            asc(
+              sql`CASE WHEN ${orgEvents.startDate} >= ${today} THEN ${orgEvents.startDate} END`
+            ),
+            desc(
+              sql`CASE WHEN ${orgEvents.startDate} < ${today} THEN ${orgEvents.startDate} END`
+            ),
+            desc(eventRosters.createdAt)
           )
           .limit(1);
-
-        if (activeEvent) {
-          const [roster] = await db
-            .select({
-              id: eventRosters.id,
-              eventId: eventRosters.eventId,
-              type: eventRosters.type,
-            })
-            .from(eventRosters)
-            .where(
-              and(
-                eq(eventRosters.eventId, activeEvent.id),
-                eq(eventRosters.userId, userId)
-              )
-            )
-            .limit(1);
-          if (roster) {
-            myRoster = {
-              id: roster.id,
-              eventId: roster.eventId,
-              type: roster.type as "coach" | "dancer",
-            };
-          }
+        if (roster) {
+          myRoster = {
+            id: roster.id,
+            eventId: roster.eventId,
+            type: roster.type as "coach" | "dancer",
+            eventName: roster.eventName,
+            eventStartDate: roster.eventStartDate,
+            eventEndDate: roster.eventEndDate,
+            isActive: roster.isActive,
+            hasStarted: hasEventStarted(
+              roster.eventStartDate,
+              roster.eventStartTime,
+              roster.eventTimezone
+            ),
+          };
         }
       }
 

--- a/apps/backend/app/modules/orgs/scouting/coach-cross-event-access.spec.ts
+++ b/apps/backend/app/modules/orgs/scouting/coach-cross-event-access.spec.ts
@@ -1,0 +1,382 @@
+import { test } from "@japa/runner";
+import { db } from "#database/connection";
+import { getUserSession } from "#auth/queries";
+import {
+  eventCallbacks,
+  eventFavorites,
+  eventNotes,
+  eventRatings,
+  eventShowcases,
+  publishedCallbacks,
+} from "#database/schema/event-features";
+import {
+  eventDancerProfiles,
+  eventRosters,
+  orgEvents,
+} from "#database/schema/org-events";
+import { organizations, orgMemberships } from "#database/schema/organizations";
+import { dancerProfiles } from "#database/schema/dancers";
+import { schoolProfiles } from "#database/schema/schools";
+import { users } from "#database/schema/users";
+import redis from "@adonisjs/redis/services/main";
+import { MessageBuilder } from "@adonisjs/core/helpers";
+import { randomUUID } from "node:crypto";
+
+function dateFromToday(days: number) {
+  const date = new Date();
+  date.setDate(date.getDate() + days);
+  return date.toISOString().slice(0, 10);
+}
+
+async function createUser(
+  username: string,
+  type: "school" | "dancer" = "school"
+) {
+  const email = `${username}@example.com`;
+  const [user] = await db
+    .insert(users)
+    .values({
+      username,
+      email,
+      displayEmail: email,
+      firstName: username,
+      lastName: "Test",
+      password: "hashed",
+      role: "user",
+      type,
+      verified: true,
+    })
+    .returning();
+  return user!;
+}
+
+async function loginUser(userId: string) {
+  const session = await getUserSession(userId);
+  if (!session) throw new Error("Test user session was not created");
+  const token = randomUUID();
+  const version = Date.now();
+  const connection = redis.connection("session");
+  await connection.setex(`version:${userId}`, 3600, version);
+  await connection.setex(
+    token,
+    3600,
+    new MessageBuilder().build({ version, user: session }, undefined, token)
+  );
+  return token;
+}
+
+test.group("coach cross-event scouting access", (group) => {
+  group.each.setup(async () => {
+    await db.delete(publishedCallbacks).execute();
+    await db.delete(eventCallbacks).execute();
+    await db.delete(eventFavorites).execute();
+    await db.delete(eventNotes).execute();
+    await db.delete(eventRatings).execute();
+    await db.delete(eventShowcases).execute();
+    await db.delete(eventDancerProfiles).execute();
+    await db.delete(eventRosters).execute();
+    await db.delete(orgEvents).execute();
+    await db.delete(orgMemberships).execute();
+    await db.delete(dancerProfiles).execute();
+    await db.delete(schoolProfiles).execute();
+    await db.delete(users).execute();
+    await db.delete(organizations).execute();
+  });
+
+  test("a future-event coach can browse every event but cannot write active-event scouting data", async ({
+    client,
+    assert,
+  }) => {
+    const [org] = await db
+      .insert(organizations)
+      .values({
+        name: "Cross Event Org",
+        slug: "cross-event-org",
+        features: { callbacks: true },
+      })
+      .returning();
+    const [activeEvent, futureEvent] = await db
+      .insert(orgEvents)
+      .values([
+        {
+          orgId: org!.id,
+          name: "Active Event",
+          startDate: dateFromToday(-1),
+          endDate: dateFromToday(1),
+          isActive: true,
+        },
+        {
+          orgId: org!.id,
+          name: "Future Event",
+          startDate: dateFromToday(30),
+          endDate: dateFromToday(32),
+        },
+      ])
+      .returning();
+    const coach = await createUser("future_coach");
+    await db.insert(orgMemberships).values({
+      orgId: org!.id,
+      userId: coach.id,
+      role: "member",
+      type: "coach",
+    });
+    await db.insert(eventRosters).values({
+      eventId: futureEvent!.id,
+      userId: coach.id,
+      type: "coach",
+      email: coach.email,
+      firstName: "Future",
+      lastName: "Coach",
+    });
+    const [activeDancer, futureDancer] = await db
+      .insert(eventRosters)
+      .values([
+        {
+          eventId: activeEvent!.id,
+          type: "dancer",
+          email: "active-dancer@example.com",
+          firstName: "Active",
+          lastName: "Dancer",
+          bibNumber: 10,
+        },
+        {
+          eventId: futureEvent!.id,
+          type: "dancer",
+          email: "future-dancer@example.com",
+          firstName: "Future",
+          lastName: "Dancer",
+          bibNumber: 20,
+        },
+      ])
+      .returning();
+    const token = await loginUser(coach.id);
+
+    const list = await client
+      .get(`/orgs/${org!.slug}/dancers`)
+      .header("Authorization", `Bearer ${token}`);
+    list.assertStatus(200);
+    assert.deepEqual(
+      list
+        .body()
+        .map((row: { firstName: string }) => row.firstName)
+        .sort(),
+      ["Active", "Future"]
+    );
+    assert.isTrue(
+      list.body().every((row: { isFavorited: boolean }) => !row.isFavorited)
+    );
+    assert.isTrue(
+      list.body().every((row: { rating: number | null }) => row.rating === null)
+    );
+
+    const detail = await client
+      .get(`/orgs/${org!.slug}/dancers/${activeDancer!.id}`)
+      .header("Authorization", `Bearer ${token}`);
+    detail.assertStatus(200);
+    assert.equal(detail.body().rosterId, activeDancer!.id);
+
+    const filtered = await client
+      .get(`/orgs/${org!.slug}/dancers`)
+      .qs({ eventId: futureEvent!.id })
+      .header("Authorization", `Bearer ${token}`);
+    filtered.assertStatus(200);
+    assert.deepEqual(
+      filtered.body().map((row: { rosterId: string }) => row.rosterId),
+      [futureDancer!.id]
+    );
+    const [otherOrg] = await db
+      .insert(organizations)
+      .values({ name: "Other Org", slug: "other-org" })
+      .returning();
+    const [otherOrgEvent] = await db
+      .insert(orgEvents)
+      .values({
+        orgId: otherOrg!.id,
+        name: "Other Org Event",
+        startDate: dateFromToday(10),
+        endDate: dateFromToday(11),
+      })
+      .returning();
+    const invalidFilter = await client
+      .get(`/orgs/${org!.slug}/dancers`)
+      .qs({ eventId: otherOrgEvent!.id })
+      .header("Authorization", `Bearer ${token}`);
+    invalidFilter.assertStatus(422);
+
+    const favorite = await client
+      .post(`/orgs/${org!.slug}/favorites`)
+      .json({ dancerRosterId: activeDancer!.id })
+      .header("Authorization", `Bearer ${token}`);
+    favorite.assertStatus(403);
+    const rating = await client
+      .put(`/orgs/${org!.slug}/dancers/${activeDancer!.id}/rating`)
+      .json({ rating: 5 })
+      .header("Authorization", `Bearer ${token}`);
+    rating.assertStatus(403);
+    const note = await client
+      .put(`/orgs/${org!.slug}/dancers/${activeDancer!.id}/notes`)
+      .json({ content: "Watch again" })
+      .header("Authorization", `Bearer ${token}`);
+    note.assertStatus(403);
+    const callback = await client
+      .post(`/orgs/${org!.slug}/callbacks`)
+      .json({ dancerRosterId: activeDancer!.id })
+      .header("Authorization", `Bearer ${token}`);
+    callback.assertStatus(403);
+  });
+
+  test("an active-event coach retains full scouting writes", async ({
+    client,
+  }) => {
+    const [org] = await db
+      .insert(organizations)
+      .values({
+        name: "Active Coach Org",
+        slug: "active-coach-org",
+        features: { callbacks: true },
+      })
+      .returning();
+    const [event] = await db
+      .insert(orgEvents)
+      .values({
+        orgId: org!.id,
+        name: "Active Event",
+        startDate: dateFromToday(-1),
+        endDate: dateFromToday(1),
+        isActive: true,
+      })
+      .returning();
+    const coach = await createUser("active_coach");
+    await db.insert(orgMemberships).values({
+      orgId: org!.id,
+      userId: coach.id,
+      role: "member",
+      type: "coach",
+    });
+    await db.insert(eventRosters).values({
+      eventId: event!.id,
+      userId: coach.id,
+      type: "coach",
+      email: coach.email,
+      firstName: "Active",
+      lastName: "Coach",
+    });
+    const [dancer] = await db
+      .insert(eventRosters)
+      .values({
+        eventId: event!.id,
+        type: "dancer",
+        email: "active-write-dancer@example.com",
+        firstName: "Write",
+        lastName: "Dancer",
+        bibNumber: 30,
+      })
+      .returning();
+    const [otherEvent] = await db
+      .insert(orgEvents)
+      .values({
+        orgId: org!.id,
+        name: "Other Event",
+        startDate: dateFromToday(30),
+        endDate: dateFromToday(31),
+      })
+      .returning();
+    const [otherEventDancer] = await db
+      .insert(eventRosters)
+      .values({
+        eventId: otherEvent!.id,
+        type: "dancer",
+        email: "other-event-dancer@example.com",
+        firstName: "Other",
+        lastName: "Dancer",
+        bibNumber: 31,
+      })
+      .returning();
+    const token = await loginUser(coach.id);
+
+    const list = await client
+      .get(`/orgs/${org!.slug}/dancers`)
+      .header("Authorization", `Bearer ${token}`);
+    list.assertStatus(200);
+    const favorite = await client
+      .post(`/orgs/${org!.slug}/favorites`)
+      .json({ dancerRosterId: dancer!.id })
+      .header("Authorization", `Bearer ${token}`);
+    favorite.assertStatus(201);
+    const rating = await client
+      .put(`/orgs/${org!.slug}/dancers/${dancer!.id}/rating`)
+      .json({ rating: 5 })
+      .header("Authorization", `Bearer ${token}`);
+    rating.assertStatus(200);
+    const note = await client
+      .put(`/orgs/${org!.slug}/dancers/${dancer!.id}/notes`)
+      .json({ content: "Strong technique" })
+      .header("Authorization", `Bearer ${token}`);
+    note.assertStatus(200);
+    const callback = await client
+      .post(`/orgs/${org!.slug}/callbacks`)
+      .json({ dancerRosterId: dancer!.id })
+      .header("Authorization", `Bearer ${token}`);
+    callback.assertStatus(201);
+    const crossEventRating = await client
+      .put(`/orgs/${org!.slug}/dancers/${otherEventDancer!.id}/rating`)
+      .json({ rating: 5 })
+      .header("Authorization", `Bearer ${token}`);
+    crossEventRating.assertStatus(403);
+  });
+
+  test("dancer denial and org-admin coach access are unchanged", async ({
+    client,
+  }) => {
+    const [org] = await db
+      .insert(organizations)
+      .values({ name: "Gating Org", slug: "gating-org" })
+      .returning();
+    const [event] = await db
+      .insert(orgEvents)
+      .values({
+        orgId: org!.id,
+        name: "Active Event",
+        startDate: dateFromToday(-1),
+        endDate: dateFromToday(1),
+        isActive: true,
+      })
+      .returning();
+    const dancer = await createUser("dancer_member", "dancer");
+    const admin = await createUser("org_admin");
+    await db.insert(orgMemberships).values([
+      {
+        orgId: org!.id,
+        userId: dancer.id,
+        role: "member",
+        type: "dancer",
+      },
+      {
+        orgId: org!.id,
+        userId: admin.id,
+        role: "admin",
+        type: "coach",
+      },
+    ]);
+    await db.insert(eventRosters).values({
+      eventId: event!.id,
+      userId: dancer.id,
+      type: "dancer",
+      email: dancer.email,
+      firstName: "Dancer",
+      lastName: "Member",
+      bibNumber: 40,
+    });
+
+    const dancerToken = await loginUser(dancer.id);
+    const denied = await client
+      .get(`/orgs/${org!.slug}/dancers`)
+      .header("Authorization", `Bearer ${dancerToken}`);
+    denied.assertStatus(403);
+    const adminToken = await loginUser(admin.id);
+    const allowed = await client
+      .get(`/orgs/${org!.slug}/dancers`)
+      .header("Authorization", `Bearer ${adminToken}`);
+    allowed.assertStatus(200);
+  });
+});

--- a/apps/backend/app/modules/orgs/scouting/dancers/get-by-id/controller.ts
+++ b/apps/backend/app/modules/orgs/scouting/dancers/get-by-id/controller.ts
@@ -7,7 +7,8 @@ export default class GetDancerByIdController {
   async handle(ctx: HttpContext, service: GetDancerByIdService) {
     const rosterId = ctx.params.rosterId as string;
     const result = await service.execute(
-      ctx.orgEvent!.id,
+      ctx.org!.id,
+      ctx.orgEvent?.id ?? null,
       rosterId,
       ctx.orgRoster?.id ?? null
     );

--- a/apps/backend/app/modules/orgs/scouting/dancers/get-by-id/service.ts
+++ b/apps/backend/app/modules/orgs/scouting/dancers/get-by-id/service.ts
@@ -1,6 +1,10 @@
 import { DatabaseService } from "#database/service";
 import { inject } from "@adonisjs/core";
-import { eventRosters, eventDancerProfiles } from "#database/schema/org-events";
+import {
+  eventRosters,
+  eventDancerProfiles,
+  orgEvents,
+} from "#database/schema/org-events";
 import { dancerProfiles } from "#database/schema/dancers";
 import {
   eventCallbacks,
@@ -16,7 +20,8 @@ export class GetDancerByIdService {
   constructor(private db: DatabaseService = new DatabaseService()) {}
 
   async execute(
-    eventId: string,
+    orgId: string,
+    activeEventId: string | null,
     dancerRosterId: string,
     coachRosterId: string | null
   ) {
@@ -46,6 +51,7 @@ export class GetDancerByIdService {
           extra: eventDancerProfiles.extra,
           highSchool: dancerProfiles.highSchool,
           location: dancerProfiles.location,
+          eventId: eventRosters.eventId,
         })
         .from(eventRosters)
         .leftJoin(
@@ -57,10 +63,11 @@ export class GetDancerByIdService {
           eq(dancerProfiles.userId, eventRosters.userId)
         )
         .leftJoin(users, eq(users.id, eventRosters.userId))
+        .innerJoin(orgEvents, eq(orgEvents.id, eventRosters.eventId))
         .where(
           and(
             eq(eventRosters.id, dancerRosterId),
-            eq(eventRosters.eventId, eventId),
+            eq(orgEvents.orgId, orgId),
             eq(eventRosters.type, "dancer")
           )
         )
@@ -76,7 +83,7 @@ export class GetDancerByIdService {
     let isFavorited = false;
     let isCalledBack = false;
 
-    if (coachRosterId !== null) {
+    if (coachRosterId !== null && activeEventId !== null) {
       const [noteRow, ratingRow, favoriteRow, callbackRow] = await Promise.all([
         this.db.use((db) =>
           db
@@ -84,7 +91,7 @@ export class GetDancerByIdService {
             .from(eventNotes)
             .where(
               and(
-                eq(eventNotes.eventId, eventId),
+                eq(eventNotes.eventId, activeEventId!),
                 eq(eventNotes.coachRosterId, coachRosterId),
                 eq(eventNotes.dancerRosterId, dancerRosterId)
               )
@@ -97,7 +104,7 @@ export class GetDancerByIdService {
             .from(eventRatings)
             .where(
               and(
-                eq(eventRatings.eventId, eventId),
+                eq(eventRatings.eventId, activeEventId!),
                 eq(eventRatings.coachRosterId, coachRosterId),
                 eq(eventRatings.dancerRosterId, dancerRosterId)
               )
@@ -110,7 +117,7 @@ export class GetDancerByIdService {
             .from(eventFavorites)
             .where(
               and(
-                eq(eventFavorites.eventId, eventId),
+                eq(eventFavorites.eventId, activeEventId!),
                 eq(eventFavorites.coachRosterId, coachRosterId),
                 eq(eventFavorites.dancerRosterId, dancerRosterId)
               )
@@ -123,7 +130,7 @@ export class GetDancerByIdService {
             .from(eventCallbacks)
             .where(
               and(
-                eq(eventCallbacks.eventId, eventId),
+                eq(eventCallbacks.eventId, activeEventId!),
                 eq(eventCallbacks.coachRosterId, coachRosterId),
                 eq(eventCallbacks.dancerRosterId, dancerRosterId)
               )

--- a/apps/backend/app/modules/orgs/scouting/dancers/list/controller.ts
+++ b/apps/backend/app/modules/orgs/scouting/dancers/list/controller.ts
@@ -1,9 +1,11 @@
 import { inject } from "@adonisjs/core";
 import type { HttpContext } from "@adonisjs/core/http";
-import { hasEventStarted } from "#utils/event-time";
 import { ListDancersService } from "./service.ts";
 import { EnsureActiveShowcaseService } from "../../showcases/ensure-active/service.ts";
 import { schema } from "./validator.ts";
+import { orgEvents } from "#database/schema/org-events";
+import { db } from "#database/connection";
+import { and, eq } from "drizzle-orm";
 
 export default class ListDancersController {
   @inject()
@@ -13,26 +15,39 @@ export default class ListDancersController {
     ensureShowcase: EnsureActiveShowcaseService
   ) {
     const payload = await ctx.request.validateUsing(schema);
-    const event = ctx.orgEvent!;
+    const event = ctx.orgEvent;
 
-    // Free-tier orgs show every dancer across all of the org's events, and
-    // never hide un-checked-in dancers (check-in only applies to the active
-    // event, which is meaningless across the full history).
-    const features = (ctx.org?.features ?? {}) as Record<string, boolean>;
-    const isFreeTier = Boolean(features.freeTierUsers);
+    if (payload.eventId) {
+      const [selectedEvent] = await db
+        .select({ id: orgEvents.id })
+        .from(orgEvents)
+        .where(
+          and(
+            eq(orgEvents.id, payload.eventId),
+            eq(orgEvents.orgId, ctx.org!.id)
+          )
+        )
+        .limit(1);
+      if (!selectedEvent) {
+        return ctx.response.unprocessableEntity({
+          message: "Selected event does not belong to this organization.",
+        });
+      }
+    }
 
-    const filterCheckedInOnly = isFreeTier
-      ? false
-      : hasEventStarted(event.startDate, event.startTime, event.timezone);
-    const showcase = await ensureShowcase.execute(event.id);
+    // Cross-event browsing never hides unchecked dancers: check-in state only
+    // has meaning within the active event, while this endpoint defaults to the
+    // organization's complete dancer history.
+    const filterCheckedInOnly = false;
+    const showcase = event ? await ensureShowcase.execute(event.id) : null;
     const rows = await service.execute(
-      event.orgId,
-      event.id,
+      ctx.org!.id,
+      event?.id ?? null,
       ctx.orgRoster?.id ?? null,
       payload,
       filterCheckedInOnly,
-      showcase.id,
-      isFreeTier
+      showcase?.id,
+      payload.eventId
     );
     return ctx.response.ok(rows);
   }

--- a/apps/backend/app/modules/orgs/scouting/dancers/list/service.spec.ts
+++ b/apps/backend/app/modules/orgs/scouting/dancers/list/service.spec.ts
@@ -289,19 +289,7 @@ test.group("ListDancersService", (group) => {
 
     const svc = new ListDancersService();
 
-    const activeOnly = await svc.execute(summit.id, event.id, null, {});
-    assert.equal(activeOnly.length, 1);
-    assert.equal(activeOnly[0]!.firstName, "Current");
-
-    const all = await svc.execute(
-      summit.id,
-      event.id,
-      null,
-      {},
-      false,
-      undefined,
-      true
-    );
+    const all = await svc.execute(summit.id, event.id, null, {});
     assert.equal(all.length, 2);
   });
 
@@ -357,15 +345,7 @@ test.group("ListDancersService", (group) => {
       .returning();
 
     const svc = new ListDancersService();
-    const all = await svc.execute(
-      summit.id,
-      event.id,
-      null,
-      {},
-      false,
-      undefined,
-      true
-    );
+    const all = await svc.execute(summit.id, event.id, null, {});
     assert.equal(all.length, 1);
     assert.equal(all[0]!.rosterId, activeRoster!.id);
   });

--- a/apps/backend/app/modules/orgs/scouting/dancers/list/service.ts
+++ b/apps/backend/app/modules/orgs/scouting/dancers/list/service.ts
@@ -22,23 +22,21 @@ export class ListDancersService {
 
   async execute(
     orgId: string,
-    eventId: string,
+    activeEventId: string | null,
     coachRosterId: string | null,
     q: Validator,
     filterCheckedInOnly: boolean = false,
     showcaseId?: string,
-    allEvents: boolean = false
+    selectedEventId?: string
   ) {
     const rows = await this.db.use((db) => {
       const filters = [
-        // Free-tier orgs surface dancers from every event they've run, not just
-        // the active one; otherwise stay scoped to the active event.
-        allEvents
-          ? sql`${eventRosters.eventId} IN (
+        selectedEventId
+          ? eq(eventRosters.eventId, selectedEventId)
+          : sql`${eventRosters.eventId} IN (
               SELECT ${orgEvents.id} FROM ${orgEvents}
               WHERE ${orgEvents.orgId} = ${orgId}
-            )`
-          : eq(eventRosters.eventId, eventId),
+            )`,
         eq(eventRosters.type, "dancer"),
         eq(eventRosters.isStaff, false),
       ];
@@ -60,7 +58,7 @@ export class ListDancersService {
             SELECT 1 FROM event_school_selections ess
             WHERE ess.dancer_roster_id = ${eventRosters.id}
               AND ess.coach_roster_id = ${coachRosterId}
-              AND ess.event_id = ${eventId}
+              AND ess.event_id = ${activeEventId}
           )`
         : sql<boolean>`false`;
 
@@ -69,7 +67,7 @@ export class ListDancersService {
             SELECT 1 FROM ${eventFavorites}
             WHERE ${eventFavorites.dancerRosterId} = ${eventRosters.id}
               AND ${eventFavorites.coachRosterId} = ${coachRosterId}
-              AND ${eventFavorites.eventId} = ${eventId}
+              AND ${eventFavorites.eventId} = ${activeEventId}
           )`
         : sql<boolean>`false`;
 
@@ -78,7 +76,7 @@ export class ListDancersService {
             SELECT ${eventRatings.rating} FROM ${eventRatings}
             WHERE ${eventRatings.dancerRosterId} = ${eventRosters.id}
               AND ${eventRatings.coachRosterId} = ${coachRosterId}
-              AND ${eventRatings.eventId} = ${eventId}
+              AND ${eventRatings.eventId} = ${activeEventId}
             LIMIT 1
           )`
         : sql<number | null>`NULL`;
@@ -88,7 +86,7 @@ export class ListDancersService {
             SELECT 1 FROM ${eventNotes}
             WHERE ${eventNotes.dancerRosterId} = ${eventRosters.id}
               AND ${eventNotes.coachRosterId} = ${coachRosterId}
-              AND ${eventNotes.eventId} = ${eventId}
+              AND ${eventNotes.eventId} = ${activeEventId}
           )`
         : sql<boolean>`false`;
 
@@ -113,7 +111,7 @@ export class ListDancersService {
             SELECT 1 FROM event_school_selections ess
             WHERE ess.dancer_roster_id = ${eventRosters.id}
               AND ess.coach_roster_id = ${coachRosterId}
-              AND ess.event_id = ${eventId}
+              AND ess.event_id = ${activeEventId}
           )`
         );
       }
@@ -164,7 +162,9 @@ export class ListDancersService {
     // event. Collapse to one row per dancer — keyed by their account when
     // registered, otherwise left distinct — preferring the active event's row
     // so the coach's favorites/ratings/callbacks stay wired to it.
-    const deduped = allEvents ? this.dedupeByDancer(rows, eventId) : rows;
+    const deduped = selectedEventId
+      ? rows
+      : this.dedupeByDancer(rows, activeEventId);
 
     return deduped.map((row) => ({
       rosterId: row.rosterId,
@@ -183,6 +183,7 @@ export class ListDancersService {
       hasNote: row.hasNote,
       isCalledBack: row.isCalledBack,
       username: row.username,
+      eventId: row.eventId,
     }));
   }
 
@@ -194,7 +195,7 @@ export class ListDancersService {
       eventId: string;
       createdAt: Date | null;
     },
-  >(rows: T[], activeEventId: string): T[] {
+  >(rows: T[], activeEventId: string | null): T[] {
     const byDancer = new Map<string, T>();
     for (const row of rows) {
       const key = row.userId ?? `roster:${row.rosterId}`;
@@ -211,7 +212,7 @@ export class ListDancersService {
   private isBetterRow(
     candidate: { eventId: string; createdAt: Date | null },
     current: { eventId: string; createdAt: Date | null },
-    activeEventId: string
+    activeEventId: string | null
   ) {
     const candidateActive = candidate.eventId === activeEventId;
     const currentActive = current.eventId === activeEventId;

--- a/apps/backend/app/modules/orgs/scouting/dancers/list/validator.ts
+++ b/apps/backend/app/modules/orgs/scouting/dancers/list/validator.ts
@@ -6,6 +6,7 @@ export const schema = vine.compile(
     search: vine.string().trim().minLength(1).optional(),
     bib: vine.number().positive().optional(),
     interested: vine.boolean().optional(),
+    eventId: vine.string().uuid().optional(),
   })
 );
 export type Validator = Infer<typeof schema>;

--- a/apps/backend/app/modules/orgs/scouting/routes.ts
+++ b/apps/backend/app/modules/orgs/scouting/routes.ts
@@ -19,27 +19,53 @@ const DeleteSelection = () => import("./selections/delete/controller.ts");
 const ListCallbacks = () => import("./callbacks/list/controller.ts");
 const CreateCallback = () => import("./callbacks/create/controller.ts");
 const DeleteCallback = () => import("./callbacks/delete/controller.ts");
-const AdminCallbackBoard = () => import("./callbacks/admin-board/controller.ts");
+const AdminCallbackBoard = () =>
+  import("./callbacks/admin-board/controller.ts");
 
 const ListShowcases = () => import("./showcases/list/controller.ts");
 const PublishShowcase = () => import("./showcases/publish/controller.ts");
 const StartNextShowcase = () => import("./showcases/next/controller.ts");
-const PublishedCallbacks = () => import("./showcases/published-callbacks/controller.ts");
-const DancerCallbacks = () => import("./callbacks/dancer-callbacks/controller.ts");
+const PublishedCallbacks = () =>
+  import("./showcases/published-callbacks/controller.ts");
+const DancerCallbacks = () =>
+  import("./callbacks/dancer-callbacks/controller.ts");
 
 router
   .group(() => {
     router.get(":slug/dancers", [ListDancersController]).openapi({
-      summary: "List dancers in active event",
-      description: "Coach-scoped dancer search by name or bib number.",
+      summary: "List dancers across organization events",
+      description: "Coach-scoped dancer search by name, bib number, or event.",
     });
     router.get(":slug/dancers/:rosterId", [GetDancerById]);
+  })
+  .prefix("orgs")
+  .use([
+    middleware.auth(),
+    middleware.org(),
+    middleware.orgEvent("coachDancerRead"),
+    middleware.orgMember(),
+    middleware.orgCoach(),
+  ])
+  .openapi({ tags: ["Org Scouting"] });
+
+router
+  .group(() => {
     router.get(":slug/favorites", [ListFavorites]);
-    router.post(":slug/favorites", [CreateFavorite]);
-    router.delete(":slug/favorites/:dancerRosterId", [DeleteFavorite]);
-    router.put(":slug/dancers/:dancerRosterId/notes", [UpsertNote]);
-    router.delete(":slug/dancers/:dancerRosterId/notes", [DeleteNote]);
-    router.put(":slug/dancers/:dancerRosterId/rating", [UpsertRating]);
+    router
+      .post(":slug/favorites", [CreateFavorite])
+      .use(middleware.orgEventDancer());
+    router
+      .delete(":slug/favorites/:dancerRosterId", [DeleteFavorite])
+      .use(middleware.orgEventDancer());
+    router
+      .put(":slug/dancers/:dancerRosterId/notes", [UpsertNote])
+      .use(middleware.orgEventDancer());
+    router
+      .delete(":slug/dancers/:dancerRosterId/notes", [DeleteNote])
+      .use(middleware.orgEventDancer());
+    router
+      .put(":slug/dancers/:dancerRosterId/rating", [UpsertRating])
+      .use(middleware.orgEventDancer());
     router.get(":slug/rankings", [ListRankings]);
   })
   .prefix("orgs")
@@ -72,8 +98,12 @@ router
 router
   .group(() => {
     router.get(":slug/callbacks", [ListCallbacks]);
-    router.post(":slug/callbacks", [CreateCallback]);
-    router.delete(":slug/callbacks/:dancerRosterId", [DeleteCallback]);
+    router
+      .post(":slug/callbacks", [CreateCallback])
+      .use(middleware.orgEventDancer());
+    router
+      .delete(":slug/callbacks/:dancerRosterId", [DeleteCallback])
+      .use(middleware.orgEventDancer());
   })
   .prefix("orgs")
   .use([

--- a/apps/backend/app/shared/org/school-invite-expiry.ts
+++ b/apps/backend/app/shared/org/school-invite-expiry.ts
@@ -1,0 +1,19 @@
+const FOURTEEN_DAYS_MS = 14 * 86400000;
+const GRACE_DAYS_AFTER_EVENT_START = 7;
+
+/**
+ * School/coach invites must outlive far-future events: they expire at the
+ * later of 14 days from issue or 7 days after the event starts.
+ */
+export function schoolInviteExpiry(
+  eventStartDate: string | null | undefined
+): Date {
+  const minimumExpiry = new Date(Date.now() + FOURTEEN_DAYS_MS);
+  if (!eventStartDate) return minimumExpiry;
+
+  const eventExpiry = new Date(`${eventStartDate}T00:00:00`);
+  if (Number.isNaN(eventExpiry.getTime())) return minimumExpiry;
+  eventExpiry.setDate(eventExpiry.getDate() + GRACE_DAYS_AFTER_EVENT_START);
+
+  return new Date(Math.max(minimumExpiry.getTime(), eventExpiry.getTime()));
+}

--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -4634,6 +4634,21 @@
             }
           },
           {
+            "name": "eventId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          {
             "name": "interested",
             "in": "query",
             "required": false,
@@ -4681,23 +4696,13 @@
                 }
               }
             }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
           }
         },
         "tags": [
           "Org Scouting"
         ],
-        "summary": "List dancers in active event",
-        "description": "Coach-scoped dancer search by name or bib number."
+        "summary": "List dancers across organization events",
+        "description": "Coach-scoped dancer search by name, bib number, or event."
       }
     },
     "/orgs/{slug}/dancers/{rosterId}": {
@@ -12262,12 +12267,32 @@
                   },
                   "type": {
                     "$ref": "#/components/schemas/UploadKind"
+                  },
+                  "eventName": {
+                    "type": "string"
+                  },
+                  "eventStartDate": {
+                    "type": "string"
+                  },
+                  "eventEndDate": {
+                    "type": "string"
+                  },
+                  "isActive": {
+                    "type": "boolean"
+                  },
+                  "hasStarted": {
+                    "type": "boolean"
                   }
                 },
                 "required": [
                   "id",
                   "eventId",
-                  "type"
+                  "type",
+                  "eventName",
+                  "eventStartDate",
+                  "eventEndDate",
+                  "isActive",
+                  "hasStarted"
                 ]
               },
               {
@@ -15153,6 +15178,9 @@
                   "type": "null"
                 }
               ]
+            },
+            "eventId": {
+              "type": "string"
             }
           },
           "required": [
@@ -15171,7 +15199,8 @@
             "rating",
             "hasNote",
             "isCalledBack",
-            "username"
+            "username",
+            "eventId"
           ]
         }
       },
@@ -15253,6 +15282,9 @@
                 "type": "null"
               }
             ]
+          },
+          "eventId": {
+            "type": "string"
           },
           "rating": {
             "oneOf": [
@@ -15357,6 +15389,7 @@
           "studio",
           "gpa",
           "gradYear",
+          "eventId",
           "rating",
           "bibNumber",
           "rosterId",

--- a/apps/backend/start/kernel.ts
+++ b/apps/backend/start/kernel.ts
@@ -58,4 +58,5 @@ export const middleware = router.named({
   orgDancer: () => import("#middleware/routes/org-dancer"),
   orgFeature: () => import("#middleware/routes/org-feature"),
   orgEvent: () => import("#middleware/routes/org-event"),
+  orgEventDancer: () => import("#middleware/routes/org-event-dancer"),
 });

--- a/apps/frontend/src/features/org/api/scouting-queries.ts
+++ b/apps/frontend/src/features/org/api/scouting-queries.ts
@@ -7,6 +7,7 @@ export const scoutingQueries = {
       search?: string;
       bib?: number;
       interested?: boolean;
+      eventId?: string;
     } = {},
   ) =>
     $api.queryOptions("get", "/orgs/{slug}/dancers", {
@@ -52,9 +53,7 @@ export const scoutingQueries = {
       params: { path: { slug } },
     }),
   publishedCallbacks: (slug: string, showcaseId: string) =>
-    $api.queryOptions(
-      "get",
-      "/orgs/{slug}/showcases/{showcaseId}/callbacks",
-      { params: { path: { slug, showcaseId } } },
-    ),
+    $api.queryOptions("get", "/orgs/{slug}/showcases/{showcaseId}/callbacks", {
+      params: { path: { slug, showcaseId } },
+    }),
 };

--- a/apps/frontend/src/features/org/components/coach-event-access-banner.tsx
+++ b/apps/frontend/src/features/org/components/coach-event-access-banner.tsx
@@ -1,0 +1,45 @@
+import { format, parseISO } from "date-fns";
+import { CalendarClockIcon, SearchIcon } from "lucide-react";
+import { Link } from "@tanstack/react-router";
+
+import {
+  Alert,
+  AlertAction,
+  AlertDescription,
+  AlertTitle,
+} from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+
+export function CoachEventAccessBanner({
+  orgSlug,
+  eventName,
+  startDate,
+}: {
+  orgSlug: string;
+  eventName: string;
+  startDate: string;
+}) {
+  const formattedStartDate = format(parseISO(startDate), "MMMM d, yyyy");
+
+  return (
+    <Alert variant="info" className="rounded-none border-x-0 px-4 py-4">
+      <CalendarClockIcon />
+      <AlertTitle>
+        You’re registered for {eventName} on {formattedStartDate}
+      </AlertTitle>
+      <AlertDescription>
+        Ratings, favorites, notes, and callbacks unlock during your event. You
+        can browse dancers from every event now.
+      </AlertDescription>
+      <AlertAction>
+        <Button
+          variant="outline"
+          render={<Link to="/o/$orgSlug/coach/dancers" params={{ orgSlug }} />}
+        >
+          <SearchIcon />
+          Browse all dancers
+        </Button>
+      </AlertAction>
+    </Alert>
+  );
+}

--- a/apps/frontend/src/features/org/components/dancer-filter-toolbar.tsx
+++ b/apps/frontend/src/features/org/components/dancer-filter-toolbar.tsx
@@ -1,5 +1,13 @@
 import type { RefObject } from "react";
-import { Heart, Megaphone, PencilIcon, SchoolIcon, SearchIcon, StarIcon, XIcon } from "lucide-react";
+import {
+  Heart,
+  Megaphone,
+  PencilIcon,
+  SchoolIcon,
+  SearchIcon,
+  StarIcon,
+  XIcon,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   InputGroup,
@@ -29,6 +37,9 @@ const GPA_BUCKETS = [
 ];
 
 interface DancerFilterToolbarProps {
+  eventId: string | null;
+  onEventIdChange: (value: string | null) => void;
+  events: Array<{ id: string; name: string }>;
   search: string;
   onSearchChange: (value: string) => void;
   yearFilter: number | null;
@@ -87,6 +98,9 @@ function IconToggle({
 }
 
 export function DancerFilterToolbar({
+  eventId,
+  onEventIdChange,
+  events,
   search,
   onSearchChange,
   yearFilter,
@@ -111,6 +125,7 @@ export function DancerFilterToolbar({
   searchRef,
 }: DancerFilterToolbarProps) {
   const hasActiveFilters =
+    eventId !== null ||
     yearFilter !== null ||
     gpaFilter !== null ||
     stateFilter !== null ||
@@ -121,6 +136,7 @@ export function DancerFilterToolbar({
     calledBack;
 
   const clearAll = () => {
+    onEventIdChange(null);
     onYearFilterChange(null);
     onGpaFilterChange(null);
     onStateFilterChange(null);
@@ -152,6 +168,29 @@ export function DancerFilterToolbar({
 
       {/* Data filters */}
       <div className="flex items-center gap-1.5">
+        <Select
+          items={[
+            { label: "All events", value: "all" },
+            ...events.map((event) => ({ label: event.name, value: event.id })),
+          ]}
+          value={eventId ?? "all"}
+          onValueChange={(value) =>
+            onEventIdChange(value === "all" ? null : value)
+          }
+        >
+          <SelectTrigger size="sm" className="min-w-36">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectPopup>
+            <SelectItem value="all">All events</SelectItem>
+            {events.map((event) => (
+              <SelectItem key={event.id} value={event.id}>
+                {event.name}
+              </SelectItem>
+            ))}
+          </SelectPopup>
+        </Select>
+
         <Select
           value={yearFilter}
           onValueChange={(v) => onYearFilterChange(v as number | null)}

--- a/apps/frontend/src/features/org/components/dancer-table/columns.tsx
+++ b/apps/frontend/src/features/org/components/dancer-table/columns.tsx
@@ -1,8 +1,14 @@
+/* eslint-disable react-refresh/only-export-components -- column factories intentionally return render components */
 import type { ColumnDef } from "@tanstack/react-table";
 import { Link } from "@tanstack/react-router";
 import { Heart, Megaphone, PencilIcon, PlusIcon, StarIcon } from "lucide-react";
 import { Rating, RatingItem } from "@/components/ui/rating";
-import { Tooltip, TooltipPopup, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  Tooltip,
+  TooltipPopup,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { Checkbox } from "@/components/ui/checkbox";
 import { cn } from "@/components/utils/cn";
 
@@ -10,7 +16,9 @@ function NotesIndicator() {
   return (
     <TooltipProvider delay={0}>
       <Tooltip>
-        <TooltipTrigger render={<span className="flex items-center justify-center" />}>
+        <TooltipTrigger
+          render={<span className="flex items-center justify-center" />}
+        >
           <PencilIcon className="text-primary size-4" />
         </TooltipTrigger>
         <TooltipPopup>You have notes for this dancer</TooltipPopup>
@@ -32,6 +40,7 @@ export interface DancerRow {
 }
 
 export interface SearchDancerRow extends DancerRow {
+  eventId: string;
   interestedInMySchool: boolean;
   isFavorited: boolean;
   isCalledBack: boolean;
@@ -39,7 +48,6 @@ export interface SearchDancerRow extends DancerRow {
   rating: number | null;
   username?: string | null;
 }
-
 
 export const bibColumn: ColumnDef<DancerRow> = {
   accessorKey: "bibNumber",
@@ -122,63 +130,71 @@ export const gpaColumn: ColumnDef<DancerRow> = {
 
 export function favoriteToggleColumn(
   onToggle: (rosterId: string, current: boolean) => void,
+  canInteract: (dancer: SearchDancerRow) => boolean = () => true,
 ): ColumnDef<SearchDancerRow> {
   return {
     id: "favorite",
-    header: () => <span title="Favorite"><Heart className="text-muted-foreground size-4" /></span>,
+    header: () => (
+      <span title="Favorite">
+        <Heart className="text-muted-foreground size-4" />
+      </span>
+    ),
     size: 40,
     enableSorting: false,
-    cell: ({ row }) => (
-      <button
-        type="button"
-        onClick={(e) => {
-          e.stopPropagation();
-          onToggle(row.original.rosterId, row.original.isFavorited);
-        }}
-        className="flex cursor-pointer items-center justify-center"
-        aria-label={
-          row.original.isFavorited ? "Unfavorite" : "Favorite"
-        }
-      >
-        <Heart
-          className={`size-4 ${
-            row.original.isFavorited
-              ? "fill-current text-red-500"
-              : "text-muted-foreground"
-          }`}
-        />
-      </button>
-    ),
+    cell: ({ row }) =>
+      canInteract(row.original) ? (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggle(row.original.rosterId, row.original.isFavorited);
+          }}
+          className="flex cursor-pointer items-center justify-center"
+          aria-label={row.original.isFavorited ? "Unfavorite" : "Favorite"}
+        >
+          <Heart
+            className={`size-4 ${
+              row.original.isFavorited
+                ? "fill-current text-red-500"
+                : "text-muted-foreground"
+            }`}
+          />
+        </button>
+      ) : null,
   };
 }
 
 export function callbackToggleColumn(
   onToggle: (rosterId: string, current: boolean) => void,
+  canInteract: (dancer: SearchDancerRow) => boolean = () => true,
 ): ColumnDef<SearchDancerRow> {
   return {
     id: "callback",
     header: "Callback",
     size: 100,
     enableSorting: false,
-    cell: ({ row }) => (
-      <button
-        type="button"
-        onClick={(e) => {
-          e.stopPropagation();
-          onToggle(row.original.rosterId, row.original.isCalledBack);
-        }}
-        className={`flex cursor-pointer items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold transition-colors ${
-          row.original.isCalledBack
-            ? "bg-foreground text-background"
-            : "text-muted-foreground hover:text-foreground"
-        }`}
-        aria-label={row.original.isCalledBack ? "Remove callback" : "Call back"}
-        aria-pressed={row.original.isCalledBack}
-      >
-        <Megaphone className="size-3" />
-        {row.original.isCalledBack ? "Called" : "Call"}
-      </button>
-    ),
+    cell: ({ row }) =>
+      canInteract(row.original) ? (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggle(row.original.rosterId, row.original.isCalledBack);
+          }}
+          className={`flex cursor-pointer items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold transition-colors ${
+            row.original.isCalledBack
+              ? "bg-foreground text-background"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+          aria-label={
+            row.original.isCalledBack ? "Remove callback" : "Call back"
+          }
+          aria-pressed={row.original.isCalledBack}
+        >
+          <Megaphone className="size-3" />
+          {row.original.isCalledBack ? "Called" : "Call"}
+        </button>
+      ) : null,
   };
 }
 
@@ -188,7 +204,11 @@ export const notesIndicatorColumn: ColumnDef<{
   note?: string | null;
 }> = {
   id: "notes",
-  header: () => <span className="flex items-center justify-center" title="Notes"><PencilIcon className="size-4 text-muted-foreground" /></span>,
+  header: () => (
+    <span className="flex items-center justify-center" title="Notes">
+      <PencilIcon className="text-muted-foreground size-4" />
+    </span>
+  ),
   size: 40,
   enableSorting: false,
   cell: ({ row }) => {
@@ -202,7 +222,11 @@ export const notesIndicatorColumn: ColumnDef<{
 
 export const schoolInterestColumn: ColumnDef<SearchDancerRow> = {
   id: "schoolInterest",
-  header: () => <span title="Interested in your school"><StarIcon className="size-3.5 text-muted-foreground" /></span>,
+  header: () => (
+    <span title="Interested in your school">
+      <StarIcon className="text-muted-foreground size-3.5" />
+    </span>
+  ),
   size: 40,
   enableSorting: false,
   cell: ({ row }) =>
@@ -242,20 +266,19 @@ export function selectColumn<T>(): ColumnDef<T> {
 
 export function ratingQuickActionColumn(
   onRate: (rosterId: string, rating: number) => void,
+  canInteract: (dancer: SearchDancerRow) => boolean = () => true,
 ): ColumnDef<SearchDancerRow> {
   return {
     accessorKey: "rating",
     header: "Rating",
     size: 120,
     cell: ({ row }) => {
+      if (!canInteract(row.original)) return null;
       const rating = row.original.rating;
       return (
-        <div
-          className="flex items-center"
-          onClick={(e) => e.stopPropagation()}
-        >
+        <div className="flex items-center" onClick={(e) => e.stopPropagation()}>
           {rating == null && (
-            <span className="text-muted-foreground text-sm group-hover/row:hidden group-focus-within/row:hidden">
+            <span className="text-muted-foreground text-sm group-focus-within/row:hidden group-hover/row:hidden">
               —
             </span>
           )}
@@ -266,8 +289,8 @@ export function ratingQuickActionColumn(
             className={cn(
               "transition-opacity",
               rating == null
-                ? "hidden group-hover/row:flex group-focus-within/row:flex"
-                : "pointer-events-none group-hover/row:pointer-events-auto group-focus-within/row:pointer-events-auto",
+                ? "hidden group-focus-within/row:flex group-hover/row:flex"
+                : "pointer-events-none group-focus-within/row:pointer-events-auto group-hover/row:pointer-events-auto",
             )}
           >
             {Array.from({ length: 5 }, (_, i) => (
@@ -282,6 +305,7 @@ export function ratingQuickActionColumn(
 
 export function notesQuickActionColumn(
   onOpenNotes: (rosterId: string) => void,
+  canInteract: (dancer: SearchDancerRow) => boolean = () => true,
 ): ColumnDef<SearchDancerRow> {
   return {
     id: "notes",
@@ -293,6 +317,7 @@ export function notesQuickActionColumn(
     size: 40,
     enableSorting: false,
     cell: ({ row }) => {
+      if (!canInteract(row.original)) return null;
       const hasNote = row.original.hasNote;
       const Icon = hasNote ? PencilIcon : PlusIcon;
       return (

--- a/apps/frontend/src/features/org/components/dancer-table/dancer-card.tsx
+++ b/apps/frontend/src/features/org/components/dancer-table/dancer-card.tsx
@@ -9,6 +9,7 @@ interface DancerCardProps {
   onRate: (rosterId: string, rating: number) => void;
   onOpenNotes: (rosterId: string) => void;
   onCallbackToggle?: (rosterId: string, current: boolean) => void;
+  readOnly?: boolean;
 }
 
 export function DancerCard({
@@ -17,6 +18,7 @@ export function DancerCard({
   onRate,
   onOpenNotes,
   onCallbackToggle,
+  readOnly = false,
 }: DancerCardProps) {
   const NoteIcon = dancer.hasNote ? PencilIcon : PlusIcon;
 
@@ -25,7 +27,10 @@ export function DancerCard({
       {/* Header: bib + school interest */}
       <div className="flex items-center justify-between">
         <span className="font-mono text-sm font-semibold">
-          #{dancer.bibNumber != null ? String(dancer.bibNumber).padStart(2, "0") : "—"}
+          #
+          {dancer.bibNumber != null
+            ? String(dancer.bibNumber).padStart(2, "0")
+            : "—"}
         </span>
         {dancer.interestedInMySchool && (
           <span className="text-sm text-amber-500">{"★"}</span>
@@ -44,69 +49,75 @@ export function DancerCard({
       </span>
 
       {/* Action bar */}
-      <div className="mt-1 flex items-center gap-3">
-        {/* Favorite toggle */}
-        <button
-          type="button"
-          onClick={() => onFavoriteToggle(dancer.rosterId, dancer.isFavorited)}
-          className="flex cursor-pointer items-center justify-center"
-          aria-label={dancer.isFavorited ? "Unfavorite" : "Favorite"}
-        >
-          <Heart
-            className={`size-4 ${
-              dancer.isFavorited
-                ? "fill-current text-red-500"
-                : "text-muted-foreground"
-            }`}
-          />
-        </button>
-
-        {/* Interactive rating */}
-        <Rating
-          size="sm"
-          value={dancer.rating ?? 0}
-          onValueChange={(v) => onRate(dancer.rosterId, v)}
-        >
-          {Array.from({ length: 5 }, (_, i) => (
-            <RatingItem key={i} index={i} />
-          ))}
-        </Rating>
-
-        {/* Callback pill */}
-        {onCallbackToggle && (
+      {!readOnly && (
+        <div className="mt-1 flex items-center gap-3">
+          {/* Favorite toggle */}
           <button
             type="button"
-            onClick={() => onCallbackToggle(dancer.rosterId, dancer.isCalledBack)}
-            className={`flex cursor-pointer items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold transition-colors ${
-              dancer.isCalledBack
-                ? "bg-foreground text-background"
-                : "text-muted-foreground hover:text-foreground"
-            }`}
-            aria-label={dancer.isCalledBack ? "Remove callback" : "Call back"}
-            aria-pressed={dancer.isCalledBack}
+            onClick={() =>
+              onFavoriteToggle(dancer.rosterId, dancer.isFavorited)
+            }
+            className="flex cursor-pointer items-center justify-center"
+            aria-label={dancer.isFavorited ? "Unfavorite" : "Favorite"}
           >
-            <Megaphone className="size-3" />
-            {dancer.isCalledBack ? "Called" : "Call"}
+            <Heart
+              className={`size-4 ${
+                dancer.isFavorited
+                  ? "fill-current text-red-500"
+                  : "text-muted-foreground"
+              }`}
+            />
           </button>
-        )}
 
-        {/* Notes button */}
-        <button
-          type="button"
-          onClick={() => onOpenNotes(dancer.rosterId)}
-          className="text-muted-foreground hover:text-foreground flex cursor-pointer items-center justify-center transition-colors"
-          aria-label={dancer.hasNote ? "Edit notes" : "Add notes"}
-        >
-          <NoteIcon className="size-4" />
-        </button>
-      </div>
+          {/* Interactive rating */}
+          <Rating
+            size="sm"
+            value={dancer.rating ?? 0}
+            onValueChange={(v) => onRate(dancer.rosterId, v)}
+          >
+            {Array.from({ length: 5 }, (_, i) => (
+              <RatingItem key={i} index={i} />
+            ))}
+          </Rating>
+
+          {/* Callback pill */}
+          {onCallbackToggle && (
+            <button
+              type="button"
+              onClick={() =>
+                onCallbackToggle(dancer.rosterId, dancer.isCalledBack)
+              }
+              className={`flex cursor-pointer items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold transition-colors ${
+                dancer.isCalledBack
+                  ? "bg-foreground text-background"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+              aria-label={dancer.isCalledBack ? "Remove callback" : "Call back"}
+              aria-pressed={dancer.isCalledBack}
+            >
+              <Megaphone className="size-3" />
+              {dancer.isCalledBack ? "Called" : "Call"}
+            </button>
+          )}
+
+          {/* Notes button */}
+          <button
+            type="button"
+            onClick={() => onOpenNotes(dancer.rosterId)}
+            className="text-muted-foreground hover:text-foreground flex cursor-pointer items-center justify-center transition-colors"
+            aria-label={dancer.hasNote ? "Edit notes" : "Add notes"}
+          >
+            <NoteIcon className="size-4" />
+          </button>
+        </div>
+      )}
 
       {/* Profile link */}
       {dancer.username && (
         <Link
           to="/$username"
           params={{ username: dancer.username }}
-          className="border-border text-foreground mt-1 flex w-full items-center justify-center rounded-md border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-accent"
+          className="border-border text-foreground hover:bg-accent mt-1 flex w-full items-center justify-center rounded-md border px-3 py-1.5 text-sm font-medium transition-colors"
         >
           Visit Profile →
         </Link>

--- a/apps/frontend/src/features/org/components/dancer-table/dancer-table.tsx
+++ b/apps/frontend/src/features/org/components/dancer-table/dancer-table.tsx
@@ -44,6 +44,7 @@ interface DancerTableProps<T> {
   onSortingChange?: OnChangeFn<SortingState>;
   pageSize?: number;
   enableSelection?: boolean;
+  isRowSelectable?: (row: T) => boolean;
   rowSelection?: RowSelectionState;
   onRowSelectionChange?: OnChangeFn<RowSelectionState>;
 }
@@ -60,6 +61,7 @@ export function DancerTable<T extends { rosterId: string }>({
   onSortingChange: onSortingChangeProp,
   pageSize = 25,
   enableSelection,
+  isRowSelectable,
   rowSelection,
   onRowSelectionChange,
 }: DancerTableProps<T>) {
@@ -81,7 +83,9 @@ export function DancerTable<T extends { rosterId: string }>({
     return () => container.removeEventListener("scroll", onScroll);
   }, []);
 
-  const [internalSorting, setInternalSorting] = useState<SortingState>(sortingProp ?? []);
+  const [internalSorting, setInternalSorting] = useState<SortingState>(
+    sortingProp ?? [],
+  );
   const isControlled = onSortingChangeProp !== undefined;
   const sorting = isControlled ? (sortingProp ?? []) : internalSorting;
   const setSorting = isControlled ? onSortingChangeProp : setInternalSorting;
@@ -90,7 +94,9 @@ export function DancerTable<T extends { rosterId: string }>({
     columns,
     data,
     enableSortingRemoval: false,
-    enableRowSelection: enableSelection,
+    enableRowSelection: isRowSelectable
+      ? (row) => isRowSelectable(row.original)
+      : enableSelection,
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
@@ -115,7 +121,7 @@ export function DancerTable<T extends { rosterId: string }>({
       <div className="flex flex-col gap-2 sm:hidden">
         {isLoading ? (
           <div className="relative">
-            <div className="pointer-events-none select-none blur-[2px] opacity-40">
+            <div className="pointer-events-none opacity-40 blur-[2px] select-none">
               {Array.from({ length: 3 }, (_, i) => (
                 <div
                   key={`placeholder-${i}`}
@@ -175,9 +181,14 @@ export function DancerTable<T extends { rosterId: string }>({
       </div>
 
       {/* Desktop Table View */}
-      <Frame ref={frameRef} className="relative hidden w-full min-h-0 flex-1 overflow-hidden sm:flex sm:flex-col *:data-[slot=table-container]:min-h-0 *:data-[slot=table-container]:flex-1 *:data-[slot=table-container]:overflow-y-auto *:data-[slot=table-container]:[scrollbar-width:thin]">
+      <Frame
+        ref={frameRef}
+        className="relative hidden min-h-0 w-full flex-1 overflow-hidden *:data-[slot=table-container]:min-h-0 *:data-[slot=table-container]:flex-1 *:data-[slot=table-container]:overflow-y-auto *:data-[slot=table-container]:[scrollbar-width:thin] sm:flex sm:flex-col"
+      >
         <Table className={isLoading || !paginatedRows.length ? "h-full" : ""}>
-          <TableHeader className={`sticky top-0 z-10 [&_th]:transition-colors ${isScrolled ? "[&_th]:bg-[#f8f8f8] dark:[&_th]:bg-[#18181A]" : ""}`}>
+          <TableHeader
+            className={`sticky top-0 z-10 [&_th]:transition-colors ${isScrolled ? "[&_th]:bg-[#f8f8f8] dark:[&_th]:bg-[#18181A]" : ""}`}
+          >
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow className="hover:bg-transparent" key={headerGroup.id}>
                 {headerGroup.headers.map((header) => {
@@ -236,20 +247,23 @@ export function DancerTable<T extends { rosterId: string }>({
           <TableBody>
             {isLoading ? (
               Array.from({ length: 5 }, (_, i) => (
-                <TableRow key={`placeholder-${i}`} className="pointer-events-none opacity-0">
+                <TableRow
+                  key={`placeholder-${i}`}
+                  className="pointer-events-none opacity-0"
+                >
                   {Array.from({ length: columns.length }, (_, j) => (
-                    <TableCell key={`placeholder-${i}-${j}`}>
-                      &nbsp;
-                    </TableCell>
+                    <TableCell key={`placeholder-${i}-${j}`}>&nbsp;</TableCell>
                   ))}
                 </TableRow>
               ))
             ) : paginatedRows.length ? (
               paginatedRows.map((row) => (
                 <TableRow
-                  className={`group/row${onRowClick ? " cursor-pointer" : ""}`}
+                  className={`group/row${onRowClick ? "cursor-pointer" : ""}`}
                   key={row.id}
-                  onClick={onRowClick ? () => onRowClick(row.original) : undefined}
+                  onClick={
+                    onRowClick ? () => onRowClick(row.original) : undefined
+                  }
                 >
                   {row.getVisibleCells().map((cell) => (
                     <TableCell key={cell.id}>

--- a/apps/frontend/src/features/org/components/dancer-table/use-dancer-columns.ts
+++ b/apps/frontend/src/features/org/components/dancer-table/use-dancer-columns.ts
@@ -18,13 +18,14 @@ import {
 } from "./columns";
 
 export function useSearchColumns(
-  onFavoriteToggle: (rosterId: string, current: boolean) => void,
+  onFavoriteToggle?: (rosterId: string, current: boolean) => void,
   opts?: {
     enableSelection?: boolean;
     onRate?: (rosterId: string, rating: number) => void;
     onOpenNotes?: (rosterId: string) => void;
     onCallbackToggle?: (rosterId: string, current: boolean) => void;
     showRank?: boolean;
+    canScoutDancer?: (dancer: SearchDancerRow) => boolean;
   },
 ): ColumnDef<SearchDancerRow>[] {
   return useMemo(() => {
@@ -47,23 +48,32 @@ export function useSearchColumns(
     );
 
     if (opts?.onRate) {
-      cols.push(ratingQuickActionColumn(opts.onRate));
+      cols.push(ratingQuickActionColumn(opts.onRate, opts.canScoutDancer));
     } else {
       cols.push(ratingDisplayColumn() as ColumnDef<SearchDancerRow>);
     }
 
-    cols.push(favoriteToggleColumn(onFavoriteToggle));
+    if (onFavoriteToggle) {
+      cols.push(favoriteToggleColumn(onFavoriteToggle, opts?.canScoutDancer));
+    }
 
     if (opts?.onCallbackToggle) {
-      cols.push(callbackToggleColumn(opts.onCallbackToggle));
+      cols.push(
+        callbackToggleColumn(opts.onCallbackToggle, opts.canScoutDancer),
+      );
     }
 
     if (opts?.onOpenNotes) {
-      cols.push(notesQuickActionColumn(opts.onOpenNotes) as ColumnDef<SearchDancerRow>);
+      cols.push(
+        notesQuickActionColumn(
+          opts.onOpenNotes,
+          opts.canScoutDancer,
+        ) as ColumnDef<SearchDancerRow>,
+      );
     }
 
     cols.push(schoolInterestColumn);
 
     return cols;
-  }, [onFavoriteToggle, opts?.enableSelection, opts?.onRate, opts?.onOpenNotes, opts?.onCallbackToggle, opts?.showRank]);
+  }, [onFavoriteToggle, opts]);
 }

--- a/apps/frontend/src/features/org/components/roster-detail-sheet.tsx
+++ b/apps/frontend/src/features/org/components/roster-detail-sheet.tsx
@@ -164,7 +164,7 @@ export function RosterDetailSheet({
   };
 
   const handleResendInvite = async () => {
-    if (!entry || entry.type !== "dancer") return;
+    if (!entry) return;
     try {
       const result = await resendMutation.mutateAsync({
         params: { path: { slug: orgSlug, id: eventId } },
@@ -513,7 +513,7 @@ export function RosterDetailSheet({
           </SheetContent>
           <SheetFooter>
             <div className="flex w-full items-center justify-end gap-2">
-              {!isActive && isDancer && (
+              {!isActive && (
                 <Button
                   type="button"
                   variant="ghost"

--- a/apps/frontend/src/features/org/context/org-context.ts
+++ b/apps/frontend/src/features/org/context/org-context.ts
@@ -9,6 +9,11 @@ export interface MyRoster {
   id: string;
   eventId: string;
   type: "coach" | "dancer";
+  eventName: string;
+  eventStartDate: string;
+  eventEndDate: string;
+  isActive: boolean;
+  hasStarted: boolean;
 }
 
 export interface OrgContextValue {

--- a/apps/frontend/src/lib/api/types.d.ts
+++ b/apps/frontend/src/lib/api/types.d.ts
@@ -4627,13 +4627,14 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * List dancers in active event
-         * @description Coach-scoped dancer search by name or bib number.
+         * List dancers across organization events
+         * @description Coach-scoped dancer search by name, bib number, or event.
          */
         get: {
             parameters: {
                 query?: {
                     search?: string | null;
+                    eventId?: string | null;
                     interested?: (string | number | boolean) | null;
                     bib?: (string | number) | null;
                 };
@@ -4652,15 +4653,6 @@ export interface paths {
                     };
                     content: {
                         "application/json": components["schemas"]["OrgsIdDancersResponse"];
-                    };
-                };
-                /** @description Unprocessable Entity */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
                     };
                 };
             };
@@ -10402,6 +10394,11 @@ export interface components {
                 id: string;
                 eventId: string;
                 type: components["schemas"]["UploadKind"];
+                eventName: string;
+                eventStartDate: string;
+                eventEndDate: string;
+                isActive: boolean;
+                hasStarted: boolean;
             } | null;
         };
         OrgsIdEventsResponse: {
@@ -10909,6 +10906,7 @@ export interface components {
             hasNote: boolean;
             isCalledBack: boolean;
             username: string | null;
+            eventId: string;
         }[];
         OrgsIdDancersIdResponse: {
             note: string | null;
@@ -10920,6 +10918,7 @@ export interface components {
             studio: string | null;
             gpa: number | null;
             gradYear: number | null;
+            eventId: string;
             rating: number | null;
             bibNumber: number | null;
             rosterId: string;

--- a/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/admin/coaches.tsx
+++ b/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/admin/coaches.tsx
@@ -7,6 +7,7 @@ import {
   downloadRosterCsv,
   rosterQueries,
   useDeleteRosters,
+  useResendInvites,
   useUpdateRoster,
 } from "@/features/org/api/roster-queries";
 import { DataGrid, StatusBadge } from "@/features/org/components/data-grid";
@@ -134,6 +135,7 @@ function CoachesPage() {
 
   const updateMutation = useUpdateRoster();
   const deleteMutation = useDeleteRosters();
+  const resendMutation = useResendInvites();
 
   const handleRowClick = (row: RosterEntry) => {
     setSelectedEntry(row);
@@ -203,6 +205,32 @@ function CoachesPage() {
 
   const bulkActions = rosterBulkActions({
     onExport: handleExport,
+    onResendInvite: async (ids: string[]) => {
+      if (!active) return;
+      toastManager.add({
+        title: `Resending invites to ${ids.length} coach${ids.length === 1 ? "" : "es"}…`,
+        type: "info",
+      });
+      try {
+        const result = await resendMutation.mutateAsync({
+          params: { path: { slug: orgSlug, id: active.id } },
+          body: { ids },
+        });
+        if (result.failed.length > 0) {
+          toastManager.add({
+            title: `Resent ${result.sent}, ${result.failed.length} failed`,
+            type: "warning",
+          });
+        } else {
+          toastManager.add({
+            title: `Resent ${result.sent} invite${result.sent === 1 ? "" : "s"}${result.skipped ? ` (${result.skipped} skipped)` : ""}`,
+            type: "success",
+          });
+        }
+      } catch {
+        toastManager.add({ title: "Failed to resend invites", type: "error" });
+      }
+    },
     onDelete: async (ids: string[]) => {
       if (!active) return;
       try {

--- a/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/coach/dancers/index.tsx
+++ b/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/coach/dancers/index.tsx
@@ -1,13 +1,15 @@
 import { createFileRoute, useParams } from "@tanstack/react-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
-import { formatDistanceToNow } from "date-fns";
 import {
-  HeartIcon,
-  PencilIcon,
-  StarIcon,
-  XIcon,
-} from "lucide-react";
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { formatDistanceToNow } from "date-fns";
+import { HeartIcon, PencilIcon, StarIcon, XIcon } from "lucide-react";
 import { $api } from "@/lib/api/client";
 import { scoutingQueries } from "@/features/org/api/scouting-queries";
 import { useOrg } from "@/features/org/context/use-org";
@@ -17,7 +19,10 @@ import { DancerSheet } from "@/features/org/components/dancer-sheet";
 import { DancerFilterToolbar } from "@/features/org/components/dancer-filter-toolbar";
 import { useSearchColumns } from "@/features/org/components/dancer-table/use-dancer-columns";
 import type { SearchDancerRow } from "@/features/org/components/dancer-table/columns";
-import { StatCell, SidebarSection } from "@/features/org/components/dashboard-shared";
+import {
+  StatCell,
+  SidebarSection,
+} from "@/features/org/components/dashboard-shared";
 import { Rating, RatingItem } from "@/components/ui/rating";
 import type { RowSelectionState, SortingState } from "@tanstack/react-table";
 import { FloatingActionBar } from "@/features/org/components/floating-action-bar";
@@ -25,6 +30,8 @@ import { CompareView } from "@/features/org/components/compare-view";
 import { toastManager } from "@/components/ui/toast-manager";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
+import { adminQueries } from "@/features/org/api/admin-queries";
+import type { components } from "@/lib/api/types";
 
 export const Route = createFileRoute(
   "/_org/o/$orgSlug/_authenticated/coach/dancers/",
@@ -45,6 +52,13 @@ type ActivityItem = {
   timestamp: Date;
 };
 
+type DancerList = components["schemas"]["OrgsIdDancersResponse"];
+type FavoritesList = components["schemas"]["OrgsIdFavoritesResponse"];
+type MutationContext = {
+  previous?: DancerList;
+  previousFavs?: FavoritesList;
+};
+
 /* ------------------------------------------------------------------ */
 /*  Page component                                                     */
 /* ------------------------------------------------------------------ */
@@ -53,8 +67,14 @@ function DancerSearch() {
   const { orgSlug } = useParams({
     from: "/_org/o/$orgSlug/_authenticated/coach/dancers/",
   });
-  const { org, hasFeature } = useOrg();
+  const { org, hasFeature, myRoster } = useOrg();
   const callbacksEnabled = hasFeature("callbacks");
+  const canScout = Boolean(myRoster?.isActive && myRoster.hasStarted);
+  const canScoutDancer = useCallback(
+    (dancer: SearchDancerRow) =>
+      canScout && dancer.eventId === myRoster?.eventId,
+    [canScout, myRoster?.eventId],
+  );
 
   /* --- Filter state --- */
   const [search, setSearch] = useState("");
@@ -66,15 +86,28 @@ function DancerSearch() {
   const [rated, setRated] = useState(false);
   const [hasNotes, setHasNotes] = useState(false);
   const [calledBack, setCalledBack] = useState(false);
+  const [eventId, setEventId] = useState<string | null>(null);
   const deferredSearch = useDeferredValue(search);
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
   useEffect(() => {
     setRowSelection({});
-  }, [yearFilter, gpaFilter, stateFilter, interested, favorited, rated, hasNotes, calledBack]);
+  }, [
+    eventId,
+    yearFilter,
+    gpaFilter,
+    stateFilter,
+    interested,
+    favorited,
+    rated,
+    hasNotes,
+    calledBack,
+  ]);
 
-  const [sorting, setSorting] = useState<SortingState>([{ id: "bibNumber", desc: false }]);
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: "bibNumber", desc: false },
+  ]);
 
   useEffect(() => {
     if (rated) {
@@ -85,10 +118,18 @@ function DancerSearch() {
   }, [rated]);
 
   /* --- Data --- */
+  const dancerParams = {
+    interested: interested || undefined,
+    eventId: eventId ?? undefined,
+  };
   const { data: dancers, isLoading } = useQuery(
-    scoutingQueries.dancers(orgSlug, { interested: interested || undefined }),
+    scoutingQueries.dancers(orgSlug, dancerParams),
   );
-  const { data: favorites } = useQuery(scoutingQueries.favorites(orgSlug));
+  const { data: favorites } = useQuery({
+    ...scoutingQueries.favorites(orgSlug),
+    enabled: canScout,
+  });
+  const { data: events } = useQuery(adminQueries.events(orgSlug));
 
   /* --- Compare clipboard --- */
   const [compareIds, setCompareIds] = useState<string[]>([]);
@@ -104,7 +145,9 @@ function DancerSearch() {
   /* --- Activity feed --- */
   const [activity, setActivity] = useState<ActivityItem[]>([]);
   const addActivity = useCallback((item: Omit<ActivityItem, "timestamp">) => {
-    setActivity((prev) => [{ ...item, timestamp: new Date() }, ...prev].slice(0, 5));
+    setActivity((prev) =>
+      [{ ...item, timestamp: new Date() }, ...prev].slice(0, 5),
+    );
   }, []);
 
   /* --- Sheet --- */
@@ -112,7 +155,7 @@ function DancerSearch() {
 
   /* --- Favorite toggle (optimistic on dancers list) --- */
   const qc = useQueryClient();
-  const dancersKey = scoutingQueries.dancers(orgSlug, { interested: interested || undefined }).queryKey;
+  const dancersKey = scoutingQueries.dancers(orgSlug, dancerParams).queryKey;
 
   const favKey = scoutingQueries.favorites(orgSlug).queryKey;
 
@@ -120,26 +163,46 @@ function DancerSearch() {
     onMutate: async ({ body }) => {
       await qc.cancelQueries({ queryKey: dancersKey });
       await qc.cancelQueries({ queryKey: favKey });
-      const previous = qc.getQueryData(dancersKey);
-      const previousFavs = qc.getQueryData(favKey);
-      const dancer = (dancers ?? []).find((d) => d.rosterId === body?.dancerRosterId);
-      qc.setQueryData(dancersKey, (old: any) =>
+      const previous = qc.getQueryData<DancerList>(dancersKey);
+      const previousFavs = qc.getQueryData<FavoritesList>(favKey);
+      const dancer = (dancers ?? []).find(
+        (d) => d.rosterId === body?.dancerRosterId,
+      );
+      qc.setQueryData<DancerList>(dancersKey, (old) =>
         Array.isArray(old)
-          ? old.map((d: any) =>
-              d.rosterId === body?.dancerRosterId ? { ...d, isFavorited: true } : d,
+          ? old.map((d) =>
+              d.rosterId === body?.dancerRosterId
+                ? { ...d, isFavorited: true }
+                : d,
             )
           : old,
       );
       if (dancer) {
-        qc.setQueryData(favKey, (old: any) =>
-          Array.isArray(old) ? [...old, { rosterId: dancer.rosterId, bibNumber: dancer.bibNumber, firstName: dancer.firstName, lastName: dancer.lastName, profilePhotoUrl: dancer.profilePhotoUrl, gradYear: dancer.gradYear, studio: dancer.studio, state: dancer.state, gpa: dancer.gpa }] : old,
+        qc.setQueryData<FavoritesList>(favKey, (old) =>
+          Array.isArray(old)
+            ? [
+                ...old,
+                {
+                  rosterId: dancer.rosterId,
+                  bibNumber: dancer.bibNumber,
+                  firstName: dancer.firstName,
+                  lastName: dancer.lastName,
+                  profilePhotoUrl: dancer.profilePhotoUrl,
+                  gradYear: dancer.gradYear,
+                  studio: dancer.studio,
+                  state: dancer.state,
+                  gpa: dancer.gpa,
+                },
+              ]
+            : old,
         );
       }
       return { previous, previousFavs };
     },
-    onError: (_err, _vars, ctx: any) => {
-      if (ctx?.previous) qc.setQueryData(dancersKey, ctx.previous);
-      if (ctx?.previousFavs) qc.setQueryData(favKey, ctx.previousFavs);
+    onError: (_err, _vars, ctx) => {
+      const context = ctx as MutationContext | undefined;
+      if (context?.previous) qc.setQueryData(dancersKey, context.previous);
+      if (context?.previousFavs) qc.setQueryData(favKey, context.previousFavs);
       toastManager.add({ title: "Couldn't favorite dancer", type: "error" });
     },
     meta: {
@@ -151,37 +214,47 @@ function DancerSearch() {
     },
   });
 
-  const removeFav = $api.useMutation("delete", "/orgs/{slug}/favorites/{dancerRosterId}", {
-    onMutate: async ({ params }) => {
-      await qc.cancelQueries({ queryKey: dancersKey });
-      await qc.cancelQueries({ queryKey: favKey });
-      const previous = qc.getQueryData(dancersKey);
-      const previousFavs = qc.getQueryData(favKey);
-      qc.setQueryData(dancersKey, (old: any) =>
-        Array.isArray(old)
-          ? old.map((d: any) =>
-              d.rosterId === params?.path?.dancerRosterId ? { ...d, isFavorited: false } : d,
-            )
-          : old,
-      );
-      qc.setQueryData(favKey, (old: any) =>
-        Array.isArray(old) ? old.filter((d: any) => d.rosterId !== params?.path?.dancerRosterId) : old,
-      );
-      return { previous, previousFavs };
+  const removeFav = $api.useMutation(
+    "delete",
+    "/orgs/{slug}/favorites/{dancerRosterId}",
+    {
+      onMutate: async ({ params }) => {
+        await qc.cancelQueries({ queryKey: dancersKey });
+        await qc.cancelQueries({ queryKey: favKey });
+        const previous = qc.getQueryData<DancerList>(dancersKey);
+        const previousFavs = qc.getQueryData<FavoritesList>(favKey);
+        qc.setQueryData<DancerList>(dancersKey, (old) =>
+          Array.isArray(old)
+            ? old.map((d) =>
+                d.rosterId === params?.path?.dancerRosterId
+                  ? { ...d, isFavorited: false }
+                  : d,
+              )
+            : old,
+        );
+        qc.setQueryData<FavoritesList>(favKey, (old) =>
+          Array.isArray(old)
+            ? old.filter((d) => d.rosterId !== params?.path?.dancerRosterId)
+            : old,
+        );
+        return { previous, previousFavs };
+      },
+      onError: (_err, _vars, ctx) => {
+        const context = ctx as MutationContext | undefined;
+        if (context?.previous) qc.setQueryData(dancersKey, context.previous);
+        if (context?.previousFavs)
+          qc.setQueryData(favKey, context.previousFavs);
+        toastManager.add({ title: "Couldn't remove favorite", type: "error" });
+      },
+      meta: {
+        invalidateQueries: [
+          scoutingQueries.favorites(orgSlug).queryKey,
+          dancersKey,
+          scoutingQueries.rankings(orgSlug).queryKey,
+        ],
+      },
     },
-    onError: (_err, _vars, ctx: any) => {
-      if (ctx?.previous) qc.setQueryData(dancersKey, ctx.previous);
-      if (ctx?.previousFavs) qc.setQueryData(favKey, ctx.previousFavs);
-      toastManager.add({ title: "Couldn't remove favorite", type: "error" });
-    },
-    meta: {
-      invalidateQueries: [
-        scoutingQueries.favorites(orgSlug).queryKey,
-        dancersKey,
-        scoutingQueries.rankings(orgSlug).queryKey,
-      ],
-    },
-  });
+  );
 
   const upsertRating = $api.useMutation(
     "put",
@@ -189,20 +262,25 @@ function DancerSearch() {
     {
       onMutate: async ({ params, body }) => {
         await qc.cancelQueries({ queryKey: dancersKey });
-        const previous = qc.getQueryData(dancersKey);
-        qc.setQueryData(dancersKey, (old: any) =>
+        const previous = qc.getQueryData<DancerList>(dancersKey);
+        qc.setQueryData<DancerList>(dancersKey, (old) =>
           Array.isArray(old)
-            ? old.map((d: any) =>
+            ? old.map((d) =>
                 d.rosterId === params?.path?.dancerRosterId
-                  ? { ...d, rating: body?.rating ?? null }
+                  ? {
+                      ...d,
+                      rating:
+                        body?.rating === undefined ? null : Number(body.rating),
+                    }
                   : d,
               )
             : old,
         );
         return { previous };
       },
-      onError: (_err, _vars, ctx: any) => {
-        if (ctx?.previous) qc.setQueryData(dancersKey, ctx.previous);
+      onError: (_err, _vars, ctx) => {
+        const context = ctx as MutationContext | undefined;
+        if (context?.previous) qc.setQueryData(dancersKey, context.previous);
         toastManager.add({ title: "Couldn't save rating", type: "error" });
       },
       meta: {
@@ -217,42 +295,52 @@ function DancerSearch() {
   const addCallback = $api.useMutation("post", "/orgs/{slug}/callbacks", {
     onMutate: async ({ body }) => {
       await qc.cancelQueries({ queryKey: dancersKey });
-      const previous = qc.getQueryData(dancersKey);
-      qc.setQueryData(dancersKey, (old: any) =>
+      const previous = qc.getQueryData<DancerList>(dancersKey);
+      qc.setQueryData<DancerList>(dancersKey, (old) =>
         Array.isArray(old)
-          ? old.map((d: any) =>
-              d.rosterId === body?.dancerRosterId ? { ...d, isCalledBack: true } : d,
+          ? old.map((d) =>
+              d.rosterId === body?.dancerRosterId
+                ? { ...d, isCalledBack: true }
+                : d,
             )
           : old,
       );
       return { previous };
     },
-    onError: (_err, _vars, ctx: any) => {
-      if (ctx?.previous) qc.setQueryData(dancersKey, ctx.previous);
+    onError: (_err, _vars, ctx) => {
+      const context = ctx as MutationContext | undefined;
+      if (context?.previous) qc.setQueryData(dancersKey, context.previous);
       toastManager.add({ title: "Couldn't add callback", type: "error" });
     },
     meta: { invalidateQueries: [dancersKey] },
   });
 
-  const removeCallback = $api.useMutation("delete", "/orgs/{slug}/callbacks/{dancerRosterId}", {
-    onMutate: async ({ params }) => {
-      await qc.cancelQueries({ queryKey: dancersKey });
-      const previous = qc.getQueryData(dancersKey);
-      qc.setQueryData(dancersKey, (old: any) =>
-        Array.isArray(old)
-          ? old.map((d: any) =>
-              d.rosterId === params?.path?.dancerRosterId ? { ...d, isCalledBack: false } : d,
-            )
-          : old,
-      );
-      return { previous };
+  const removeCallback = $api.useMutation(
+    "delete",
+    "/orgs/{slug}/callbacks/{dancerRosterId}",
+    {
+      onMutate: async ({ params }) => {
+        await qc.cancelQueries({ queryKey: dancersKey });
+        const previous = qc.getQueryData<DancerList>(dancersKey);
+        qc.setQueryData<DancerList>(dancersKey, (old) =>
+          Array.isArray(old)
+            ? old.map((d) =>
+                d.rosterId === params?.path?.dancerRosterId
+                  ? { ...d, isCalledBack: false }
+                  : d,
+              )
+            : old,
+        );
+        return { previous };
+      },
+      onError: (_err, _vars, ctx) => {
+        const context = ctx as MutationContext | undefined;
+        if (context?.previous) qc.setQueryData(dancersKey, context.previous);
+        toastManager.add({ title: "Couldn't remove callback", type: "error" });
+      },
+      meta: { invalidateQueries: [dancersKey] },
     },
-    onError: (_err, _vars, ctx: any) => {
-      if (ctx?.previous) qc.setQueryData(dancersKey, ctx.previous);
-      toastManager.add({ title: "Couldn't remove callback", type: "error" });
-    },
-    meta: { invalidateQueries: [dancersKey] },
-  });
+  );
 
   const handleFavoriteToggle = useCallback(
     (rosterId: string, current: boolean) => {
@@ -299,12 +387,9 @@ function DancerSearch() {
     [orgSlug, upsertRating, dancers, addActivity],
   );
 
-  const handleOpenNotes = useCallback(
-    (rosterId: string) => {
-      setSheetRosterId(rosterId);
-    },
-    [],
-  );
+  const handleOpenNotes = useCallback((rosterId: string) => {
+    setSheetRosterId(rosterId);
+  }, []);
 
   const handleCallbackToggle = useCallback(
     (rosterId: string, current: boolean) => {
@@ -322,13 +407,18 @@ function DancerSearch() {
     [orgSlug, addCallback, removeCallback],
   );
 
-  const columns = useSearchColumns(handleFavoriteToggle, {
-    enableSelection: true,
-    onRate: handleRate,
-    onOpenNotes: handleOpenNotes,
-    onCallbackToggle: callbacksEnabled ? handleCallbackToggle : undefined,
-    showRank: rated,
-  });
+  const columns = useSearchColumns(
+    canScout ? handleFavoriteToggle : undefined,
+    {
+      enableSelection: canScout,
+      onRate: canScout ? handleRate : undefined,
+      onOpenNotes: canScout ? handleOpenNotes : undefined,
+      onCallbackToggle:
+        canScout && callbacksEnabled ? handleCallbackToggle : undefined,
+      showRank: rated,
+      canScoutDancer,
+    },
+  );
 
   /* --- Active dancers only (registered/claimed accounts) --- */
   const activeDancers = useMemo(
@@ -339,7 +429,9 @@ function DancerSearch() {
   /* --- Derived filter options --- */
   const availableYears = useMemo(() => {
     const years = new Set(
-      activeDancers.map((d) => d.gradYear).filter((y): y is number => y != null),
+      activeDancers
+        .map((d) => d.gradYear)
+        .filter((y): y is number => y != null),
     );
     return Array.from(years).sort();
   }, [activeDancers]);
@@ -372,9 +464,13 @@ function DancerSearch() {
       if (threshold >= 3.5) {
         result = result.filter((d) => d.gpa != null && d.gpa >= 3.5);
       } else if (threshold >= 3.0) {
-        result = result.filter((d) => d.gpa != null && d.gpa >= 3.0 && d.gpa < 3.5);
+        result = result.filter(
+          (d) => d.gpa != null && d.gpa >= 3.0 && d.gpa < 3.5,
+        );
       } else if (threshold >= 2.5) {
-        result = result.filter((d) => d.gpa != null && d.gpa >= 2.5 && d.gpa < 3.0);
+        result = result.filter(
+          (d) => d.gpa != null && d.gpa >= 2.5 && d.gpa < 3.0,
+        );
       } else {
         result = result.filter((d) => d.gpa != null && d.gpa < 2.5);
       }
@@ -395,7 +491,16 @@ function DancerSearch() {
       result = result.filter((d) => d.isCalledBack);
     }
     return result;
-  }, [dancers, yearFilter, gpaFilter, stateFilter, favorited, rated, hasNotes, calledBack]);
+  }, [
+    dancers,
+    yearFilter,
+    gpaFilter,
+    stateFilter,
+    favorited,
+    rated,
+    hasNotes,
+    calledBack,
+  ]);
 
   const selectedRosterIds = useMemo(() => {
     return Object.keys(rowSelection)
@@ -479,7 +584,10 @@ function DancerSearch() {
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
       const tag = (e.target as HTMLElement)?.tagName;
-      const isInput = tag === "INPUT" || tag === "TEXTAREA" || (e.target as HTMLElement)?.isContentEditable;
+      const isInput =
+        tag === "INPUT" ||
+        tag === "TEXTAREA" ||
+        (e.target as HTMLElement)?.isContentEditable;
 
       if (e.key === "/" && !isInput) {
         e.preventDefault();
@@ -538,11 +646,21 @@ function DancerSearch() {
               <StatCell label="To Review" value={toReviewCount} accent="blue" />
               <StatCell label="Favorited" value={favCount} heart />
               {callbacksEnabled && (
-                <StatCell label="Callbacks" value={callbackCount} accent="amber" />
+                <StatCell
+                  label="Callbacks"
+                  value={callbackCount}
+                  accent="amber"
+                />
               )}
             </section>
 
             <DancerFilterToolbar
+              eventId={eventId}
+              onEventIdChange={setEventId}
+              events={(events ?? []).map((event) => ({
+                id: event.id,
+                name: event.name,
+              }))}
               search={search}
               onSearchChange={setSearch}
               yearFilter={yearFilter}
@@ -587,13 +705,17 @@ function DancerSearch() {
                     onFavoriteToggle={handleFavoriteToggle}
                     onRate={handleRate}
                     onOpenNotes={handleOpenNotes}
-                    onCallbackToggle={callbacksEnabled ? handleCallbackToggle : undefined}
+                    onCallbackToggle={
+                      callbacksEnabled ? handleCallbackToggle : undefined
+                    }
+                    readOnly={!canScoutDancer(row)}
                   />
                 )}
                 sorting={sorting}
                 onSortingChange={setSorting}
                 pageSize={50}
-                enableSelection
+                enableSelection={canScout}
+                isRowSelectable={canScoutDancer}
                 rowSelection={rowSelection}
                 onRowSelectionChange={setRowSelection}
               />
@@ -602,22 +724,26 @@ function DancerSearch() {
         )}
       </div>
 
-      <FloatingActionBar
-        selectedCount={selectedRosterIds.length}
-        isVisible={selectedRosterIds.length > 0}
-        onFavoriteAll={handleBulkFavorite}
-        onRateAll={handleBulkRate}
-        onClear={() => setRowSelection({})}
-        isLoading={isBulkLoading}
-      />
+      {canScout && (
+        <FloatingActionBar
+          selectedCount={selectedRosterIds.length}
+          isVisible={selectedRosterIds.length > 0}
+          onFavoriteAll={handleBulkFavorite}
+          onRateAll={handleBulkRate}
+          onClear={() => setRowSelection({})}
+          isLoading={isBulkLoading}
+        />
+      )}
 
       {/* Sidebar */}
       <ScoutingSidebar
         dancers={activeDancers}
         isLoading={isLoading}
-        filteredUnreviewedCount={filteredData.filter(
-          (d) => !d.isFavorited && d.rating == null && !d.hasNote,
-        ).length}
+        filteredUnreviewedCount={
+          filteredData.filter(
+            (d) => !d.isFavorited && d.rating == null && !d.hasNote,
+          ).length
+        }
         reviewedCount={reviewedCount}
         totalCount={dancerCount}
         compareIds={compareIds}
@@ -635,6 +761,11 @@ function DancerSearch() {
         onOpenChange={(open) => {
           if (!open) setSheetRosterId(null);
         }}
+        readOnly={
+          !canScout ||
+          dancers?.find((dancer) => dancer.rosterId === sheetRosterId)
+            ?.eventId !== myRoster?.eventId
+        }
         onFavoriteToggle={(rosterId, current) => {
           const dancer = dancers?.find((d) => d.rosterId === rosterId);
           if (dancer && !current) {
@@ -654,7 +785,8 @@ function DancerSearch() {
             dancerName: `${dancer.firstName} ${dancer.lastName}`,
             bibNumber: dancer.bibNumber,
           };
-          if (saved.rating != null) addActivity({ ...meta, type: "rate", rating: saved.rating });
+          if (saved.rating != null)
+            addActivity({ ...meta, type: "rate", rating: saved.rating });
           if (saved.hasNote) addActivity({ ...meta, type: "note" });
         }}
       />
@@ -728,11 +860,18 @@ function ScoutingSidebar({
 /*  Sidebar: Talent Pool Breakdown                                     */
 /* ------------------------------------------------------------------ */
 
-function TalentPoolBreakdown({ dancers, isLoading }: { dancers: DancerData[]; isLoading?: boolean }) {
+function TalentPoolBreakdown({
+  dancers,
+  isLoading,
+}: {
+  dancers: DancerData[];
+  isLoading?: boolean;
+}) {
   const yearDist = useMemo(() => {
     const counts = new Map<number, number>();
     for (const d of dancers) {
-      if (d.gradYear != null) counts.set(d.gradYear, (counts.get(d.gradYear) ?? 0) + 1);
+      if (d.gradYear != null)
+        counts.set(d.gradYear, (counts.get(d.gradYear) ?? 0) + 1);
     }
     return Array.from(counts.entries())
       .sort(([a], [b]) => a - b)
@@ -763,9 +902,10 @@ function TalentPoolBreakdown({ dancers, isLoading }: { dancers: DancerData[]; is
     for (const d of dancers) {
       if (d.state) counts.set(d.state, (counts.get(d.state) ?? 0) + 1);
     }
-    const sorted = Array.from(counts.entries())
-      .sort(([, a], [, b]) => b - a);
-    const top5 = sorted.slice(0, 5).map(([state, count]) => ({ label: state, count }));
+    const sorted = Array.from(counts.entries()).sort(([, a], [, b]) => b - a);
+    const top5 = sorted
+      .slice(0, 5)
+      .map(([state, count]) => ({ label: state, count }));
     const remaining = sorted.length - 5;
     return { top5, remaining };
   }, [dancers]);
@@ -796,8 +936,18 @@ function TalentPoolBreakdown({ dancers, isLoading }: { dancers: DancerData[]; is
   return (
     <SidebarSection title="Talent pool">
       <div className="flex flex-col gap-3">
-        <DistributionBars label="By year" items={yearDist} total={dancers.length} labelWidth="w-10" />
-        <DistributionBars label="By GPA" items={gpaDist} total={dancers.length} labelWidth="w-14" />
+        <DistributionBars
+          label="By year"
+          items={yearDist}
+          total={dancers.length}
+          labelWidth="w-10"
+        />
+        <DistributionBars
+          label="By GPA"
+          items={gpaDist}
+          total={dancers.length}
+          labelWidth="w-14"
+        />
         <div>
           <span className="text-muted-foreground mb-1.5 block text-[10px] font-medium tracking-widest uppercase">
             By state
@@ -870,13 +1020,17 @@ function BarRow({
   const pct = max > 0 ? (count / max) * 100 : 0;
   return (
     <div className="flex items-center gap-2">
-      <span className={`text-muted-foreground text-xs tabular-nums ${labelWidth}`}>
+      <span
+        className={`text-muted-foreground text-xs tabular-nums ${labelWidth}`}
+      >
         {label}
       </span>
       <div className="bg-border relative h-1.5 flex-1 overflow-hidden rounded-full">
         <div className="bg-foreground h-full" style={{ width: `${pct}%` }} />
       </div>
-      <span className="w-8 text-right text-xs font-medium tabular-nums">{count}</span>
+      <span className="w-8 text-right text-xs font-medium tabular-nums">
+        {count}
+      </span>
     </div>
   );
 }
@@ -913,7 +1067,10 @@ function CompareClipboard({
               <div className="flex items-center justify-between">
                 <span className="text-xs font-medium">
                   <span className="text-muted-foreground font-mono text-[10px]">
-                    #{d.bibNumber != null ? String(d.bibNumber).padStart(2, "0") : "—"}{" "}
+                    #
+                    {d.bibNumber != null
+                      ? String(d.bibNumber).padStart(2, "0")
+                      : "—"}{" "}
                   </span>
                   {d.firstName} {d.lastName}
                 </span>
@@ -1006,7 +1163,8 @@ function ScoutingSession({
     );
   }
 
-  const pct = totalCount > 0 ? Math.round((reviewedCount / totalCount) * 100) : 0;
+  const pct =
+    totalCount > 0 ? Math.round((reviewedCount / totalCount) * 100) : 0;
 
   return (
     <SidebarSection title="Your session">
@@ -1017,7 +1175,8 @@ function ScoutingSession({
             <span className="text-xs">
               <span className="font-medium tabular-nums">{reviewedCount}</span>
               <span className="text-muted-foreground">
-                {" "}of {totalCount} reviewed
+                {" "}
+                of {totalCount} reviewed
               </span>
             </span>
             <span className="text-muted-foreground text-[10px] tabular-nums">
@@ -1025,7 +1184,10 @@ function ScoutingSession({
             </span>
           </div>
           <div className="bg-border mt-1.5 h-1.5 w-full overflow-hidden rounded-full">
-            <div className="bg-foreground h-full" style={{ width: `${pct}%` }} />
+            <div
+              className="bg-foreground h-full"
+              style={{ width: `${pct}%` }}
+            />
           </div>
           {filteredUnreviewed > 0 && (
             <p className="text-muted-foreground mt-1 text-[10px]">
@@ -1052,9 +1214,13 @@ function ScoutingSession({
                   >
                     <Icon className="text-muted-foreground mt-0.5 size-3 shrink-0" />
                     <div className="flex min-w-0 flex-1 flex-col">
-                      <span className="truncate text-xs">{item.dancerName}</span>
+                      <span className="truncate text-xs">
+                        {item.dancerName}
+                      </span>
                       <span className="text-muted-foreground text-[10px]">
-                        {formatDistanceToNow(item.timestamp, { addSuffix: true })}
+                        {formatDistanceToNow(item.timestamp, {
+                          addSuffix: true,
+                        })}
                       </span>
                     </div>
                   </button>

--- a/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/coach/event-info.tsx
+++ b/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/coach/event-info.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/features/org/components/dashboard-shared";
 import { useEventPhase } from "@/features/org/hooks/use-event-phase";
 import type { EventPhaseInfo } from "@/features/org/hooks/use-event-phase";
+import { CoachEventAccessBanner } from "@/features/org/components/coach-event-access-banner";
 
 export const Route = createFileRoute(
   "/_org/o/$orgSlug/_authenticated/coach/event-info",
@@ -48,8 +49,10 @@ function EventInfo() {
   const { isAdmin, myRoster } = useOrg();
   const { data: events } = useQuery(adminQueries.events(orgSlug));
   const activeEvent = events?.find((e) => e.isActive) ?? null;
+  const rosterEvent =
+    events?.find((event) => event.id === myRoster?.eventId) ?? null;
 
-  if (!activeEvent) {
+  if (!activeEvent && !rosterEvent) {
     return (
       <div className="text-muted-foreground py-12 text-center">
         No active event.
@@ -57,11 +60,65 @@ function EventInfo() {
     );
   }
 
-  if (isAdmin && !myRoster) {
+  if (isAdmin && !myRoster && activeEvent) {
     return <AttendEventGate orgSlug={orgSlug} eventName={activeEvent.name} />;
   }
 
-  return <CoachDashboard orgSlug={orgSlug} event={activeEvent} />;
+  const event = rosterEvent ?? activeEvent;
+  if (!event) return null;
+
+  if (!isAdmin && myRoster && (!myRoster.isActive || !myRoster.hasStarted)) {
+    return <PreEventDashboard orgSlug={orgSlug} event={event} />;
+  }
+
+  return <CoachDashboard orgSlug={orgSlug} event={event} />;
+}
+
+function PreEventDashboard({
+  orgSlug,
+  event,
+}: {
+  orgSlug: string;
+  event: OrgEvent;
+}) {
+  const phase = useEventPhase(event.startDate, event.endDate);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+      <DashboardHeader
+        name={event.name}
+        phase={phase}
+        dateRange={formatDateRange(event.startDate, event.endDate)}
+      />
+      <CoachEventAccessBanner
+        orgSlug={orgSlug}
+        eventName={event.name}
+        startDate={event.startDate}
+      />
+      <div className="grid flex-1 content-start gap-6 p-4 lg:grid-cols-[minmax(0,1fr)_20rem]">
+        <section className="flex max-w-2xl flex-col gap-3 py-2">
+          <p className="text-muted-foreground max-w-xl text-sm leading-relaxed">
+            Your coach workspace is ready. Explore the full dancer directory
+            before {event.name}; your event-specific scouting tools will become
+            available when the event is active.
+          </p>
+          <Button
+            className="w-fit"
+            render={
+              <Link to="/o/$orgSlug/coach/dancers" params={{ orgSlug }} />
+            }
+          >
+            Browse all dancers
+            <ArrowRightIcon />
+          </Button>
+        </section>
+        <aside className="border-border overflow-hidden rounded-md border">
+          <SidebarPhaseSection phase={phase} />
+          <SidebarDetailsSection orgSlug={orgSlug} event={event} />
+        </aside>
+      </div>
+    </div>
+  );
 }
 
 function AttendEventGate({
@@ -146,8 +203,7 @@ function CoachDashboard({
     .filter((d) => d.isFavorited && d.favoritedAt)
     .sort(
       (a, b) =>
-        new Date(b.favoritedAt!).getTime() -
-        new Date(a.favoritedAt!).getTime(),
+        new Date(b.favoritedAt!).getTime() - new Date(a.favoritedAt!).getTime(),
     )
     .slice(0, 4);
 
@@ -225,21 +281,24 @@ function QuickNavPanel({
       label: "Search Dancers",
       to: "/o/$orgSlug/coach/dancers",
       description: `${dancerCount} dancers registered`,
-      iconClass: "bg-blue-500/10 text-blue-600 dark:text-blue-400 border-blue-500/20",
+      iconClass:
+        "bg-blue-500/10 text-blue-600 dark:text-blue-400 border-blue-500/20",
     },
     {
       icon: HeartIcon,
       label: "My Favorites",
       to: "/o/$orgSlug/coach/dancers",
       description: `${favCount} dancers saved`,
-      iconClass: "bg-rose-500/10 text-rose-600 dark:text-rose-400 border-rose-500/20",
+      iconClass:
+        "bg-rose-500/10 text-rose-600 dark:text-rose-400 border-rose-500/20",
     },
     {
       icon: TrophyIcon,
       label: "My Rankings",
       to: "/o/$orgSlug/coach/dancers",
       description: "Review your ranked dancers",
-      iconClass: "bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/20",
+      iconClass:
+        "bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/20",
     },
   ];
 
@@ -265,7 +324,9 @@ function QuickNavPanel({
               params={{ orgSlug } as any}
               className="hover:bg-muted/40 group flex items-center gap-3 px-3 py-2.5 transition-colors"
             >
-              <span className={`flex size-7 items-center justify-center rounded-md border ${item.iconClass}`}>
+              <span
+                className={`flex size-7 items-center justify-center rounded-md border ${item.iconClass}`}
+              >
                 <item.icon className="size-3.5" />
               </span>
               <div className="flex min-w-0 flex-1 flex-col">
@@ -509,7 +570,7 @@ function CoachSidebarPanel({
                   key={dancer.rosterId}
                   className="flex items-start gap-2 text-xs 2xl:text-sm"
                 >
-                  <HeartIcon className="text-rose-500 mt-0.5 size-3 shrink-0" />
+                  <HeartIcon className="mt-0.5 size-3 shrink-0 text-rose-500" />
                   <div className="flex min-w-0 flex-1 flex-col">
                     <span>
                       <span className="font-medium">


### PR DESCRIPTION
PRs #36 and #37 were marked merged but landed on their stacked base *branches* (`agent/t3-email-delivery`, `agent/t5-coach-resend`) rather than `main` — the stack was merged inward instead of top-down, so main never received the coach work. This PR relands the union: everything from #36 (coach resend invites) and #37 (coach access decoupling, cross-event dancer visibility, event filter, pre-event banner, extended invite expiry) merged onto current main (which already has #35's email throttling + vault fixes). Verified: emails build, backend typecheck, frontend tsc all pass on the merged state. No conflicts — file sets are disjoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)