### PR TITLE
fix(test): stop media permission tests failing at random

### DIFF
--- a/apps/backend/app/modules/videos/media-permissions.test.ts
+++ b/apps/backend/app/modules/videos/media-permissions.test.ts
@@ -7,6 +7,7 @@ import { subscriptions } from "#database/schema/subscriptions";
 import { users } from "#database/schema/users";
 import { DatabaseService } from "#database/service";
 import { SetRosterPaidService } from "#modules/orgs/events/rosters/set-paid/service";
+import { normalizeEmail } from "#utils/normalize-email";
 import hash from "@adonisjs/core/services/hash";
 import { faker } from "@faker-js/faker";
 import type { ApiClient } from "@japa/api-client";
@@ -22,13 +23,14 @@ interface TestDancerOptions {
 }
 
 async function createDancer(options: TestDancerOptions = {}) {
-  const email = faker.internet.email().toLowerCase();
+  const displayEmail = faker.internet.email().toLowerCase();
+  const email = await normalizeEmail(displayEmail);
   const [user] = await db
     .insert(users)
     .values({
       username: faker.internet.username().toLowerCase(),
       email,
-      displayEmail: email,
+      displayEmail,
       firstName: faker.person.firstName(),
       lastName: faker.person.lastName(),
       password: await hash.make(PASSWORD),
@@ -50,13 +52,14 @@ async function createDancer(options: TestDancerOptions = {}) {
 }
 
 async function createSchool() {
-  const email = faker.internet.email().toLowerCase();
+  const displayEmail = faker.internet.email().toLowerCase();
+  const email = await normalizeEmail(displayEmail);
   const [user] = await db
     .insert(users)
     .values({
       username: faker.internet.username().toLowerCase(),
       email,
-      displayEmail: email,
+      displayEmail,
       firstName: faker.person.firstName(),
       lastName: faker.person.lastName(),
       password: await hash.make(PASSWORD),


### PR DESCRIPTION
## The problem

The `Dancer media permission matrix` group fails at random — **10 of 13** isolated runs on `main` — with `Invalid user credentials` on a dancer that was created moments earlier. A different test fails each time, which is what made it look like a mystery.

## Root cause

The seed helpers write a **raw faker email** straight into the `users` table, bypassing signup. But login runs the submitted email through vine's `normalizeEmail()` *before* looking the user up, and that rewrites some addresses:

| Seeded into `users.email` | What login searches for |
|---|---|
| `darby.stanton@gmail.com` | `darbystanton@gmail.com` |
| `dedric.satterfield35@gmail.com` | `dedricsatterfield35@gmail.com` |
| `linnie.hoeger-hermann@yahoo.com` | `linnie.hoeger@yahoo.com` |

`gmail_remove_dots` strips dots from gmail addresses; `yahoo_remove_subaddress` strips everything after a `-` on yahoo. When faker happens to emit one of those, the normalized lookup misses the seeded row and login 400s.

faker produces such an address about **4 times in 60 (~7%)**. Across the ~7 logins in this group that's a ~1-in-3 chance per run — matching the observed rate.

The tests were never wrong about the behaviour they assert; the fixture just created a user that could not log in.

## The fix

Normalize the email when seeding and keep the raw value as `displayEmail` — the same split production already uses (`database/drizzle/import.ts` does `email: await normalizeEmail(u.displayEmail)`). The stored row now matches what login will look for, whatever faker generates.

No assertions or behaviour under test were changed.

## Verification

Isolated runs of `app/modules/videos/media-permissions.test.ts`:

| | Failing runs |
|---|---|
| Before | **10 / 13** |
| After | **0 / 10** |

Ten consecutive passes at the prior failure rate would be under a 1% event, so this isn't a lucky streak. Typecheck and lint clean.

## Note

This is the only test file that seeds a faker email *and* logs in, so it's the only one exposed to this. Worth knowing for future fixtures: seed users through the same normalization production uses, or logins will be flaky in exactly this way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)