### PR TITLE
feat(org): reset check-in for an event roster

### DIFF
--- a/apps/backend/app/modules/orgs/events/rosters/check-in/reset/controller.ts
+++ b/apps/backend/app/modules/orgs/events/rosters/check-in/reset/controller.ts
@@ -1,0 +1,15 @@
+import { inject } from "@adonisjs/core";
+import type { HttpContext } from "@adonisjs/core/http";
+import { ResetCheckInService } from "./service.ts";
+
+export default class ResetCheckInController {
+  @inject()
+  async handle(ctx: HttpContext, service: ResetCheckInService) {
+    const actorId = ctx.auth.getUserOrFail().id;
+    const eventId = ctx.params.id;
+
+    const result = await service.execute(eventId, { eventId, actorId });
+
+    return ctx.response.ok(result);
+  }
+}

--- a/apps/backend/app/modules/orgs/events/rosters/check-in/reset/service.spec.ts
+++ b/apps/backend/app/modules/orgs/events/rosters/check-in/reset/service.spec.ts
@@ -1,0 +1,178 @@
+import { test } from "@japa/runner";
+import { and, eq, isNotNull } from "drizzle-orm";
+import { db } from "#database/connection";
+import {
+  eventAuditLog,
+  orgEvents,
+  eventRosters,
+} from "#database/schema/org-events";
+import { organizations } from "#database/schema/organizations";
+import { users } from "#database/schema/users";
+import { ResetCheckInService } from "./service.ts";
+
+test.group("ResetCheckInService", (group) => {
+  let orgId: string;
+  let eventId: string;
+  let otherEventId: string;
+  let actorId: string;
+
+  const addRoster = async (
+    targetEventId: string,
+    values: { email: string; checkedIn: boolean; isStaff?: boolean }
+  ) => {
+    const [row] = await db
+      .insert(eventRosters)
+      .values({
+        eventId: targetEventId,
+        type: values.isStaff ? "coach" : "dancer",
+        email: values.email,
+        firstName: "Test",
+        lastName: "Dancer",
+        isStaff: values.isStaff ?? false,
+        checkedInAt: values.checkedIn ? new Date() : null,
+      })
+      .returning();
+    return row;
+  };
+
+  group.each.setup(async () => {
+    await db.delete(eventAuditLog).execute();
+    await db.delete(eventRosters).execute();
+    await db.delete(orgEvents).execute();
+
+    const [org] = await db.select().from(organizations).limit(1);
+    orgId = org.id;
+
+    const [actor] = await db.select().from(users).limit(1);
+    actorId = actor.id;
+
+    const [ev] = await db
+      .insert(orgEvents)
+      .values({
+        orgId,
+        name: "Test Event",
+        startDate: "2020-01-01",
+        endDate: "2020-01-03",
+        isActive: true,
+      })
+      .returning();
+    eventId = ev.id;
+
+    const [other] = await db
+      .insert(orgEvents)
+      .values({
+        orgId,
+        name: "Other Event",
+        startDate: "2020-02-01",
+        endDate: "2020-02-03",
+        isActive: false,
+      })
+      .returning();
+    otherEventId = other.id;
+  });
+
+  test("clears checkedInAt and returns the reset count", async ({ assert }) => {
+    await addRoster(eventId, { email: "a@test.com", checkedIn: true });
+    await addRoster(eventId, { email: "b@test.com", checkedIn: true });
+    await addRoster(eventId, { email: "c@test.com", checkedIn: false });
+
+    const svc = new ResetCheckInService();
+    const result = await svc.execute(eventId, { eventId, actorId });
+
+    assert.equal(result.reset, 2);
+
+    const stillCheckedIn = await db
+      .select()
+      .from(eventRosters)
+      .where(
+        and(
+          eq(eventRosters.eventId, eventId),
+          isNotNull(eventRosters.checkedInAt)
+        )
+      );
+    assert.lengthOf(stillCheckedIn, 0);
+  });
+
+  test("logs one audit entry per reset row", async ({ assert }) => {
+    await addRoster(eventId, { email: "a@test.com", checkedIn: true });
+    await addRoster(eventId, { email: "b@test.com", checkedIn: true });
+    await addRoster(eventId, { email: "c@test.com", checkedIn: false });
+
+    const svc = new ResetCheckInService();
+    await svc.execute(eventId, { eventId, actorId });
+
+    const entries = await db
+      .select()
+      .from(eventAuditLog)
+      .where(eq(eventAuditLog.eventId, eventId));
+
+    // Only the two checked-in rows should produce entries.
+    assert.lengthOf(entries, 2);
+    for (const entry of entries) {
+      assert.equal(entry.action, "update");
+      assert.equal(entry.resource, "roster");
+      assert.equal(
+        (entry.metadata as { field?: string } | null)?.field,
+        "checkedInAt"
+      );
+      assert.isNull((entry.metadata as { after?: unknown } | null)?.after);
+    }
+  });
+
+  test("does not touch rosters belonging to a different event", async ({
+    assert,
+  }) => {
+    await addRoster(eventId, { email: "a@test.com", checkedIn: true });
+    const untouched = await addRoster(otherEventId, {
+      email: "other@test.com",
+      checkedIn: true,
+    });
+
+    const svc = new ResetCheckInService();
+    const result = await svc.execute(eventId, { eventId, actorId });
+
+    assert.equal(result.reset, 1);
+
+    const [after] = await db
+      .select()
+      .from(eventRosters)
+      .where(eq(eventRosters.id, untouched.id));
+    assert.isNotNull(after.checkedInAt);
+  });
+
+  test("resets staff rows too", async ({ assert }) => {
+    const staff = await addRoster(eventId, {
+      email: "staff@test.com",
+      checkedIn: true,
+      isStaff: true,
+    });
+
+    const svc = new ResetCheckInService();
+    const result = await svc.execute(eventId, { eventId, actorId });
+
+    assert.equal(result.reset, 1);
+
+    const [after] = await db
+      .select()
+      .from(eventRosters)
+      .where(eq(eventRosters.id, staff.id));
+    assert.isNull(after.checkedInAt);
+  });
+
+  test("returns { reset: 0 } and logs nothing when no one is checked in", async ({
+    assert,
+  }) => {
+    await addRoster(eventId, { email: "a@test.com", checkedIn: false });
+
+    const svc = new ResetCheckInService();
+    const result = await svc.execute(eventId, { eventId, actorId });
+
+    assert.equal(result.reset, 0);
+
+    const entries = await db
+      .select()
+      .from(eventAuditLog)
+      .where(eq(eventAuditLog.eventId, eventId));
+    assert.lengthOf(entries, 0);
+  });
+});

