### PR TITLE
fix(scouting): fall back to dancer profile location for State filter

### DIFF
--- a/apps/backend/app/modules/orgs/scouting/dancers/list/service.ts
+++ b/apps/backend/app/modules/orgs/scouting/dancers/list/service.ts
@@ -133,7 +133,9 @@ export class ListDancersService {
           studio: sql<
             string | null
           >`COALESCE(${eventDancerProfiles.studio}, ${dancerProfiles.studio})`,
-          state: eventDancerProfiles.state,
+          state: sql<
+            string | null
+          >`COALESCE(${eventDancerProfiles.state}, ${dancerProfiles.location})`,
           interestedInMySchool: interestedSubquery,
           isFavorited: isFavoritedSubquery,
           rating: ratingSubquery,


### PR DESCRIPTION
## Problem

On an org event's coach dancer roster, the **State** scouting filter shows no options when clicked. The filter builds its dropdown from the distinct `state` values of the dancers in the roster, so an empty list means no dancer has a state.

## Root cause

Dancers' state **is** captured — they pick a US state during onboarding, stored as a 2-letter code in `dancer_profiles.location`. But the scouting list query read state straight from `event_dancer_profiles.state`, a separate per-event column that no write path ever populates (not CSV import, not roster edit, not account attach). So it was always `null`.

The neighboring `gpa`, `gradYear`, and `studio` fields already handle this by COALESCE-ing the event profile value with the base `dancer_profiles` value. `state` was the one field missing that fallback.

## Fix

COALESCE `event_dancer_profiles.state` with `dancer_profiles.location` in the scouting dancers list query, matching the existing pattern. `dancer_profiles` is already joined, so no other changes were needed.

## Note / follow-up

The same missing fallback exists in the other scouting reads (`callbacks/list`, `favorites/list`, `rankings`, `dancers/get-by-id`, and `events/rosters/list` — the last also needs the `dancer_profiles` join added). This PR fixes only the coach dancer roster that was reported; happy to extend to the rest in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)