### PR TITLE
fix(emails): update free profile checklist copy

### DIFF
--- a/packages/emails/src/templates/FreeTierInviteEmail.tsx
+++ b/packages/emails/src/templates/FreeTierInviteEmail.tsx
@@ -190,21 +190,11 @@ export function FreeTierInviteEmail({
         >
           <Text
             style={{
-              fontSize: "18px",
-              fontWeight: "700",
-              color: colors.text,
-              margin: "0 0 8px",
-            }}
-          >
-            Complete Your Free Profile
-          </Text>
-          <Text
-            style={{
               ...paragraphStyle,
               margin: "0 0 12px",
             }}
           >
-            Add:
+            Complete Your Profile With:
           </Text>
           {checkItems.map((item) => (
             <Row key={item} style={{ margin: "0 0 4px" }}>


### PR DESCRIPTION
## Summary
- Replaced the "Add:" label with "Complete Your Profile With:" in the free-tier invite email's checklist section
- Removed the redundant "Complete Your Free Profile" title above it

## Test plan
- [x] `pnpm build` passes for `@stos/emails`
- [ ] Preview the free-tier invite email template to confirm the checklist section reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)