--- a/apps/backend/app/modules/orgs/events/rosters/check-in/reset/service.ts
+++ b/apps/backend/app/modules/orgs/events/rosters/check-in/reset/service.ts
@@ -1,0 +1,54 @@
+import { DatabaseService } from "#database/service";
+import { eventRosters } from "#database/schema/org-events";
+import { inject } from "@adonisjs/core";
+import { and, eq, isNotNull } from "drizzle-orm";
+import type { AuditContext } from "#database/audit";
+
+@inject()
+export class ResetCheckInService {
+  constructor(private db: DatabaseService = new DatabaseService()) {}
+
+  async execute(eventId: string, audit: AuditContext) {
+    return this.db.withAudit(audit, async (tx, auditLog) => {
+      const before = await tx
+        .select({
+          id: eventRosters.id,
+          checkedInAt: eventRosters.checkedInAt,
+        })
+        .from(eventRosters)
+        .where(
+          and(
+            eq(eventRosters.eventId, eventId),
+            isNotNull(eventRosters.checkedInAt)
+          )
+        );
+
+      if (before.length === 0) return { reset: 0 };
+
+      await tx
+        .update(eventRosters)
+        .set({ checkedInAt: null })
+        .where(
+          and(
+            eq(eventRosters.eventId, eventId),
+            isNotNull(eventRosters.checkedInAt)
+          )
+        );
+
+      for (const row of before) {
+        auditLog.log({
+          action: "update",
+          resource: "roster",
+          resourceId: row.id,
+          metadata: {
+            field: "checkedInAt",
+            before: row.checkedInAt,
+            after: null,
+          },
+        });
+      }
+
+      return { reset: before.length };
+    });
+  }
+}

