### PR TITLE
fix(videos): reconcile stuck direct video uploads via hourly cron

### DIFF
--- a/apps/backend/services/reap-stuck-video-uploads.ts
+++ b/apps/backend/services/reap-stuck-video-uploads.ts
@@ -1,0 +1,180 @@
+import { db } from "#database/connection";
+import { videoUploads } from "#database/schema/media";
+import {
+  handleStreamWebhook,
+  type StreamWebhookPayload,
+} from "#modules/webhooks/cloudflare/handlers";
+import env from "#start/env";
+import { and, eq, inArray, isNull, lt } from "drizzle-orm";
+
+// A direct (TUS) upload that never finishes leaves a `pending` row and a
+// Cloudflare Stream entry stuck in `pendingupload`. Cloudflare never fires a
+// webhook for those, so the row lives forever and keeps consuming the user's
+// direct-video limit. Uploads of a <=120s clip complete in minutes, so any row
+// still unresolved after this window is treated as reconcilable.
+const STUCK_THRESHOLD_MS = 2 * 60 * 60 * 1000; // 2 hours
+
+interface CloudflareStreamResult {
+  uid: string;
+  readyToStream: boolean;
+  status: {
+    state: string;
+    errorReasonCode?: string;
+    errorReasonText?: string;
+  };
+  thumbnail?: string;
+  duration?: number;
+}
+
+type StuckUpload = typeof videoUploads.$inferSelect;
+
+export default class ReapStuckVideoUploadsService {
+  async run() {
+    const cutoff = new Date(Date.now() - STUCK_THRESHOLD_MS);
+
+    const stuck = await db
+      .select()
+      .from(videoUploads)
+      .where(
+        and(
+          isNull(videoUploads.videoId),
+          inArray(videoUploads.status, ["pending", "processing"]),
+          lt(videoUploads.createdAt, cutoff)
+        )
+      );
+
+    if (stuck.length === 0) {
+      return;
+    }
+
+    console.log(
+      `[ReapStuckVideoUploads]: Reconciling ${stuck.length} stuck upload(s)`
+    );
+
+    for (const upload of stuck) {
+      try {
+        await this.reconcile(upload);
+      } catch (error) {
+        // Transient failures (e.g. Cloudflare API hiccup) are left for the
+        // next hourly run rather than blocking the rest of the batch.
+        console.error(
+          `[ReapStuckVideoUploads]: Failed to reconcile ${upload.cloudflareMediaId}:`,
+          error
+        );
+      }
+    }
+  }
+
+  private async reconcile(upload: StuckUpload) {
+    const response = await fetch(
+      `https://api.cloudflare.com/client/v4/accounts/${env.get(
+        "CLOUDFLARE_ACCOUNT_ID"
+      )}/stream/${upload.cloudflareMediaId}`,
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${env.get("CLOUDFLARE_STREAM_TOKEN")}`,
+        },
+      }
+    );
+
+    // The Cloudflare entry is already gone — nothing to delete, just fail the row.
+    if (response.status === 404) {
+      await this.markFailed(upload, "stale/abandoned upload");
+      return;
+    }
+
+    if (!response.ok) {
+      throw new Error(`Cloudflare Stream API error: ${response.status}`);
+    }
+
+    const body = (await response.json()) as {
+      result?: CloudflareStreamResult;
+    };
+    const result = body.result;
+    if (!result) {
+      throw new Error("Missing result in Cloudflare response");
+    }
+
+    switch (result.status.state) {
+      case "ready": {
+        // The upload actually completed but we missed the webhook. Replay it
+        // through the real handler so the video, feed entry, and ready event
+        // are all created exactly as they would have been.
+        await handleStreamWebhook(this.toWebhookPayload(result));
+        break;
+      }
+
+      case "error": {
+        const message =
+          result.status.errorReasonText ||
+          result.status.errorReasonCode ||
+          "Cloudflare processing error";
+        await this.markFailed(upload, message);
+        await this.deleteFromCloudflare(upload.cloudflareMediaId);
+        break;
+      }
+
+      case "pendingupload": {
+        // Bytes were never fully uploaded — genuinely abandoned.
+        await this.markFailed(upload, "stale/abandoned upload");
+        await this.deleteFromCloudflare(upload.cloudflareMediaId);
+        break;
+      }
+
+      // inprogress / queued / downloading: Cloudflare is still actively working
+      // on it. Leave it alone (it stays counted) and let the webhook or a later
+      // run resolve it, rather than failing legitimate in-flight processing.
+      default:
+        break;
+    }
+  }
+
+  private toWebhookPayload(
+    result: CloudflareStreamResult
+  ): StreamWebhookPayload {
+    return {
+      uid: result.uid,
+      readyToStream: result.readyToStream,
+      status: {
+        state: "ready",
+        errorReasonCode: result.status.errorReasonCode,
+        errorReasonText: result.status.errorReasonText,
+      },
+      thumbnail: result.thumbnail,
+      duration: result.duration,
+    };
+  }
+
+  private async markFailed(upload: StuckUpload, errorMessage: string) {
+    await db
+      .update(videoUploads)
+      .set({
+        status: "failed",
+        errorMessage,
+        updatedAt: new Date(),
+      })
+      .where(eq(videoUploads.id, upload.id));
+  }
+
+  private async deleteFromCloudflare(mediaId: string) {
+    const response = await fetch(
+      `https://api.cloudflare.com/client/v4/accounts/${env.get(
+        "CLOUDFLARE_ACCOUNT_ID"
+      )}/stream/${mediaId}`,
+      {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${env.get("CLOUDFLARE_STREAM_TOKEN")}`,
+        },
+      }
+    );
+
+    // 404 is fine — the entry is already gone.
+    if (!response.ok && response.status !== 404) {
+      console.error(
+        `[ReapStuckVideoUploads]: Failed to delete ${mediaId} from Cloudflare: ${response.status}`
+      );
+    }
+  }
+}

