### PR TITLE
fix(org): allow admins to edit bib number after a dancer activates

### DIFF
--- a/apps/backend/app/modules/orgs/events/rosters/update/service.spec.ts
+++ b/apps/backend/app/modules/orgs/events/rosters/update/service.spec.ts
@@ -169,6 +169,51 @@ test.group("UpdateRosterService", (group) => {
     );
   });
 
+  test("allows updating the bib number for an active dancer", async ({
+    assert,
+  }) => {
+    const actor = await makeActorUser();
+    const { event } = await makeOrgAndEvent();
+    const [user] = await db
+      .insert(users)
+      .values({
+        username: `u_${Date.now()}_${Math.random()}`,
+        email: "bibactive@example.com",
+        displayEmail: "bibactive@example.com",
+        firstName: "Bib",
+        lastName: "Active",
+        password: "hashed",
+        role: "user",
+        type: "dancer",
+      })
+      .returning();
+    const [row] = await db
+      .insert(eventRosters)
+      .values({
+        eventId: event.id,
+        type: "dancer",
+        email: "bibactive@example.com",
+        firstName: "Bib",
+        lastName: "Active",
+        bibNumber: 7,
+        userId: user!.id,
+      })
+      .returning();
+
+    const service = new UpdateRosterService();
+    const result = await service.execute(
+      event.id,
+      row!.id,
+      { bibNumber: 42 },
+      { eventId: event.id, actorId: actor.id }
+    );
+
+    assert.equal(result.bibNumber, 42);
+    // Other fields remain untouched.
+    assert.equal(result.firstName, "Bib");
+    assert.equal(result.lastName, "Active");
+  });
+
   test("rejects profile field updates for coaches", async ({ assert }) => {
     const actor = await makeActorUser();
     const { event } = await makeOrgAndEvent();

--- a/apps/backend/app/modules/orgs/events/rosters/update/service.ts
+++ b/apps/backend/app/modules/orgs/events/rosters/update/service.ts
@@ -68,8 +68,19 @@ export class UpdateRosterService {
         throw new RosterNotFoundError();
       }
 
+      // Registered entries are owned by the dancer's own profile, so admins
+      // may only adjust the bib number (event roster metadata). Any attempt to
+      // edit the other fields is rejected.
       if (row.userId !== null) {
-        throw new RosterActiveReadonlyError();
+        const editsLockedFields =
+          input.firstName !== undefined ||
+          input.lastName !== undefined ||
+          input.email !== undefined ||
+          input.organization !== undefined ||
+          input.profile !== undefined;
+        if (editsLockedFields) {
+          throw new RosterActiveReadonlyError();
+        }
       }
 
       if (row.type === "coach" && input.profile !== undefined) {

--- a/apps/frontend/src/features/org/components/roster-detail-sheet.tsx
+++ b/apps/frontend/src/features/org/components/roster-detail-sheet.tsx
@@ -115,21 +115,28 @@ export function RosterDetailSheet({
   }, [open, entry, reset]);
 
   const onSubmit = async (data: FormValues) => {
-    if (!entry || isActive) return;
+    if (!entry) return;
 
-    const body: Record<string, unknown> = {
-      firstName: data.firstName,
-      lastName: data.lastName,
-      email: data.email,
-    };
-    if (isDancer) {
-      body.bibNumber = data.bibNumber;
-      body.profile = {
-        gradYear: data.gradYear,
-        gpa: data.gpa,
-      };
+    let body: Record<string, unknown>;
+    if (isActive) {
+      // Registered entries: bib number is the only field admins can change.
+      if (!isDancer) return;
+      body = { bibNumber: data.bibNumber };
     } else {
-      body.organization = data.organization;
+      body = {
+        firstName: data.firstName,
+        lastName: data.lastName,
+        email: data.email,
+      };
+      if (isDancer) {
+        body.bibNumber = data.bibNumber;
+        body.profile = {
+          gradYear: data.gradYear,
+          gpa: data.gpa,
+        };
+      } else {
+        body.organization = data.organization;
+      }
     }
 
     try {
@@ -261,8 +268,9 @@ export function RosterDetailSheet({
           <SheetContent>
             {isActive && (
               <div className="mx-4 mt-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-200">
-                This {isDancer ? "dancer" : "coach"} has registered and
-                connected their profile. Admin edits are disabled.
+                {isDancer
+                  ? "This dancer has registered and connected their profile. You can still update their bib number; other details are managed by the dancer."
+                  : "This coach has registered and connected their profile. Admin edits are disabled."}
               </div>
             )}
             <form
@@ -271,7 +279,7 @@ export function RosterDetailSheet({
               className="flex flex-col gap-6 px-4 pt-2 pb-4"
             >
               {/* Roster Info */}
-              <fieldset className="flex flex-col gap-4" disabled={isActive}>
+              <fieldset className="flex flex-col gap-4">
                 <legend className="text-muted-foreground mb-1 text-xs font-medium tracking-wide uppercase">
                   Roster Info
                 </legend>
@@ -281,7 +289,11 @@ export function RosterDetailSheet({
                   render={({ field, fieldState }) => (
                     <Field name={field.name} invalid={fieldState.invalid}>
                       <FieldLabel>First name</FieldLabel>
-                      <Input {...field} value={field.value ?? ""} />
+                      <Input
+                        {...field}
+                        value={field.value ?? ""}
+                        disabled={isActive}
+                      />
                       <FieldError error={fieldState.error} />
                     </Field>
                   )}
@@ -292,7 +304,11 @@ export function RosterDetailSheet({
                   render={({ field, fieldState }) => (
                     <Field name={field.name} invalid={fieldState.invalid}>
                       <FieldLabel>Last name</FieldLabel>
-                      <Input {...field} value={field.value ?? ""} />
+                      <Input
+                        {...field}
+                        value={field.value ?? ""}
+                        disabled={isActive}
+                      />
                       <FieldError error={fieldState.error} />
                     </Field>
                   )}
@@ -307,6 +323,7 @@ export function RosterDetailSheet({
                         {...field}
                         type="email"
                         value={field.value ?? ""}
+                        disabled={isActive}
                       />
                       <FieldError error={fieldState.error} />
                     </Field>
@@ -343,7 +360,11 @@ export function RosterDetailSheet({
                     render={({ field, fieldState }) => (
                       <Field name={field.name} invalid={fieldState.invalid}>
                         <FieldLabel>Organization</FieldLabel>
-                        <Input {...field} value={field.value ?? ""} />
+                        <Input
+                          {...field}
+                          value={field.value ?? ""}
+                          disabled={isActive}
+                        />
                         <FieldError error={fieldState.error} />
                       </Field>
                     )}
@@ -529,7 +550,7 @@ export function RosterDetailSheet({
                 <SheetClose render={<Button variant="ghost" />}>
                   Cancel
                 </SheetClose>
-                {!isActive && (
+                {(!isActive || isDancer) && (
                   <Button type="submit" form={FORM_ID} disabled={saving}>
                     {saving ? <Spinner label="Saving..." /> : "Save changes"}
                   </Button>


### PR DESCRIPTION
Registered roster entries were fully locked (frontend fieldset disable + backend RosterActiveReadonlyError), so admins could not adjust a dancer's bib number once they connected their account. Bib number is event-roster metadata, not dancer-owned profile data, so it is now editable for active entries while name/email/profile stay locked.

- backend: reject only edits to locked fields for registered entries; permit bibNumber changes (per-event uniqueness check still applies)
- frontend: enable the bib input, submit only { bibNumber } for active dancers, show Save, and update the banner copy
- test: cover updating bib for an active dancer