--- a/apps/backend/app/modules/orgs/events/routes.ts
+++ b/apps/backend/app/modules/orgs/events/routes.ts
@@ -58,6 +58,8 @@ const AudioUploadUrlController = () =>
 const ViewAsController = () => import("./view-as/controller.ts");
 const CheckInController = () => import("./check-in/controller.ts");
 const AdminCheckInController = () => import("./rosters/check-in/controller.ts");
+const ResetCheckInController = () =>
+  import("./rosters/check-in/reset/controller.ts");
 const CheckInStatusController = () => import("./check-in/status-controller.ts");
 const ScheduleController = () => import("./schedule/controller.ts");
 const TestEmailsController = () => import("./test-emails/controller.ts");
@@ -355,6 +357,14 @@ router
         middleware.org(),
         middleware.orgEvent(),
         middleware.orgMember(),
+      ]);
+    router
+      .post(":slug/events/:id/rosters/check-in/reset", [ResetCheckInController])
+      .use([
+        middleware.auth(),
+        middleware.org(),
+        middleware.orgMember(),
+        middleware.orgAdmin(),
       ]);
     router
       .post(":slug/events/:id/rosters/:rosterId/check-in", [

--- a/apps/frontend/src/features/org/api/check-in-queries.ts
+++ b/apps/frontend/src/features/org/api/check-in-queries.ts
@@ -68,6 +68,21 @@ export function useDancerCheckIn(slug: string, eventId: string) {
   });
 }
 
+export function useResetCheckIn() {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ slug, eventId }: { slug: string; eventId: string }) =>
+      rawClient
+        .POST(`/orgs/${slug}/events/${eventId}/rosters/check-in/reset`)
+        .then((r) => r.data as { reset: number }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: [...ROSTER_LIST_KEY_PREFIX] });
+      qc.invalidateQueries({ queryKey: [...ROSTER_STATS_KEY_PREFIX] });
+    },
+  });
+}
+
 export function useAdminCheckInToggle() {
   const qc = useQueryClient();
 

--- a/apps/frontend/src/features/org/components/reset-check-in-dialog.tsx
+++ b/apps/frontend/src/features/org/components/reset-check-in-dialog.tsx
@@ -1,0 +1,92 @@
+import { useId, useState } from "react";
+
+import {
+  AlertDialog,
+  AlertDialogClose,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogPopup,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+
+export interface ResetCheckInDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  eventName: string;
+  checkedInCount: number;
+  isPending?: boolean;
+  onConfirm: () => void;
+}
+
+export function ResetCheckInDialog({
+  open,
+  onOpenChange,
+  ...rest
+}: ResetCheckInDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogPopup>
+        {/* Content unmounts while closed, so the confirmation checkbox starts
+            unchecked on every open. */}
+        <ResetCheckInDialogContent {...rest} />
+      </AlertDialogPopup>
+    </AlertDialog>
+  );
+}
+
+type ResetCheckInDialogContentProps = Omit<
+  ResetCheckInDialogProps,
+  "open" | "onOpenChange"
+>;
+
+function ResetCheckInDialogContent({
+  eventName,
+  checkedInCount,
+  isPending = false,
+  onConfirm,
+}: ResetCheckInDialogContentProps) {
+  const [confirmed, setConfirmed] = useState(false);
+  const confirmId = useId();
+
+  return (
+    <>
+      <AlertDialogHeader>
+        <AlertDialogTitle>Reset check-in</AlertDialogTitle>
+        <AlertDialogDescription>
+          This will clear check-in for all {checkedInCount.toLocaleString()}{" "}
+          checked-in dancers in {eventName}. They will need to check in again.
+        </AlertDialogDescription>
+      </AlertDialogHeader>
+
+      <div className="flex items-start gap-2 px-6">
+        <Checkbox
+          id={confirmId}
+          checked={confirmed}
+          onCheckedChange={(checked) => setConfirmed(!!checked)}
+        />
+        <label
+          htmlFor={confirmId}
+          className="text-muted-foreground cursor-pointer text-sm leading-tight select-none"
+        >
+          I understand this will clear all check-in records for this event.
+        </label>
+      </div>
+
+      <AlertDialogFooter variant="bare">
+        <AlertDialogClose render={<Button variant="ghost" />}>
+          Cancel
+        </AlertDialogClose>
+        <Button
+          variant="destructive"
+          disabled={!confirmed || isPending}
+          onClick={onConfirm}
+        >
+          {isPending ? "Resetting…" : "Reset check-in"}
+        </Button>
+      </AlertDialogFooter>
+    </>
+  );
+}

