### PR TITLE
fix(org): update paid access copy and reorder free profile email CTA

### DIFF
--- a/apps/frontend/src/features/org/components/roster-detail-sheet.tsx
+++ b/apps/frontend/src/features/org/components/roster-detail-sheet.tsx
@@ -468,7 +468,7 @@ export function RosterDetailSheet({
                       <span className="text-muted-foreground text-xs">
                         {isActive
                           ? paid
-                            ? "Full S2S access with premium features."
+                            ? "Enable paid organization access"
                             : "Limited profile, YouTube-only video."
                           : "Applied when the dancer activates their account."}
                       </span>

--- a/packages/emails/src/templates/FreeTierInviteEmail.tsx
+++ b/packages/emails/src/templates/FreeTierInviteEmail.tsx
@@ -145,6 +145,22 @@ export function FreeTierInviteEmail({
         <Text style={paragraphStyle}>
           Right now, coaches can only see your basic registration information.
         </Text>
+        <ReactEmailButton
+          href={inviteUrl}
+          style={{
+            display: "inline-block",
+            backgroundColor: colors.primary,
+            color: "#ffffff",
+            fontSize: "14px",
+            fontWeight: "600",
+            padding: "10px 24px",
+            borderRadius: "6px",
+            textDecoration: "none",
+            margin: "0 0 24px",
+          }}
+        >
+          Complete My Free Profile
+        </ReactEmailButton>
         <Text
           style={{
             fontSize: "18px",
@@ -216,22 +232,6 @@ export function FreeTierInviteEmail({
               </Column>
             </Row>
           ))}
-          <ReactEmailButton
-            href={inviteUrl}
-            style={{
-              display: "inline-block",
-              backgroundColor: colors.primary,
-              color: "#ffffff",
-              fontSize: "14px",
-              fontWeight: "600",
-              padding: "10px 24px",
-              borderRadius: "6px",
-              textDecoration: "none",
-              marginTop: "16px",
-            }}
-          >
-            Complete My Free Profile
-          </ReactEmailButton>
         </Section>
 
         {/* ── Recruiting Doesn't End ── */}


### PR DESCRIPTION
## Summary
- Reworded the PAID ACCESS status label in the org roster detail sheet from "Full S2S access with premium features." to "Enable paid organization access"
- Moved the "Complete My Free Profile" button in the free-tier invite email above "Want to stand out?", out of the "Complete Your Free Profile" checklist section

## Test plan
- [x] `pnpm build` passes for `@stos/emails`
- [x] Reviewed diff for scope — no unrelated changes included
- [ ] Visually confirm the roster detail sheet paid-access copy in the browser
- [ ] Preview the free-tier invite email template to confirm button placement

🤖 Generated with [Claude Code](https://claude.com/claude-code)