### PR TITLE
fix(backend): exit the test runner instead of hanging forever

### DIFF
--- a/apps/backend/bin/test.ts
+++ b/apps/backend/bin/test.ts
@@ -59,4 +59,39 @@ new Ignitor(APP_ROOT, { importer: IMPORTER })
   .catch((error) => {
     process.exitCode = 1;
     prettyPrintError(error);
+  })
+  .finally(async () => {
+    /**
+     * Something in the test environment keeps the event loop alive after Japa
+     * has finished and the app has terminated, so the runner would otherwise
+     * hang forever instead of exiting. Each hung run holds onto its Postgres
+     * connections, so repeated runs exhaust the server's connection limit.
+     * Force the exit, preserving whatever exit code Japa set.
+     */
+    await flushOutput();
+    process.exit(process.exitCode ?? 0);
   });
+
+/**
+ * process.exit() discards anything still buffered in stdout/stderr, which
+ * truncates the reporter's output when it is piped to a file or another
+ * process. Wait for both streams to drain first.
+ */
+function flushOutput() {
+  return new Promise<void>((resolve) => {
+    let pending = 0;
+    const settle = () => {
+      pending -= 1;
+      if (pending === 0) resolve();
+    };
+
+    for (const stream of [process.stdout, process.stderr]) {
+      if (stream.writableLength > 0) {
+        pending += 1;
+        stream.write("", settle);
+      }
+    }
+
+    if (pending === 0) resolve();
+  });
+}


### PR DESCRIPTION
## The problem

`node ace test` runs the tests, prints the summary, and then **never exits**. It sits there idle until you Ctrl-C it.

This is worse than a nuisance. Every hung run keeps its Postgres connections open, so repeated local runs walk the server toward its `max_connections` limit (I watched it reach 50 of 100). Once that happens, *new* test runs block on connection acquisition — which presents as a completely unrelated hang, in a different place, with no obvious cause.

Reproduces on Node **v22.16.0** and **v24.9.0**, with any spec file. Not new — it affects existing specs and is unrelated to any feature work.

## The fix

Force the exit once Japa is done, preserving its exit code.

Output is flushed first: `process.exit()` discards whatever is still buffered in stdout/stderr, which truncates the reporter's summary when output is piped to a file or another process (i.e. CI).

## This treats the symptom

Worth being explicit: this does not fix whatever holds the event loop open, and that's still worth finding. What the evidence rules out:

- **The ts-node ESM loader's MessagePort** — `ace --help` holds the same MessagePort and exits in 1s.
- **An unclosed connection pool / leaked handles** — the hung process holds *zero* TCP sockets.
- **A stray worker thread** — `async_hooks` reports zero live `MESSAGEPORT`/`WORKER` resources while hung.

At the point it hangs, `process._getActiveHandles()` is empty and nothing is ref'd, which by Node's own semantics should mean the process exits. That contradiction is unresolved.

## Verification

On Node v22.16.0 and v24.9.0:

| Check | Result |
|---|---|
| Passing spec | exits **0**, full output intact when piped |
| Failing spec | exits **1** — a runner that always exits 0 would silently green CI |
| Full suite | exits **1** in 13s, with the pre-existing 177 passed / 8 failed |
| Connection leak | **0** connections on the test DB before a run, **0** after it exits |

(The 8 failures are pre-existing on `main` and unrelated: `ExportRosterService` ×2, `StatsRosterService` ×4, one org-role middleware, one `UploadDancersService`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)