--- a/apps/frontend/src/features/org/components/roster-page-header.spec.ts
+++ b/apps/frontend/src/features/org/components/roster-page-header.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { ROSTER_HEADER_ACTIONS_CLASS_NAME } from "./roster-page-header";
+
+describe("RosterPageHeader", () => {
+  it("wraps the reset action onto its own line on mobile instead of overflowing", () => {
+    expect(ROSTER_HEADER_ACTIONS_CLASS_NAME).toContain("flex-wrap");
+    // Row gap only matters once the button has wrapped below the widget.
+    expect(ROSTER_HEADER_ACTIONS_CLASS_NAME).toContain("gap-y-2");
+  });
+
+  it("keeps the activation widget and reset action aligned on one row", () => {
+    expect(ROSTER_HEADER_ACTIONS_CLASS_NAME).toContain("items-center");
+    expect(ROSTER_HEADER_ACTIONS_CLASS_NAME).toContain("gap-x-3");
+  });
+});

--- a/apps/frontend/src/features/org/components/roster-page-header.tsx
+++ b/apps/frontend/src/features/org/components/roster-page-header.tsx
@@ -1,5 +1,13 @@
+import { Button } from "@/components/ui/button";
 import { cn } from "@/components/utils/cn";
 import type { RosterStatus } from "@/features/org/api/roster-queries";