--- a/apps/backend/start/cron.ts
+++ b/apps/backend/start/cron.ts
@@ -2,10 +2,12 @@ import { CronJob } from "cron";
 import CacheSkillsService from "../services/cache-skills.ts";
 import ExpireSubscriptionsService from "../services/expire-subscriptions.ts";
 import PublishOutboxService from "../services/publish-outbox.ts";
+import ReapStuckVideoUploadsService from "../services/reap-stuck-video-uploads.ts";
 
 const cacheSkillsService = new CacheSkillsService();
 const expireSubscriptionsService = new ExpireSubscriptionsService();
 const publishOutboxService = new PublishOutboxService();
+const reapStuckVideoUploadsService = new ReapStuckVideoUploadsService();
 
 // Cache skill rarity every hour
 new CronJob("0 * * * *", async () => {
@@ -19,6 +21,16 @@ new CronJob("0 0 * * *", async () => {
     await expireSubscriptionsService.run();
   } catch (error) {
     console.error("[Cron]: Error expiring subscriptions:", error);
+  }
+}).start();
+
+// Reconcile stuck/abandoned direct video uploads every hour so they stop
+// consuming users' direct-video limit (recovers ready ones, fails abandoned)
+new CronJob("0 * * * *", async () => {
+  try {
+    await reapStuckVideoUploadsService.run();
+  } catch (error) {
+    console.error("[Cron]: Error reaping stuck video uploads:", error);
   }
 }).start();
 


### PR DESCRIPTION
## Problem

Abandoned direct (TUS/Cloudflare) video uploads leave a `pending` row in `video_uploads` that never receives a Cloudflare webhook. The row lives forever and permanently consumes the user's **3-video direct upload limit** — silently blocking further uploads (the frontend only counts completed `profile_videos`, so the UI looks like there's room while the backend rejects the upload).

At the time of this change, **32 stuck rows across 17 users** existed, with **13 users at/over their limit** purely because of stale rows. One premium dancer (Brooke Cullison) hit exactly this: 1 real video + 2 abandoned `pending` rows = 3/3.

## Root cause

- The Cloudflare webhook is the **only** code path that moves a row out of `pending`. An upload abandoned before bytes finish stays `pendingupload` on Cloudflare, which fires no webhook.
- `delete-video` only reaches uploads *through* a completed `videos` record, so unlinked stuck rows are unreachable from the UI.
- No cron/reaper existed to reconcile them.

## Fix

Add `ReapStuckVideoUploadsService`, registered hourly in `start/cron.ts` (mirrors the existing `expire-subscriptions` pattern). For each unlinked `pending`/`processing` row older than **2 hours**, it reconciles against the Cloudflare Stream API:

| Cloudflare state | Action |
|---|---|
| `ready` | Replay `handleStreamWebhook` — recovers an upload whose webhook was dropped (creates video + feed + ready event) |
| `pendingupload` | Mark `failed` (`stale/abandoned upload`) + delete the Cloudflare entry |
| `error` / `404` | Mark `failed` |
| `inprogress` / `queued` / `downloading` | Skip — still counts, resolved by webhook or a later run |

### Design notes
- **Recovers, not just fails** — a genuinely-ready upload with a dropped webhook is completed correctly.
- **No failure notifications from the reaper** — avoids blasting users about long-abandoned uploads on the first sweep.
- **Active uploads still count** — only rows past the 2h window are freed, so users can't bypass the limit by starting many uploads at once.
- **Does not touch the upload-limit query** — purely additive.

## Verification
- Read-only dry-run against live Cloudflare: all 32 backlog rows were `pendingupload` (none recoverable-ready, none actively processing).
- Ran the reconciler once against the backlog: all 32 rows → `failed` (`stale/abandoned upload`), Cloudflare entries deleted (verified 404), **0 stuck rows remaining, 0 users still limit-blocked**.
- New files typecheck clean. (Pre-existing unrelated `tsc` error in `app/shared/org/free-tier-invite-email.ts` re: `@stos/emails` is present on `main`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHtomxEs9NEujXBQ1PznEQ