### PR TITLE
fix(org): separate event viewing from activation

### DIFF
--- a/apps/frontend/src/features/org/components/org-event-switcher.tsx
+++ b/apps/frontend/src/features/org/components/org-event-switcher.tsx
@@ -1,5 +1,18 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { CheckIcon, PlusIcon } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import {
+  AlertDialog,
+  AlertDialogClose,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
-import { Label } from "@/components/ui/label";
 import {
   Select,
   SelectContent,
@@ -10,46 +23,28 @@ import {
 import { toastManager } from "@/components/ui/toast-manager";
 import { adminQueries, type OrgEvent } from "@/features/org/api/admin-queries";
 import { EventFormSheet } from "@/features/org/components/event-form-sheet";
+import { useAdminEvent } from "@/features/org/context/use-admin-event";
 import { client } from "@/lib/api/client";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { format } from "date-fns";
-import { PlusIcon } from "lucide-react";
-import { useState } from "react";
 
-function parseYmd(ymd: string): Date {
-  const [y, m, d] = ymd.split("-").map(Number);
-  return new Date(y, (m ?? 1) - 1, d ?? 1);
-}
-
-function sortEventsForPicker(events: OrgEvent[]): OrgEvent[] {
-  return [...events].sort((a, b) => {
-    const byStart = b.startDate.localeCompare(a.startDate);
-    if (byStart !== 0) return byStart;
-    return b.createdAt.localeCompare(a.createdAt);
-  });
-}
-
-function eventOptionLabel(e: OrgEvent): string {
-  const start = parseYmd(e.startDate);
-  return `${e.name} · ${format(start, "MMM d, yyyy")}`;
-}
-
-export function OrgEventSwitcher({
-  orgSlug,
-  events,
-  activeEvent,
-}: {
-  orgSlug: string;
-  events: OrgEvent[];
-  activeEvent: OrgEvent;
-}) {
-  const qc = useQueryClient();
+export function OrgEventSwitcher({ orgSlug }: { orgSlug: string }) {
+  const queryClient = useQueryClient();
+  const { activeEvent, events, selectedEvent, selectEvent } = useAdminEvent();
   const [createOpen, setCreateOpen] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
-  const sorted = sortEventsForPicker(events);
-  const selectItems = sorted.map((e) => ({
-    value: e.id,
-    label: eventOptionLabel(e),
+  const sortedEvents = useMemo(
+    () =>
+      [...events].sort((a, b) => {
+        const byStart = b.startDate.localeCompare(a.startDate);
+        if (byStart !== 0) return byStart;
+        return b.createdAt.localeCompare(a.createdAt);
+      }),
+    [events],
+  );
+
+  const items = sortedEvents.map((event) => ({
+    value: event.id,
+    label: event.name,
   }));
 
   const activate = useMutation({
@@ -57,63 +52,128 @@ export function OrgEventSwitcher({
       const raw = client as unknown as {
         PATCH: (
           path: string,
-          opts: { body: { isActive: boolean } },
-        ) => Promise<{ data: OrgEvent }>;
+          options: { body: { isActive: boolean } },
+        ) => Promise<{ data: OrgEvent; error?: unknown }>;
       };
-      const res = await raw.PATCH(`/orgs/${orgSlug}/events/${eventId}`, {
+      const response = await raw.PATCH(`/orgs/${orgSlug}/events/${eventId}`, {
         body: { isActive: true },
       });
-      return res.data;
+      if (response.error) throw new Error("Activation failed");
+      return response.data;
     },
     onSuccess: () => {
-      qc.invalidateQueries(adminQueries.events(orgSlug));
+      setConfirmOpen(false);
+      void queryClient.invalidateQueries(adminQueries.events(orgSlug));
       toastManager.add({ title: "Active event updated", type: "success" });
     },
     onError: () => {
       toastManager.add({
-        title: "Couldn't switch event",
+        title: "Couldn't make event active",
         type: "error",
       });
     },
   });
 
+  const isSelectedActive =
+    selectedEvent !== null && selectedEvent.id === activeEvent?.id;
+
   return (
     <>
-      <div className="space-y-1.5">
-        <Label htmlFor="org-active-event">Active event</Label>
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
-          <div className="min-w-0 flex-1">
-            <Select
-              items={selectItems}
-              value={activeEvent.id}
-              onValueChange={(value) => {
-                if (!value || value === activeEvent.id) return;
-                activate.mutate(value);
-              }}
-              disabled={activate.isPending}
-            >
-              <SelectTrigger id="org-active-event" className="w-full">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {selectItems.map((item) => (
-                  <SelectItem key={item.value} value={item.value}>
-                    {item.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-          <Button
-            type="button"
-            variant="outline"
-            className="h-9 w-full shrink-0 gap-1.5 sm:w-auto"
-            onClick={() => setCreateOpen(true)}
+      <div className="flex items-center gap-2">
+        <Select
+          items={items}
+          value={selectedEvent?.id ?? null}
+          onValueChange={(value) => {
+            if (value) selectEvent(value);
+          }}
+          disabled={items.length === 0}
+        >
+          <SelectTrigger
+            aria-label="Event to view"
+            className="bg-background h-8 w-[220px] text-xs 2xl:text-sm"
           >
-            <PlusIcon className="size-4" aria-hidden />
-            New event
+            <SelectValue placeholder="Select event" />
+          </SelectTrigger>
+          <SelectContent>
+            {sortedEvents.map((event) => (
+              <SelectItem key={event.id} value={event.id}>
+                <span className="flex min-w-0 items-center justify-between gap-3">
+                  <span className="truncate">{event.name}</span>
+                  {event.isActive && (
+                    <span className="text-muted-foreground text-[10px] font-medium tracking-wide uppercase">
+                      Active
+                    </span>
+                  )}
+                </span>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        {isSelectedActive ? (
+          <Button
+            variant="outline"
+            size="xs"
+            className="h-8 gap-1.5 px-2.5"
+            disabled
+          >
+            <CheckIcon aria-hidden className="size-3" />
+            Active event
           </Button>
-        </div>
+        ) : (
+          <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+            <AlertDialogTrigger
+              render={
+                <Button
+                  size="xs"
+                  className="h-8 px-2.5"
+                  disabled={!selectedEvent}
+                />
+              }
+            >
+              Make active
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>
+                  Make {selectedEvent?.name} the active event?
+                </AlertDialogTitle>
+                <AlertDialogDescription>
+                  Dancers and coaches will see this as the active event. If
+                  another event is active, it will no longer be shown to them.
+                  Admins can still view any event from the event switcher.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogClose
+                  render={
+                    <Button variant="ghost" disabled={activate.isPending} />
+                  }
+                >
+                  Cancel
+                </AlertDialogClose>
+                <Button
+                  onClick={() => {
+                    if (selectedEvent) activate.mutate(selectedEvent.id);
+                  }}
+                  disabled={!selectedEvent || activate.isPending}
+                >
+                  {activate.isPending ? "Making active…" : "Make active"}
+                </Button>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        )}
+
+        <Button
+          variant="ghost"
+          size="xs"
+          className="h-8 gap-1 px-2"
+          onClick={() => setCreateOpen(true)}
+        >
+          <PlusIcon aria-hidden className="size-3" />
+          New
+        </Button>
       </div>
 
       <EventFormSheet

--- a/apps/frontend/src/features/org/context/admin-event-context.spec.ts
+++ b/apps/frontend/src/features/org/context/admin-event-context.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import type { OrgEvent } from "@/features/org/api/admin-queries";
+import { resolveAdminEventSelection } from "./admin-event-context";
+
+function event(id: string, isActive = false): OrgEvent {
+  return {
+    id,
+    orgId: "org-1",
+    name: `Event ${id}`,
+    startDate: "2026-07-13",
+    endDate: "2026-07-14",
+    startTime: null,
+    timezone: null,
+    venueName: null,
+    venueAddress: null,
+    contactEmail: null,
+    schedulePdfUrl: null,
+    isActive,
+    createdAt: "2026-07-01T00:00:00.000Z",
+    updatedAt: "2026-07-01T00:00:00.000Z",
+  };
+}
+
+describe("resolveAdminEventSelection", () => {
+  it("keeps a selected inactive event visible", () => {
+    const events = [event("active", true), event("selected")];
+
+    expect(resolveAdminEventSelection(events, "selected")?.id).toBe("selected");
+    expect(events.find((item) => item.isActive)?.id).toBe("active");
+  });
+
+  it("defaults to the active event", () => {
+    const events = [event("first"), event("active", true)];
+
+    expect(resolveAdminEventSelection(events, null)?.id).toBe("active");
+  });
+
+  it("falls back when the selected event no longer exists", () => {
+    const events = [event("active", true), event("other")];
+
+    expect(resolveAdminEventSelection(events, "deleted")?.id).toBe("active");
+  });
+});

--- a/apps/frontend/src/features/org/context/admin-event-context.ts
+++ b/apps/frontend/src/features/org/context/admin-event-context.ts
@@ -1,0 +1,26 @@
+import { createContext } from "react";
+
+import type { OrgEvent } from "@/features/org/api/admin-queries";
+
+export interface AdminEventContextValue {
+  activeEvent: OrgEvent | null;
+  events: OrgEvent[];
+  selectedEvent: OrgEvent | null;
+  selectEvent: (eventId: string) => void;
+}
+
+export const AdminEventContext = createContext<AdminEventContextValue | null>(
+  null,
+);
+
+export function resolveAdminEventSelection(
+  events: OrgEvent[],
+  selectedEventId: string | null,
+): OrgEvent | null {
+  return (
+    events.find((event) => event.id === selectedEventId) ??
+    events.find((event) => event.isActive) ??
+    events[0] ??
+    null
+  );
+}

--- a/apps/frontend/src/features/org/context/admin-event-provider.tsx
+++ b/apps/frontend/src/features/org/context/admin-event-provider.tsx
@@ -1,0 +1,38 @@
+import { useMemo, useState, type ReactNode } from "react";
+
+import type { OrgEvent } from "@/features/org/api/admin-queries";
+import {
+  AdminEventContext,
+  resolveAdminEventSelection,
+  type AdminEventContextValue,
+} from "./admin-event-context";
+
+export function AdminEventProvider({
+  children,
+  events,
+}: {
+  children: ReactNode;
+  events: OrgEvent[];
+}) {
+  const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
+
+  const value = useMemo<AdminEventContextValue>(
+    () => ({
+      activeEvent: events.find((event) => event.isActive) ?? null,
+      events,
+      selectedEvent: resolveAdminEventSelection(events, selectedEventId),
+      selectEvent: (eventId) => {
+        if (events.some((event) => event.id === eventId)) {
+          setSelectedEventId(eventId);
+        }
+      },
+    }),
+    [events, selectedEventId],
+  );
+
+  return (
+    <AdminEventContext.Provider value={value}>
+      {children}
+    </AdminEventContext.Provider>
+  );
+}

--- a/apps/frontend/src/features/org/context/use-admin-event.ts
+++ b/apps/frontend/src/features/org/context/use-admin-event.ts
@@ -1,0 +1,11 @@
+import { useContext } from "react";
+
+import { AdminEventContext } from "./admin-event-context";
+
+export function useAdminEvent() {
+  const context = useContext(AdminEventContext);
+  if (!context) {
+    throw new Error("useAdminEvent must be used inside <AdminEventProvider>");
+  }
+  return context;
+}

--- a/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/admin/coaches.tsx
+++ b/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/admin/coaches.tsx
@@ -1,5 +1,4 @@
 import { toastManager } from "@/components/ui/toast-manager";
-import { adminQueries } from "@/features/org/api/admin-queries";
 import { toastRosterMutationError } from "@/features/org/api/roster-mutation-error";
 import {
   type RosterEntry,
@@ -14,8 +13,9 @@ import { DataGrid, StatusBadge } from "@/features/org/components/data-grid";
 import { rosterBulkActions } from "@/features/org/components/roster-bulk-actions";
 import { RosterDetailSheet } from "@/features/org/components/roster-detail-sheet";
 import { RosterPageHeader } from "@/features/org/components/roster-page-header";
+import { useAdminEvent } from "@/features/org/context/use-admin-event";
 import { useOrg } from "@/features/org/context/use-org";
-import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { type ColumnDef, type SortingState } from "@tanstack/react-table";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -89,8 +89,7 @@ function CoachesPage() {
   const { orgSlug } = Route.useParams();
   const { hasFeature } = useOrg();
   const checkInEnabled = hasFeature("check_in");
-  const { data: events } = useSuspenseQuery(adminQueries.events(orgSlug));
-  const active = events?.find((e) => e.isActive);
+  const { selectedEvent: active } = useAdminEvent();
 
   const [search, setSearch] = useState("");
   const [status, setStatus] = useState<RosterStatus>("all");
@@ -254,7 +253,7 @@ function CoachesPage() {
   if (!active) {
     return (
       <div className="text-muted-foreground flex flex-1 items-center justify-center text-sm">
-        No active event.
+        No event selected.
       </div>
     );
   }

--- a/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/admin/dancers.tsx
+++ b/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/admin/dancers.tsx
@@ -1,5 +1,4 @@
 import { toastManager } from "@/components/ui/toast-manager";
-import { adminQueries } from "@/features/org/api/admin-queries";
 import { toastRosterMutationError } from "@/features/org/api/roster-mutation-error";
 import {
   type RosterEntry,
@@ -14,8 +13,9 @@ import { DataGrid, StatusBadge } from "@/features/org/components/data-grid";
 import { rosterBulkActions } from "@/features/org/components/roster-bulk-actions";
 import { RosterDetailSheet } from "@/features/org/components/roster-detail-sheet";
 import { RosterPageHeader } from "@/features/org/components/roster-page-header";
+import { useAdminEvent } from "@/features/org/context/use-admin-event";
 import { useOrg } from "@/features/org/context/use-org";
-import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { type ColumnDef, type SortingState } from "@tanstack/react-table";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -153,8 +153,7 @@ function DancersPage() {
     if (checkInEnabled) cols.push(checkedInColumn);
     return cols;
   }, [checkInEnabled, freeTierEnabled]);
-  const { data: events } = useSuspenseQuery(adminQueries.events(orgSlug));
-  const active = events?.find((e) => e.isActive);
+  const { selectedEvent: active } = useAdminEvent();
 
   const [search, setSearch] = useState("");
   const [status, setStatus] = useState<RosterStatus>("all");
@@ -311,7 +310,7 @@ function DancersPage() {
   if (!active) {
     return (
       <div className="text-muted-foreground flex flex-1 items-center justify-center text-sm">
-        No active event.
+        No event selected.
       </div>
     );
   }

--- a/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/admin/index.tsx
+++ b/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/admin/index.tsx
@@ -58,6 +58,7 @@ import {
   type CsvUploadSummary,
   type OrgEvent,
 } from "@/features/org/api/admin-queries";
+import { useAdminEvent } from "@/features/org/context/use-admin-event";
 import {
   ACCENT_VALUE,
   AccentDot,
@@ -1177,16 +1178,15 @@ function SidebarActivitySection({
 
 function AdminHome() {
   const { orgSlug } = Route.useParams();
-  const { data: events } = useSuspenseQuery(adminQueries.events(orgSlug));
-  const activeEvent = events?.find((e) => e.isActive);
+  const { events, selectedEvent } = useAdminEvent();
 
-  if (!activeEvent) {
+  if (!selectedEvent && events.length === 0) {
     return (
       <div className="mx-auto w-full max-w-md space-y-4 p-4 md:p-6">
         <div>
           <h1 className="text-2xl font-semibold">Create your first event</h1>
           <p className="text-muted-foreground mt-1 text-sm">
-            You'll be able to upload rosters once an event is active.
+            You'll be able to upload rosters once the event is created.
           </p>
         </div>
         <CreateEventForm orgSlug={orgSlug} />
@@ -1194,5 +1194,7 @@ function AdminHome() {
     );
   }
 
-  return <AdminDashboard orgSlug={orgSlug} activeEvent={activeEvent} />;
+  if (!selectedEvent) return null;
+
+  return <AdminDashboard orgSlug={orgSlug} activeEvent={selectedEvent} />;
 }

--- a/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/admin/reconciliation.tsx
+++ b/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/admin/reconciliation.tsx
@@ -1,9 +1,9 @@
 import { client } from "@/lib/api/client";
-import { adminQueries } from "@/features/org/api/admin-queries";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { toastManager } from "@/components/ui/toast-manager";
-import { useMutation, useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { useAdminEvent } from "@/features/org/context/use-admin-event";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { useState } from "react";
 
@@ -162,8 +162,7 @@ function MergeDialog({
 
 function ReconciliationPage() {
   const { orgSlug } = Route.useParams();
-  const { data: events } = useSuspenseQuery(adminQueries.events(orgSlug));
-  const active = events?.find((e) => e.isActive);
+  const { selectedEvent: active } = useAdminEvent();
 
   const [mergingRosterId, setMergingRosterId] = useState<string | null>(null);
 
@@ -206,7 +205,7 @@ function ReconciliationPage() {
   if (!active) {
     return (
       <div className="text-muted-foreground flex flex-1 items-center justify-center text-sm">
-        No active event.
+        No event selected.
       </div>
     );
   }

--- a/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/admin/route.tsx
+++ b/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/admin/route.tsx
@@ -1,30 +1,20 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
-import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
-import { PlusIcon } from "lucide-react";
 import {
   SidebarInset,
   SidebarProvider,
   SidebarTrigger,
 } from "@/components/ui/sidebar";
-import { Button } from "@/components/ui/button";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
-import { toastManager } from "@/components/ui/toast-manager";
-import { AdminSidebar } from "@/features/org/components/admin-sidebar";
+import { adminQueries } from "@/features/org/api/admin-queries";
 import { AdminCommandPalette } from "@/features/org/components/admin-command-palette";
+import { AdminSidebar } from "@/features/org/components/admin-sidebar";
+import { OrgEventSwitcher } from "@/features/org/components/org-event-switcher";
+import { AdminEventProvider } from "@/features/org/context/admin-event-provider";
+import { useAdminEvent } from "@/features/org/context/use-admin-event";
 import { AdminCommandsProvider } from "@/features/org/hooks/use-admin-commands";
-import { adminQueries, type OrgEvent } from "@/features/org/api/admin-queries";
-import { EventFormSheet } from "@/features/org/components/event-form-sheet";
 import { orgQueries } from "@/features/org/api/queries";
 import { queries } from "@/lib/session";
-import { client } from "@/lib/api/client";
-import { useMemo, useState } from "react";
 
 export const Route = createFileRoute("/_org/o/$orgSlug/_authenticated/admin")({
   beforeLoad: async ({ context, params }) => {
@@ -47,7 +37,16 @@ export const Route = createFileRoute("/_org/o/$orgSlug/_authenticated/admin")({
 function AdminLayout() {
   const { orgSlug } = Route.useParams();
   const { data: events } = useSuspenseQuery(adminQueries.events(orgSlug));
-  const activeEvent = events.find((event) => event.isActive);
+
+  return (
+    <AdminEventProvider events={events}>
+      <AdminShell orgSlug={orgSlug} />
+    </AdminEventProvider>
+  );
+}
+
+function AdminShell({ orgSlug }: { orgSlug: string }) {
+  const { selectedEvent } = useAdminEvent();
 
   return (
     <AdminCommandsProvider>
@@ -61,109 +60,15 @@ function AdminLayout() {
               Admin
             </span>
             <div className="ml-auto">
-              <AdminEventSwitcher
-                orgSlug={orgSlug}
-                events={events}
-                activeEventId={activeEvent?.id}
-              />
+              <OrgEventSwitcher orgSlug={orgSlug} />
             </div>
           </header>
           <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
-            <Outlet />
+            <Outlet key={selectedEvent?.id ?? "no-event"} />
           </div>
         </SidebarInset>
         <AdminCommandPalette />
       </SidebarProvider>
     </AdminCommandsProvider>
-  );
-}
-
-function AdminEventSwitcher({
-  orgSlug,
-  events,
-  activeEventId,
-}: {
-  orgSlug: string;
-  events: OrgEvent[];
-  activeEventId?: string;
-}) {
-  const qc = useQueryClient();
-  const [createOpen, setCreateOpen] = useState(false);
-  const sortedEvents = useMemo(
-    () =>
-      [...events].sort((a, b) => {
-        const byStart = b.startDate.localeCompare(a.startDate);
-        if (byStart !== 0) return byStart;
-        return b.createdAt.localeCompare(a.createdAt);
-      }),
-    [events],
-  );
-
-  const items = sortedEvents.map((event) => ({
-    value: event.id,
-    label: event.name,
-  }));
-
-  const activate = useMutation({
-    mutationFn: async (eventId: string) => {
-      const raw = client as unknown as {
-        PATCH: (
-          path: string,
-          opts: { body: { isActive: boolean } },
-        ) => Promise<{ data: OrgEvent }>;
-      };
-      const response = await raw.PATCH(`/orgs/${orgSlug}/events/${eventId}`, {
-        body: { isActive: true },
-      });
-      return response.data;
-    },
-    onSuccess: () => {
-      qc.invalidateQueries(adminQueries.events(orgSlug));
-      toastManager.add({ title: "Active event updated", type: "success" });
-    },
-    onError: () => {
-      toastManager.add({ title: "Couldn't switch event", type: "error" });
-    },
-  });
-
-  return (
-    <>
-      <div className="flex items-center gap-2">
-        <Select
-          items={items}
-          value={activeEventId}
-          onValueChange={(value) => {
-            if (!value || value === activeEventId) return;
-            activate.mutate(value);
-          }}
-          disabled={activate.isPending || items.length === 0}
-        >
-          <SelectTrigger className="h-8 w-[220px] bg-background text-xs 2xl:text-sm">
-            <SelectValue placeholder="Select event" />
-          </SelectTrigger>
-          <SelectContent>
-            {items.map((item) => (
-              <SelectItem key={item.value} value={item.value}>
-                {item.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        <Button
-          variant="ghost"
-          size="xs"
-          className="h-8 gap-1 px-2"
-          onClick={() => setCreateOpen(true)}
-        >
-          <PlusIcon className="size-3" />
-          New
-        </Button>
-      </div>
-      <EventFormSheet
-        orgSlug={orgSlug}
-        open={createOpen}
-        onOpenChange={setCreateOpen}
-      />
-    </>
   );
 }

--- a/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/admin/uploads.tsx
+++ b/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/admin/uploads.tsx
@@ -17,7 +17,6 @@ import {
 } from "@/components/ui/sheet";
 import { useSidebar } from "@/components/ui/sidebar";
 import { cn } from "@/components/utils/cn";
-import { adminQueries } from "@/features/org/api/admin-queries";
 import {
   auditQueries,
   type AuditAction,
@@ -26,7 +25,8 @@ import {
   type AuditLogStats,
   type AuditResource,
 } from "@/features/org/api/audit-queries";
-import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { useAdminEvent } from "@/features/org/context/use-admin-event";
+import { useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { format, formatDistanceToNow } from "date-fns";
 import {
@@ -644,10 +644,8 @@ function AuditSidebar({
 
 function AuditLogPage() {
   const { orgSlug } = Route.useParams();
-  const { data: events } = useSuspenseQuery(adminQueries.events(orgSlug));
-
-  const active = events?.find((e) => e.isActive);
-  const selectedEventId = active?.id ?? "";
+  const { events, selectedEvent } = useAdminEvent();
+  const selectedEventId = selectedEvent?.id ?? "";
 
   const [search, setSearch] = useState("");
   const [actionFilter, setActionFilter] = useState<AuditAction | "all">("all");
@@ -711,7 +709,7 @@ function AuditLogPage() {
     }
   };
 
-  if (!active && events.length === 0) {
+  if (!selectedEvent && events.length === 0) {
     return (
       <div className="text-muted-foreground flex flex-1 items-center justify-center text-sm">
         No events yet.
@@ -730,7 +728,7 @@ function AuditLogPage() {
               Audit Log
             </h1>
             <span className="text-muted-foreground text-xs tabular-nums 2xl:text-sm">
-              {active?.name ?? ""}
+              {selectedEvent?.name ?? ""}
             </span>
           </div>
         </header>

--- a/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/admin/video-library.tsx
+++ b/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/admin/video-library.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
-import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { useDeferredValue, useMemo, useState } from "react";
 import { StatCell } from "@/features/org/components/dashboard-shared";
 import { EventVideoGrid } from "@/features/org/components/event-video/event-video-grid";
@@ -22,8 +22,8 @@ import {
   type EventVideo,
   type EventVideoGroup,
 } from "@/features/org/api/video-queries";
-import { adminQueries } from "@/features/org/api/admin-queries";
 import { orgQueries } from "@/features/org/api/queries";
+import { useAdminEvent } from "@/features/org/context/use-admin-event";
 import { formatDistanceToNow } from "date-fns";
 
 export const Route = createFileRoute(
@@ -43,9 +43,8 @@ export const Route = createFileRoute(
 
 function AdminVideoLibrary() {
   const { orgSlug } = Route.useParams();
-  const { data: events } = useSuspenseQuery(adminQueries.events(orgSlug));
-  const activeEvent = events.find((e) => e.isActive);
-  const eventId = activeEvent?.id ?? "";
+  const { selectedEvent } = useAdminEvent();
+  const eventId = selectedEvent?.id ?? "";
 
   const { data: categories = [] } = useQuery(
     videoQueries.categories(orgSlug, eventId),
@@ -119,11 +118,11 @@ function AdminVideoLibrary() {
     });
   }
 
-  if (!activeEvent) {
+  if (!selectedEvent) {
     return (
       <div className="flex flex-1 items-center justify-center">
         <p className="text-muted-foreground text-sm">
-          No active event. Create or activate an event to manage videos.
+          No event selected. Create an event to manage videos.
         </p>
       </div>
     );


### PR DESCRIPTION
Let admins inspect any event without changing the organization active event, and require confirmation before activation.