+
+/**
+ * The activation widget and the reset action share one wrapping row so the
+ * button drops to its own line on narrow viewports instead of overflowing.
+ */
+export const ROSTER_HEADER_ACTIONS_CLASS_NAME =
+  "flex flex-wrap items-center gap-x-3 gap-y-2";
 
 export interface RosterPageHeaderStats {
   total: number;
@@ -17,6 +25,7 @@ export interface RosterPageHeaderProps {
   isLoading?: boolean;
   status: RosterStatus;
   onStatusChange: (status: RosterStatus) => void;
+  onResetCheckIn?: () => void;
 }
 
 export function RosterPageHeader({
@@ -26,6 +35,7 @@ export function RosterPageHeader({
   isLoading = false,
   status,
   onStatusChange,
+  onResetCheckIn,
 }: RosterPageHeaderProps) {
   const activationPct =
     stats.total === 0 ? 0 : Math.round((stats.activated / stats.total) * 100);
@@ -41,31 +51,43 @@ export function RosterPageHeader({
             {eventName}
           </span>
         </div>
-        <div className="flex items-center gap-3">
-          <div className="text-sm 2xl:text-base">
-            <span className="font-semibold tabular-nums">
-              {isLoading ? "–" : stats.activated.toLocaleString()}
-            </span>
-            <span className="text-muted-foreground">
-              /{isLoading ? "–" : stats.total.toLocaleString()} activated
-            </span>
-          </div>
-          <div
-            className="bg-border h-0.5 w-[120px] overflow-hidden"
-            role="progressbar"
-            aria-valuenow={activationPct}
-            aria-valuemin={0}
-            aria-valuemax={100}
-            aria-label="Roster activation progress"
-          >
+        <div className={ROSTER_HEADER_ACTIONS_CLASS_NAME}>
+          <div className="flex items-center gap-3">
+            <div className="text-sm 2xl:text-base">
+              <span className="font-semibold tabular-nums">
+                {isLoading ? "–" : stats.activated.toLocaleString()}
+              </span>
+              <span className="text-muted-foreground">
+                /{isLoading ? "–" : stats.total.toLocaleString()} activated
+              </span>
+            </div>
             <div
-              className="bg-foreground h-full"
-              style={{ width: `${activationPct}%` }}
-            />
+              className="bg-border h-0.5 w-[120px] overflow-hidden"
+              role="progressbar"
+              aria-valuenow={activationPct}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label="Roster activation progress"
+            >
+              <div
+                className="bg-foreground h-full"
+                style={{ width: `${activationPct}%` }}
+              />
+            </div>
+            <span className="text-muted-foreground text-[11px] tabular-nums 2xl:text-xs">
+              {activationPct}%
+            </span>
           </div>
-          <span className="text-muted-foreground text-[11px] tabular-nums 2xl:text-xs">
-            {activationPct}%
-          </span>
+          {onResetCheckIn && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onResetCheckIn}
+              disabled={isLoading || !stats.checkedIn}
+            >
+              Reset check-in
+            </Button>
+          )}
         </div>
       </header>
 

--- a/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/admin/dancers.tsx
+++ b/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/admin/dancers.tsx
@@ -9,7 +9,9 @@ import {
   useResendInvites,
   useUpdateRoster,
 } from "@/features/org/api/roster-queries";
+import { useResetCheckIn } from "@/features/org/api/check-in-queries";
 import { DataGrid, StatusBadge } from "@/features/org/components/data-grid";
+import { ResetCheckInDialog } from "@/features/org/components/reset-check-in-dialog";
 import { rosterBulkActions } from "@/features/org/components/roster-bulk-actions";
 import { RosterDetailSheet } from "@/features/org/components/roster-detail-sheet";
 import { RosterPageHeader } from "@/features/org/components/roster-page-header";
@@ -162,6 +164,7 @@ function DancersPage() {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [sheetOpen, setSheetOpen] = useState(false);
+  const [resetOpen, setResetOpen] = useState(false);
   const openSheetRafRef = useRef<number | null>(null);
 
   const sortBy = sorting[0]?.id as SortColumn | undefined;
@@ -187,10 +190,15 @@ function DancersPage() {
 
   const data = (listQuery.data?.data ?? []) as RosterEntryWithCheckIn[];
   const total = listQuery.data?.total ?? 0;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const checkedInCount = (statsQuery.data as any)?.checkedIn as
+    | number
+    | undefined;
 
   const updateMutation = useUpdateRoster();
   const deleteMutation = useDeleteRosters();
   const resendMutation = useResendInvites();
+  const resetCheckInMutation = useResetCheckIn();
 
   const selectedEntry = data.find((r) => r.id === selectedId) ?? null;
 
@@ -307,6 +315,23 @@ function DancersPage() {
     },
   });
 
+  const handleResetCheckIn = async () => {
+    if (!active) return;
+    try {
+      const result = await resetCheckInMutation.mutateAsync({
+        slug: orgSlug,
+        eventId: active.id,
+      });
+      setResetOpen(false);
+      toastManager.add({
+        title: `Check-in reset for ${result.reset} dancer${result.reset === 1 ? "" : "s"}`,
+        type: "success",
+      });
+    } catch {
+      toastManager.add({ title: "Failed to reset check-in", type: "error" });
+    }
+  };
+
   if (!active) {
     return (
       <div className="text-muted-foreground flex flex-1 items-center justify-center text-sm">
@@ -324,8 +349,7 @@ function DancersPage() {
           total: statsQuery.data?.total ?? 0,
           activated: statsQuery.data?.active ?? 0,
           pending: statsQuery.data?.pending ?? 0,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          checkedIn: checkInEnabled ? ((statsQuery.data as any)?.checkedIn as number | undefined) : undefined,
+          checkedIn: checkInEnabled ? checkedInCount : undefined,
         }}
         isLoading={statsQuery.isLoading}
         status={status}
@@ -333,6 +357,9 @@ function DancersPage() {
           setStatus(next);
           setPage(0);
         }}
+        onResetCheckIn={
+          checkInEnabled ? () => setResetOpen(true) : undefined
+        }
       />
       <DataGrid
         storageKey="roster-dancers"
@@ -372,6 +399,15 @@ function DancersPage() {
         onOpenChange={setSheetOpen}
         checkInEnabled={checkInEnabled}
         freeTierEnabled={freeTierEnabled}
+      />
+
+      <ResetCheckInDialog
+        open={resetOpen}
+        onOpenChange={setResetOpen}
+        eventName={active.name}
+        checkedInCount={checkedInCount ?? 0}
+        isPending={resetCheckInMutation.isPending}
+        onConfirm={handleResetCheckIn}
       />
     </div>
   );


### PR DESCRIPTION
Adds an admin-only action to clear check-in for every roster row on the selected event.

Design doc: `docs/superpowers/specs/2026-07-16-reset-checkin-design.md` (already on `main`).

## Backend

`POST /orgs/:slug/events/:id/rosters/check-in/reset`, gated by `orgAdmin` like the other destructive roster routes. There is no separate check-in table — check-in is the nullable `event_rosters.checked_in_at` column — so "reset" nulls it.

The service selects the event's rows where `checkedInAt is not null` (scoped by `eventId`, the tenant-safety pattern used throughout this router), nulls them, and logs one audit entry per row, matching the single-row toggle and bulk-delete services. Filtering to non-null rows up front keeps already-cleared rows out of the audit trail and yields the reset count. Staff rows are included, so a reset doesn't leave staff silently checked in. Returns `{ reset: <count> }`.

## Frontend

A ghost **Reset check-in** button beside the activation widget in the roster header, behind an `AlertDialog` with a confirmation checkbox that gates the destructive button.

- The widget and button share a `flex-wrap` row, so the button drops to its own line on narrow viewports instead of overflowing.
- The dialog's content unmounts while closed, so the checkbox starts unchecked on every open — no `useEffect`.
- Button is gated on the `check_in` feature flag and disabled when nothing is checked in.
- No optimistic update: the action sits behind a confirm dialog, and invalidating the roster + stats queries is simpler than rewriting every cached row.

## Testing

Backend (`ResetCheckInService`, 5 tests): clears `checkedInAt` and returns the count; logs one audit entry per reset row; **leaves a different event's rosters untouched**; resets staff rows; returns `{ reset: 0 }` and logs nothing when no one is checked in.

Frontend asserts the header's responsive wrap classes, following the existing `event-schedule-dialog.spec.ts` pattern (this project has no jsdom/testing-library, so components can't be rendered in tests).

## Verification

- Frontend: typecheck clean, lint clean, 9/9 tests.
- Backend: typecheck clean, lint clean on changed files, **182 passed / 8 failed (190)** — 177 baseline passes plus these 5 new tests. Those 8 failures are pre-existing on `main` and unrelated (`ExportRosterService` ×2, `StatsRosterService` ×4, one org-role middleware, one `UploadDancersService`); confirmed identical across repeated runs of unmodified `HEAD`.
- Not verified in a browser — the responsive wrap is worth a visual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)