### PR TITLE
fix(org): stabilize invite tokens and clarify invite states

### DIFF
--- a/apps/backend/.adonisjs/api.ts
+++ b/apps/backend/.adonisjs/api.ts
@@ -355,6 +355,10 @@ type OrgsIdEventsIdCheckinPost = {
   request: unknown
   response: MakeTuyauResponse<import('../app/modules/orgs/events/check-in/controller.ts').default['handle'], false>
 }
+type OrgsIdEventsIdRostersCheckinResetPost = {
+  request: unknown
+  response: MakeTuyauResponse<import('../app/modules/orgs/events/rosters/check-in/reset/controller.ts').default['handle'], false>
+}
 type OrgsIdEventsIdRostersIdCheckinPost = {
   request: unknown
   response: MakeTuyauResponse<import('../app/modules/orgs/events/rosters/check-in/controller.ts').default['handle'], false>
@@ -506,6 +510,10 @@ type OrgsRegisterSchoolPost = {
 type OrgsInvitesSchoolIdGetHead = {
   request: unknown
   response: MakeTuyauResponse<import('../app/modules/orgs/invite-lookup-school/controller.ts').default['handle'], false>
+}
+type OrgsIdInvitesDancerIdGetHead = {
+  request: unknown
+  response: MakeTuyauResponse<import('../app/modules/orgs/invite-lookup-dancer/controller.ts').default['handle'], false>
 }
 type SkillsGetHead = {
   request: unknown
@@ -1246,6 +1254,13 @@ export interface ApiDefinition {
               '$get': OrgsIdEventsIdRostersSearchdancersGetHead;
               '$head': OrgsIdEventsIdRostersSearchdancersGetHead;
             };
+            'check-in': {
+              'reset': {
+                '$url': {
+                };
+                '$post': OrgsIdEventsIdRostersCheckinResetPost;
+              };
+            };
           };
           'checklist': {
             '$url': {
@@ -1500,6 +1515,16 @@ export interface ApiDefinition {
         '$url': {
         };
         '$post': OrgsIdRegisterPost;
+      };
+      'invites': {
+        'dancer': {
+          ':token': {
+            '$url': {
+            };
+            '$get': OrgsIdInvitesDancerIdGetHead;
+            '$head': OrgsIdInvitesDancerIdGetHead;
+          };
+        };
       };
     };
     '$url': {

--- a/apps/backend/app/modules/orgs/events/reconciliation/controller.ts
+++ b/apps/backend/app/modules/orgs/events/reconciliation/controller.ts
@@ -28,6 +28,11 @@ export class ResendInviteController {
     if ("notFound" in result) {
       return response.notFound({ message: "Invite not found." });
     }
+    if ("alreadyClaimed" in result) {
+      return response.conflict({
+        message: "This coach has already registered.",
+      });
+    }
     return response.ok({ resent: true });
   }
 }

--- a/apps/backend/app/modules/orgs/events/reconciliation/resend-controller.ts
+++ b/apps/backend/app/modules/orgs/events/reconciliation/resend-controller.ts
@@ -16,6 +16,11 @@ export default class ResendInviteController {
     if ("notFound" in result) {
       return response.notFound({ message: "Invite not found." });
     }
+    if ("alreadyClaimed" in result) {
+      return response.conflict({
+        message: "This coach has already registered.",
+      });
+    }
     return response.ok({ resent: true });
   }
 }

--- a/apps/backend/app/modules/orgs/events/reconciliation/service.spec.ts
+++ b/apps/backend/app/modules/orgs/events/reconciliation/service.spec.ts
@@ -1,0 +1,104 @@
+import { test } from "@japa/runner";
+import { eq } from "drizzle-orm";
+import { db } from "#database/connection";
+import { DatabaseService } from "#database/service";
+import { organizations } from "#database/schema/organizations";
+import { orgEvents, eventRosters } from "#database/schema/org-events";
+import { schoolInvites } from "#database/schema/schools";
+import mail from "@adonisjs/mail/services/main";
+import { ReconciliationService } from "./service.ts";
+
+async function makeOrgAndEvent() {
+  const [org] = await db
+    .insert(organizations)
+    .values({ name: "T", slug: `t-${Date.now()}-${Math.random()}` })
+    .returning();
+  const [event] = await db
+    .insert(orgEvents)
+    .values({
+      orgId: org!.id,
+      name: "E",
+      startDate: "2026-06-01",
+      endDate: "2026-06-02",
+    })
+    .returning();
+  return { org: org!, event: event! };
+}
+
+test.group("ReconciliationService.resendInvite", (group) => {
+  group.each.setup(async () => {
+    await db.delete(eventRosters).execute();
+    await db.delete(schoolInvites).execute();
+    await db.delete(orgEvents).execute();
+    await db.delete(organizations).execute();
+    mail.fake();
+  });
+
+  group.each.teardown(() => {
+    mail.restore();
+  });
+
+  test("keeps the same token and preserves consumedAt on resend", async ({
+    assert,
+  }) => {
+    const { org, event } = await makeOrgAndEvent();
+    // A previously emailed, already-claimed invite with a far-future expiry.
+    const consumedAt = new Date();
+    const farFuture = new Date(Date.now() + 1000 * 60 * 60 * 24 * 60);
+    const [invite] = await db
+      .insert(schoolInvites)
+      .values({
+        eventId: event.id,
+        email: "coach@example.com",
+        organization: "Example University",
+        token: "stable_admin_token",
+        expiresAt: farFuture,
+        consumedAt,
+      })
+      .returning();
+
+    const service = new ReconciliationService(new DatabaseService());
+    const result = await service.resendInvite(invite!.id, event.id, org.slug);
+    assert.deepEqual(result, { resent: true });
+
+    const [after] = await db
+      .select()
+      .from(schoolInvites)
+      .where(eq(schoolInvites.id, invite!.id));
+    // Token reused, not regenerated.
+    assert.equal(after!.token, "stable_admin_token");
+    // Claim preserved (never reopened).
+    assert.isNotNull(after!.consumedAt);
+    // Expiry not shortened below the far-future value.
+    assert.equal(after!.expiresAt.getTime(), farFuture.getTime());
+  });
+
+  test("extends a short expiry without changing the token", async ({
+    assert,
+  }) => {
+    const { org, event } = await makeOrgAndEvent();
+    const soon = new Date(Date.now() + 1000);
+    const [invite] = await db
+      .insert(schoolInvites)
+      .values({
+        eventId: event.id,
+        email: "coach2@example.com",
+        organization: "Example University",
+        token: "short_expiry_token",
+        expiresAt: soon,
+      })
+      .returning();
+
+    const service = new ReconciliationService(new DatabaseService());
+    await service.resendInvite(invite!.id, event.id, org.slug);
+
+    const [after] = await db
+      .select()
+      .from(schoolInvites)
+      .where(eq(schoolInvites.id, invite!.id));
+    assert.equal(after!.token, "short_expiry_token");
+    // Expiry pushed out to ~14 days.
+    assert.isAbove(after!.expiresAt.getTime(), Date.now() + 13 * 86400000);
+    assert.isNull(after!.consumedAt);
+  });
+});

--- a/apps/backend/app/modules/orgs/events/reconciliation/service.spec.ts
+++ b/apps/backend/app/modules/orgs/events/reconciliation/service.spec.ts
@@ -38,7 +38,7 @@ test.group("ReconciliationService.resendInvite", (group) => {
     mail.restore();
   });
 
-  test("keeps the same token and preserves consumedAt on resend", async ({
+  test("does not resend or reopen an already-claimed invite", async ({
     assert,
   }) => {
     const { org, event } = await makeOrgAndEvent();
@@ -59,17 +59,17 @@ test.group("ReconciliationService.resendInvite", (group) => {
 
     const service = new ReconciliationService(new DatabaseService());
     const result = await service.resendInvite(invite!.id, event.id, org.slug);
-    assert.deepEqual(result, { resent: true });
+    // The coach has already registered — resend is a no-op (no email), and the
+    // guard returns before the send/expiry-bump path.
+    assert.deepEqual(result, { alreadyClaimed: true });
 
     const [after] = await db
       .select()
       .from(schoolInvites)
       .where(eq(schoolInvites.id, invite!.id));
-    // Token reused, not regenerated.
+    // Token, claim, and expiry all untouched.
     assert.equal(after!.token, "stable_admin_token");
-    // Claim preserved (never reopened).
     assert.isNotNull(after!.consumedAt);
-    // Expiry not shortened below the far-future value.
     assert.equal(after!.expiresAt.getTime(), farFuture.getTime());
   });
 

--- a/apps/backend/app/modules/orgs/events/reconciliation/service.ts
+++ b/apps/backend/app/modules/orgs/events/reconciliation/service.ts
@@ -69,6 +69,11 @@ export class ReconciliationService {
     );
     if (!invite) return { notFound: true } as const;
 
+    // An already-claimed invite must never be re-emailed — the coach has already
+    // registered. listUnclaimed still surfaces consumed invites (with a badge),
+    // so the resend action can reach this path; treat it as a no-op.
+    if (invite.consumedAt) return { alreadyClaimed: true } as const;
+
     // Stable resend: reuse the existing token so previously emailed links stay
     // valid, extend expiry without ever shortening it, and never reset
     // consumedAt (an already-claimed invite must not be reopened).

--- a/apps/backend/app/modules/orgs/events/reconciliation/service.ts
+++ b/apps/backend/app/modules/orgs/events/reconciliation/service.ts
@@ -5,7 +5,6 @@ import { orgMemberships, organizations } from "#database/schema/organizations";
 import { users } from "#database/schema/users";
 import { inject } from "@adonisjs/core";
 import { and, eq, isNull, notInArray, sql } from "drizzle-orm";
-import { randomBytes } from "node:crypto";
 import { sendSchoolAccountInviteEmail } from "#shared/org/school-account-invite-email";
 
 @inject()
@@ -70,13 +69,17 @@ export class ReconciliationService {
     );
     if (!invite) return { notFound: true } as const;
 
-    const token = randomBytes(32).toString("hex");
-    const expiresAt = new Date(Date.now() + 14 * 86400000);
-
+    // Stable resend: reuse the existing token so previously emailed links stay
+    // valid, extend expiry without ever shortening it, and never reset
+    // consumedAt (an already-claimed invite must not be reopened).
+    const token = invite.token;
+    const resendExpiry = new Date(Date.now() + 14 * 86400000);
+    const expiresAt =
+      invite.expiresAt > resendExpiry ? invite.expiresAt : resendExpiry;
     await this.db.use((db) =>
       db
         .update(schoolInvites)
-        .set({ token, expiresAt, consumedAt: null })
+        .set({ expiresAt })
         .where(eq(schoolInvites.id, inviteId))
     );
 

--- a/apps/backend/app/modules/orgs/events/rosters/resend-invites/service.spec.ts
+++ b/apps/backend/app/modules/orgs/events/rosters/resend-invites/service.spec.ts
@@ -65,7 +65,7 @@ test.group("ResendInvitesService", (group) => {
     mail.restore();
   });
 
-  test("regenerates tokens and sends emails for pending dancers", async ({
+  test("reuses existing dancer token and creates one for pending dancers", async ({
     assert,
   }) => {
     const actor = await makeActorUser();
@@ -89,11 +89,12 @@ test.group("ResendInvitesService", (group) => {
         },
       ])
       .returning();
-    // Pre-existing stale invite for a@
+    // Pre-existing invite for a@ — its token must be preserved (a previously
+    // emailed link must keep working).
     await db.insert(dancerInvites).values({
       orgId: org.id,
       email: "a@example.com",
-      token: "old_token_should_be_deleted",
+      token: "existing_token_should_be_reused",
       expiresAt: new Date(Date.now() + 1000),
     });
 
@@ -110,22 +111,93 @@ test.group("ResendInvitesService", (group) => {
     assert.equal(result.skipped, 0);
     assert.lengthOf(result.failed, 0);
 
-    // Old invite should be gone
-    const oldInvites = await db
+    // Existing invite is preserved (same token, not deleted).
+    const [inviteA] = await db
       .select()
       .from(dancerInvites)
-      .where(eq(dancerInvites.token, "old_token_should_be_deleted"));
-    assert.lengthOf(oldInvites, 0);
+      .where(eq(dancerInvites.email, "a@example.com"));
+    assert.equal(inviteA!.token, "existing_token_should_be_reused");
+    // Expiry extended to at least ~14 days out (non-shortening).
+    assert.isAbove(inviteA!.expiresAt.getTime(), Date.now() + 13 * 86400000);
 
-    // New invites should exist
-    const newInvites = await db
+    // Dancer without a prior invite gets a fresh one.
+    const [inviteB] = await db
+      .select()
+      .from(dancerInvites)
+      .where(eq(dancerInvites.email, "b@example.com"));
+    assert.isNotNull(inviteB);
+    assert.isAbove(inviteB!.token.length, 10);
+
+    const allInvites = await db
       .select()
       .from(dancerInvites)
       .where(eq(dancerInvites.orgId, org.id));
-    assert.lengthOf(newInvites, 2);
+    assert.lengthOf(allInvites, 2);
   });
 
-  test("reissues a fresh unconsumed invite for a pending coach", async ({
+  test("resending twice keeps the same token and never resets consumedAt", async ({
+    assert,
+  }) => {
+    const actor = await makeActorUser();
+    const { org, event } = await makeOrgAndEvent();
+    const [row] = await db
+      .insert(eventRosters)
+      .values({
+        eventId: event.id,
+        type: "dancer",
+        email: "stable@example.com",
+        firstName: "Stable",
+        lastName: "Dancer",
+      })
+      .returning();
+
+    const service = new ResendInvitesService();
+    await service.execute(
+      org.slug,
+      event.id,
+      { ids: [row!.id] },
+      { eventId: event.id, actorId: actor.id },
+      { pacingMs: 0 }
+    );
+
+    const [afterFirst] = await db
+      .select()
+      .from(dancerInvites)
+      .where(eq(dancerInvites.email, "stable@example.com"));
+    const firstToken = afterFirst!.token;
+    assert.isNotNull(firstToken);
+
+    // Simulate the dancer registering (invite consumed) with an expiry further
+    // out than the 14-day resend window.
+    const farFuture = new Date(Date.now() + 1000 * 60 * 60 * 24 * 60);
+    const consumedAt = new Date();
+    await db
+      .update(dancerInvites)
+      .set({ consumedAt, expiresAt: farFuture })
+      .where(eq(dancerInvites.id, afterFirst!.id));
+
+    // Resend again — must not change the token, must not shorten expiry, and
+    // must not re-open the consumed invite.
+    await service.execute(
+      org.slug,
+      event.id,
+      { ids: [row!.id] },
+      { eventId: event.id, actorId: actor.id },
+      { pacingMs: 0 }
+    );
+
+    const invites = await db
+      .select()
+      .from(dancerInvites)
+      .where(eq(dancerInvites.email, "stable@example.com"));
+    assert.lengthOf(invites, 1);
+    assert.equal(invites[0]!.token, firstToken);
+    assert.isNotNull(invites[0]!.consumedAt);
+    // Expiry not shortened below the far-future value.
+    assert.equal(invites[0]!.expiresAt.getTime(), farFuture.getTime());
+  });
+
+  test("keeps the same coach token and preserves consumedAt on resend", async ({
     assert,
   }) => {
     const actor = await makeActorUser();
@@ -141,14 +213,19 @@ test.group("ResendInvitesService", (group) => {
         organization: "Example University",
       })
       .returning();
-    const oldExpiresAt = new Date(Date.now() - 86400000);
+    // A previously emailed coach invite that has already been claimed and whose
+    // expiry sits further out than the resend window. The token must be
+    // preserved (the emailed link keeps working), consumedAt must not be reset
+    // (the claim stays), and expiry must not be shortened.
+    const consumedAt = new Date();
+    const farFuture = new Date(Date.now() + 1000 * 60 * 60 * 24 * 60);
     await db.insert(schoolInvites).values({
       eventId: event.id,
       email: coach!.email,
       organization: coach!.organization,
       token: "old_coach_token",
-      expiresAt: oldExpiresAt,
-      consumedAt: new Date(),
+      expiresAt: farFuture,
+      consumedAt,
     });
 
     const service = new ResendInvitesService();
@@ -169,9 +246,12 @@ test.group("ResendInvitesService", (group) => {
       .from(schoolInvites)
       .where(eq(schoolInvites.eventId, event.id));
     assert.lengthOf(invites, 1);
-    assert.notEqual(invites[0]!.token, "old_coach_token");
-    assert.isNull(invites[0]!.consumedAt);
-    assert.isAbove(invites[0]!.expiresAt.getTime(), Date.now() + 13 * 86400000);
+    // Token reused, not regenerated.
+    assert.equal(invites[0]!.token, "old_coach_token");
+    // Consumed invite stays consumed (never reopened).
+    assert.isNotNull(invites[0]!.consumedAt);
+    // Expiry not shortened below the far-future value.
+    assert.equal(invites[0]!.expiresAt.getTime(), farFuture.getTime());
   });
 
   test("skips a registered coach", async ({ assert }) => {

--- a/apps/backend/app/modules/orgs/events/rosters/resend-invites/service.ts
+++ b/apps/backend/app/modules/orgs/events/rosters/resend-invites/service.ts
@@ -92,27 +92,52 @@ export class ResendInvitesService {
       let task: EmailSendTask;
 
       if (row.type === "dancer") {
-        const token = randomToken();
-        const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 14);
+        // Resolved inside the tx on first prepare, then reused across email
+        // retries so a transient send failure never re-runs the tx or changes
+        // the token that was emailed.
+        let token: string;
         task = {
           recipient: row.email,
           send: async () => {
             if (!invitePrepared) {
               await this.db.tx(async (tx) => {
-                await tx
-                  .delete(dancerInvites)
+                const [existing] = await tx
+                  .select()
+                  .from(dancerInvites)
                   .where(
                     and(
                       eq(dancerInvites.orgId, org.id),
                       eq(dancerInvites.email, row.email)
                     )
-                  );
-                await tx.insert(dancerInvites).values({
-                  orgId: org.id,
-                  email: row.email,
-                  token,
-                  expiresAt,
-                });
+                  )
+                  .limit(1);
+
+                const nowPlus14d = new Date(
+                  Date.now() + 1000 * 60 * 60 * 24 * 14
+                );
+
+                if (existing) {
+                  // Reuse the existing token so previously emailed links stay
+                  // valid; extend expiry without ever shortening it and never
+                  // reset consumedAt (an already-registered invite stays consumed).
+                  token = existing.token;
+                  const newExpiresAt =
+                    existing.expiresAt > nowPlus14d
+                      ? existing.expiresAt
+                      : nowPlus14d;
+                  await tx
+                    .update(dancerInvites)
+                    .set({ expiresAt: newExpiresAt })
+                    .where(eq(dancerInvites.id, existing.id));
+                } else {
+                  token = randomToken();
+                  await tx.insert(dancerInvites).values({
+                    orgId: org.id,
+                    email: row.email,
+                    token,
+                    expiresAt: nowPlus14d,
+                  });
+                }
               });
               invitePrepared = true;
             }
@@ -128,32 +153,54 @@ export class ResendInvitesService {
           },
         };
       } else {
-        const token = randomBytes(32).toString("hex");
-        // Coach invites must outlive far-future events, matching upload-coaches.
-        const expiresAt = schoolInviteExpiry(event?.startDate);
+        // Resolved inside the tx on first prepare, then reused across email
+        // retries so a transient send failure never re-runs the tx or changes
+        // the token that was emailed.
+        let token: string;
         task = {
           recipient: row.email,
           send: async () => {
             if (!invitePrepared) {
-              await this.db.use((db) =>
-                db
-                  .insert(schoolInvites)
-                  .values({
+              await this.db.tx(async (tx) => {
+                const [existing] = await tx
+                  .select()
+                  .from(schoolInvites)
+                  .where(
+                    and(
+                      eq(schoolInvites.eventId, eventId),
+                      eq(schoolInvites.email, row.email)
+                    )
+                  )
+                  .limit(1);
+
+                // Coach invites must outlive far-future events, matching
+                // upload-coaches.
+                const expiresAt = schoolInviteExpiry(event?.startDate);
+
+                if (existing) {
+                  // Reuse the existing token so previously emailed links stay
+                  // valid; extend expiry without ever shortening it and never
+                  // reset consumedAt (an already-claimed invite stays consumed).
+                  token = existing.token;
+                  const newExpiresAt =
+                    existing.expiresAt > expiresAt
+                      ? existing.expiresAt
+                      : expiresAt;
+                  await tx
+                    .update(schoolInvites)
+                    .set({ expiresAt: newExpiresAt })
+                    .where(eq(schoolInvites.id, existing.id));
+                } else {
+                  token = randomBytes(32).toString("hex");
+                  await tx.insert(schoolInvites).values({
                     eventId,
                     email: row.email,
                     organization: row.organization,
                     token,
                     expiresAt,
-                  })
-                  .onConflictDoUpdate({
-                    target: [schoolInvites.eventId, schoolInvites.email],
-                    set: {
-                      token,
-                      expiresAt,
-                      consumedAt: null,
-                    },
-                  })
-              );
+                  });
+                }
+              });
               invitePrepared = true;
             }
 

--- a/apps/backend/app/modules/orgs/events/rosters/resend-invites/service.ts
+++ b/apps/backend/app/modules/orgs/events/rosters/resend-invites/service.ts
@@ -12,7 +12,7 @@ import {
   sendThrottledEmails,
   type EmailSendTask,
 } from "#shared/org/throttled-email-sender";
-import { and, eq, inArray, isNull } from "drizzle-orm";
+import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import type { Validator } from "./validator.ts";
 import type { AuditContext } from "#database/audit";
 
@@ -153,54 +153,41 @@ export class ResendInvitesService {
           },
         };
       } else {
-        // Resolved inside the tx on first prepare, then reused across email
-        // retries so a transient send failure never re-runs the tx or changes
-        // the token that was emailed.
+        // Resolved on first prepare, then reused across email retries so a
+        // transient send failure never re-runs the upsert or changes the token.
         let token: string;
         task = {
           recipient: row.email,
           send: async () => {
             if (!invitePrepared) {
-              await this.db.tx(async (tx) => {
-                const [existing] = await tx
-                  .select()
-                  .from(schoolInvites)
-                  .where(
-                    and(
-                      eq(schoolInvites.eventId, eventId),
-                      eq(schoolInvites.email, row.email)
-                    )
-                  )
-                  .limit(1);
-
-                // Coach invites must outlive far-future events, matching
-                // upload-coaches.
-                const expiresAt = schoolInviteExpiry(event?.startDate);
-
-                if (existing) {
-                  // Reuse the existing token so previously emailed links stay
-                  // valid; extend expiry without ever shortening it and never
-                  // reset consumedAt (an already-claimed invite stays consumed).
-                  token = existing.token;
-                  const newExpiresAt =
-                    existing.expiresAt > expiresAt
-                      ? existing.expiresAt
-                      : expiresAt;
-                  await tx
-                    .update(schoolInvites)
-                    .set({ expiresAt: newExpiresAt })
-                    .where(eq(schoolInvites.id, existing.id));
-                } else {
-                  token = randomBytes(32).toString("hex");
-                  await tx.insert(schoolInvites).values({
+              // Coach invites must outlive far-future events, matching
+              // upload-coaches.
+              const expiresAt = schoolInviteExpiry(event?.startDate);
+              // Atomic upsert on the (eventId, email) unique index: reuse the
+              // existing token (never overwrite it), extend expiry without
+              // shortening, and never reset consumedAt. RETURNING yields the
+              // effective token — the preserved one on conflict, the fresh one
+              // on insert. Using the constraint as the conflict target avoids
+              // the SELECT-then-INSERT race a duplicate insert would expose.
+              const [invite] = await this.db.use((db) =>
+                db
+                  .insert(schoolInvites)
+                  .values({
                     eventId,
                     email: row.email,
                     organization: row.organization,
-                    token,
+                    token: randomBytes(32).toString("hex"),
                     expiresAt,
-                  });
-                }
-              });
+                  })
+                  .onConflictDoUpdate({
+                    target: [schoolInvites.eventId, schoolInvites.email],
+                    set: {
+                      expiresAt: sql`greatest(${schoolInvites.expiresAt}, excluded.expires_at)`,
+                    },
+                  })
+                  .returning({ token: schoolInvites.token })
+              );
+              token = invite!.token;
               invitePrepared = true;
             }
 

--- a/apps/backend/app/modules/orgs/events/upload-coaches/service.spec.ts
+++ b/apps/backend/app/modules/orgs/events/upload-coaches/service.spec.ts
@@ -174,6 +174,59 @@ coach2@usc.edu,Coach,Two,USC`;
     assert.lengthOf(rosters, 1);
   });
 
+  test("re-uploading a pending coach keeps the same invite token and preserves consumedAt", async ({
+    assert,
+  }) => {
+    const csv = `email,firstName,lastName,organization
+pending@ucla.edu,Pending,Coach,UCLA`;
+
+    const svc = new UploadCoachesService();
+    await svc.execute({
+      orgId: summit.id,
+      eventId: event.id,
+      uploaderId: uploader.id,
+      fileUrl: "test://1.csv",
+      csv,
+    });
+
+    const [firstInvite] = await db
+      .select()
+      .from(schoolInvites)
+      .where(eq(schoolInvites.email, "pending@ucla.edu"));
+    assert.isNotNull(firstInvite);
+    const originalToken = firstInvite!.token;
+
+    // Simulate the coach claiming the invite before a second upload happens.
+    const consumedAt = new Date();
+    await db
+      .update(schoolInvites)
+      .set({ consumedAt })
+      .where(eq(schoolInvites.id, firstInvite!.id));
+
+    // Re-upload the same coach. The invite token must not be regenerated and
+    // the claim (consumedAt) must be preserved.
+    await svc.execute({
+      orgId: summit.id,
+      eventId: event.id,
+      uploaderId: uploader.id,
+      fileUrl: "test://2.csv",
+      csv,
+    });
+
+    const invites = await db
+      .select()
+      .from(schoolInvites)
+      .where(eq(schoolInvites.email, "pending@ucla.edu"));
+    assert.lengthOf(invites, 1);
+    assert.equal(invites[0]!.token, originalToken);
+    assert.isNotNull(invites[0]!.consumedAt);
+    // Expiry is never shortened by a re-upload.
+    assert.isAtLeast(
+      invites[0]!.expiresAt.getTime(),
+      firstInvite!.expiresAt.getTime()
+    );
+  });
+
   test("CSV with parse errors returns preconditionFailed — no partial commit", async ({
     assert,
   }) => {

--- a/apps/backend/app/modules/orgs/events/upload-coaches/service.ts
+++ b/apps/backend/app/modules/orgs/events/upload-coaches/service.ts
@@ -18,7 +18,7 @@ import {
 } from "#shared/org/throttled-email-sender";
 import { enforceEmailRole } from "#shared/org/role-guard";
 import { verifyPreviewToken } from "#shared/org/preview-token";
-import { and, eq, inArray, isNull } from "drizzle-orm";
+import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import { randomBytes } from "node:crypto";
 import logger from "@adonisjs/core/services/logger";
 
@@ -188,7 +188,12 @@ export class UploadCoachesService {
                   target: [orgMemberships.userId, orgMemberships.orgId],
                 });
             } else {
-              // Mint a school invite for unmatched rows; UPSERT on re-upload
+              // Mint a school invite for unmatched rows. On re-upload keep the
+              // token STABLE per (eventId, email): preserve the existing row's
+              // token so previously emailed links stay valid, extend expiry
+              // without ever shortening it, and never reset consumedAt (an
+              // already-claimed invite must not be reopened). The fresh token +
+              // expiry below are only used for the first-time INSERT.
               const token = randomBytes(32).toString("hex");
               const expiresAt = schoolInviteExpiry(event.startDate);
               await tx
@@ -203,9 +208,7 @@ export class UploadCoachesService {
                 .onConflictDoUpdate({
                   target: [schoolInvites.eventId, schoolInvites.email],
                   set: {
-                    token,
-                    expiresAt,
-                    consumedAt: null,
+                    expiresAt: sql`greatest(${schoolInvites.expiresAt}, excluded.expires_at)`,
                   },
                 });
             }

--- a/apps/backend/app/modules/orgs/events/upload-dancers/service.spec.ts
+++ b/apps/backend/app/modules/orgs/events/upload-dancers/service.spec.ts
@@ -156,6 +156,60 @@ newghost@x.co,Ghost,Dancer,202`;
     assert.isAbove(invite!.expiresAt.getTime(), Date.now());
   });
 
+  test("re-upload keeps the same dancer_invite token and does not reset consumedAt", async ({
+    assert,
+  }) => {
+    const csv1 = `email,firstName,lastName,bibNumber
+reupload@x.co,Re,Upload,501`;
+    const csv2 = `email,firstName,lastName,bibNumber
+reupload@x.co,Re,Upload,502`;
+
+    const svc = new UploadDancersService();
+    await svc.execute({
+      orgId: summit.id,
+      eventId: event.id,
+      uploaderId: uploader.id,
+      fileUrl: "test://reupload1.csv",
+      csv: csv1,
+    });
+
+    const [afterFirst] = await db
+      .select()
+      .from(dancerInvites)
+      .where(eq(dancerInvites.email, "reupload@x.co"));
+    const firstToken = afterFirst!.token;
+    assert.isNotNull(firstToken);
+
+    // Simulate registration: mark consumed and push expiry beyond the 30-day
+    // upload window.
+    const farFuture = new Date(Date.now() + 1000 * 60 * 60 * 24 * 90);
+    const consumedAt = new Date();
+    await db
+      .update(dancerInvites)
+      .set({ consumedAt, expiresAt: farFuture })
+      .where(eq(dancerInvites.id, afterFirst!.id));
+
+    await svc.execute({
+      orgId: summit.id,
+      eventId: event.id,
+      uploaderId: uploader.id,
+      fileUrl: "test://reupload2.csv",
+      csv: csv2,
+    });
+
+    const invites = await db
+      .select()
+      .from(dancerInvites)
+      .where(eq(dancerInvites.email, "reupload@x.co"));
+    assert.lengthOf(invites, 1);
+    // Same token — a previously emailed link keeps working.
+    assert.equal(invites[0]!.token, firstToken);
+    // consumedAt untouched — an already-registered invite stays consumed.
+    assert.isNotNull(invites[0]!.consumedAt);
+    // Expiry not shortened below the far-future value.
+    assert.equal(invites[0]!.expiresAt.getTime(), farFuture.getTime());
+  });
+
   test("re-upload updates bib number on existing roster row", async ({
     assert,
   }) => {

--- a/apps/backend/app/modules/orgs/events/upload-dancers/service.spec.ts
+++ b/apps/backend/app/modules/orgs/events/upload-dancers/service.spec.ts
@@ -210,6 +210,61 @@ reupload@x.co,Re,Upload,502`;
     assert.equal(invites[0]!.expiresAt.getTime(), farFuture.getTime());
   });
 
+  test("re-upload preserves an existing account link for a registered dancer with no profile row", async ({
+    assert,
+  }) => {
+    // A registered dancer whose account has NO dancerProfiles row yet, so the
+    // upload's dancerProfiles join won't match — the post-register / pre-profile
+    // window. Re-upload must not clobber the existing roster link back to null.
+    const [dancer] = await db
+      .insert(users)
+      .values({
+        username: "linked1",
+        email: "linked@x.co",
+        displayEmail: "linked@x.co",
+        firstName: "Linked",
+        lastName: "Dancer",
+        password: "x",
+        role: "user",
+        type: "dancer",
+        verified: true,
+      })
+      .returning();
+    await db.insert(eventRosters).values({
+      eventId: event.id,
+      type: "dancer",
+      email: "linked@x.co",
+      firstName: "Linked",
+      lastName: "Dancer",
+      bibNumber: 601,
+      userId: dancer!.id,
+    });
+    await db.insert(dancerInvites).values({
+      orgId: summit.id,
+      email: "linked@x.co",
+      token: "linked_consumed_token",
+      expiresAt: new Date(Date.now() + 1000 * 60 * 60 * 24 * 30),
+      consumedAt: new Date(),
+    });
+
+    const csv = `email,firstName,lastName,bibNumber
+linked@x.co,Linked,Dancer,601`;
+    await new UploadDancersService().execute({
+      orgId: summit.id,
+      eventId: event.id,
+      uploaderId: uploader.id,
+      fileUrl: "test://linked.csv",
+      csv,
+    });
+
+    const [roster] = await db
+      .select()
+      .from(eventRosters)
+      .where(eq(eventRosters.email, "linked@x.co"));
+    // The existing account link must survive the re-upload (not reset to null).
+    assert.equal(roster!.userId, dancer!.id);
+  });
+
   test("re-upload updates bib number on existing roster row", async ({
     assert,
   }) => {

--- a/apps/backend/app/modules/orgs/events/upload-dancers/service.ts
+++ b/apps/backend/app/modules/orgs/events/upload-dancers/service.ts
@@ -278,13 +278,6 @@ export class UploadDancersService {
                 });
             } else {
               // Create dancer invite for unmatched rows
-              const token = randomToken();
-              inviteTokens.push({
-                email: r.email,
-                firstName: r.firstName,
-                token,
-                paid: r.paid,
-              });
               const inviteExpiry = new Date(
                 Date.now() + 1000 * 60 * 60 * 24 * 30
               ); // 30 days
@@ -301,12 +294,22 @@ export class UploadDancersService {
                 )
                 .limit(1);
 
+              let token: string;
               if (existingInvite) {
+                // Reuse the existing token so previously emailed links stay
+                // valid; extend expiry without shortening and never reset
+                // consumedAt (an already-registered invite stays consumed).
+                token = existingInvite.token;
+                const newExpiresAt =
+                  existingInvite.expiresAt > inviteExpiry
+                    ? existingInvite.expiresAt
+                    : inviteExpiry;
                 await tx
                   .update(dancerInvites)
-                  .set({ token, expiresAt: inviteExpiry, consumedAt: null })
+                  .set({ expiresAt: newExpiresAt })
                   .where(eq(dancerInvites.id, existingInvite.id));
               } else {
+                token = randomToken();
                 await tx.insert(dancerInvites).values({
                   orgId,
                   email: r.email,
@@ -314,6 +317,14 @@ export class UploadDancersService {
                   expiresAt: inviteExpiry,
                 });
               }
+
+              // Push the effective token so the email link matches what's stored.
+              inviteTokens.push({
+                email: r.email,
+                firstName: r.firstName,
+                token,
+                paid: r.paid,
+              });
             }
           }
         }

--- a/apps/backend/app/modules/orgs/events/upload-dancers/service.ts
+++ b/apps/backend/app/modules/orgs/events/upload-dancers/service.ts
@@ -231,7 +231,11 @@ export class UploadDancersService {
                   lastName: r.lastName,
                   bibNumber: r.bibNumber,
                   paid: r.paid,
-                  userId,
+                  // Preserve an existing account link on re-upload: a dancer who
+                  // registered but has not created a dancerProfiles row yet won't
+                  // match the join above (userId === null), and we must not clobber
+                  // their existing roster link back to null.
+                  userId: userId ?? existing.userId,
                   expirationDate: userId
                     ? rowExpiration
                     : existing.expirationDate,
@@ -295,11 +299,13 @@ export class UploadDancersService {
                 .limit(1);
 
               let token: string;
+              let alreadyConsumed = false;
               if (existingInvite) {
                 // Reuse the existing token so previously emailed links stay
                 // valid; extend expiry without shortening and never reset
                 // consumedAt (an already-registered invite stays consumed).
                 token = existingInvite.token;
+                alreadyConsumed = existingInvite.consumedAt !== null;
                 const newExpiresAt =
                   existingInvite.expiresAt > inviteExpiry
                     ? existingInvite.expiresAt
@@ -318,13 +324,17 @@ export class UploadDancersService {
                 });
               }
 
-              // Push the effective token so the email link matches what's stored.
-              inviteTokens.push({
-                email: r.email,
-                firstName: r.firstName,
-                token,
-                paid: r.paid,
-              });
+              // Don't re-email an already-registered dancer (mirrors
+              // upload-coaches, which excludes consumed invites). Push the
+              // effective token only when the invite is still claimable.
+              if (!alreadyConsumed) {
+                inviteTokens.push({
+                  email: r.email,
+                  firstName: r.firstName,
+                  token,
+                  paid: r.paid,
+                });
+              }
             }
           }
         }

--- a/apps/backend/app/modules/orgs/invite-lookup-dancer/controller.ts
+++ b/apps/backend/app/modules/orgs/invite-lookup-dancer/controller.ts
@@ -1,21 +1,21 @@
 import { inject } from "@adonisjs/core";
 import type { HttpContext } from "@adonisjs/core/http";
 import {
-  InviteLookupSchoolService,
-  type InviteLookupSchoolResult,
+  InviteLookupDancerService,
+  type InviteLookupDancerResult,
 } from "./service.ts";
 
-export default class InviteLookupSchoolController {
+export default class InviteLookupDancerController {
   @inject()
   async handle(
     { params, response }: HttpContext,
-    service: InviteLookupSchoolService
+    service: InviteLookupDancerService
   ) {
     const token = typeof params.token === "string" ? params.token.trim() : "";
-    const result: InviteLookupSchoolResult =
-      token.length < 8 || token.length > 128
+    const result: InviteLookupDancerResult =
+      token.length < 8 || token.length > 64
         ? { status: "invalid" }
-        : await service.execute(token);
+        : await service.execute(params.slug, token);
 
     // Return a single flat shape (nullable prefill fields) so the generated
     // OpenAPI/TanStack Query type keeps every field; a branch-per-status return
@@ -23,9 +23,6 @@ export default class InviteLookupSchoolController {
     return response.ok({
       status: result.status,
       email: result.status === "valid" ? result.email : null,
-      organization: result.status === "valid" ? result.organization : null,
-      eventId: result.status === "valid" ? result.eventId : null,
-      eventName: result.status === "valid" ? result.eventName : null,
       orgName: result.status === "valid" ? result.orgName : null,
       orgSlug: result.status === "valid" ? result.orgSlug : null,
       brandColor: result.status === "valid" ? result.brandColor : null,

--- a/apps/backend/app/modules/orgs/invite-lookup-dancer/service.ts
+++ b/apps/backend/app/modules/orgs/invite-lookup-dancer/service.ts
@@ -1,20 +1,15 @@
 import { DatabaseService } from "#database/service";
-import { schoolInvites } from "#database/schema/schools";
-import { organizations } from "#database/schema/organizations";
-import { orgEvents } from "#database/schema/org-events";
+import { dancerInvites, organizations } from "#database/schema/organizations";
 import { inject } from "@adonisjs/core";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
-export type InviteLookupSchoolResult =
+export type InviteLookupDancerResult =
   | { status: "invalid" }
   | { status: "consumed" }
   | { status: "expired" }
   | {
       status: "valid";
       email: string;
-      organization: string | null;
-      eventId: string;
-      eventName: string;
       orgName: string;
       orgSlug: string;
       brandColor: string | null;
@@ -22,27 +17,28 @@ export type InviteLookupSchoolResult =
     };
 
 @inject()
-export class InviteLookupSchoolService {
+export class InviteLookupDancerService {
   constructor(private db: DatabaseService) {}
 
-  async execute(token: string): Promise<InviteLookupSchoolResult> {
+  async execute(
+    orgSlug: string,
+    token: string
+  ): Promise<InviteLookupDancerResult> {
     return this.db.use(async (db) => {
       const [row] = await db
         .select({
-          email: schoolInvites.email,
-          organization: schoolInvites.organization,
-          eventId: schoolInvites.eventId,
-          expiresAt: schoolInvites.expiresAt,
-          consumedAt: schoolInvites.consumedAt,
-          eventName: orgEvents.name,
+          email: dancerInvites.email,
+          expiresAt: dancerInvites.expiresAt,
+          consumedAt: dancerInvites.consumedAt,
           orgName: organizations.name,
           orgSlug: organizations.slug,
           brandColor: organizations.primaryColor,
         })
-        .from(schoolInvites)
-        .innerJoin(orgEvents, eq(orgEvents.id, schoolInvites.eventId))
-        .innerJoin(organizations, eq(organizations.id, orgEvents.orgId))
-        .where(eq(schoolInvites.token, token))
+        .from(dancerInvites)
+        .innerJoin(organizations, eq(organizations.id, dancerInvites.orgId))
+        .where(
+          and(eq(dancerInvites.token, token), eq(organizations.slug, orgSlug))
+        )
         .limit(1);
 
       if (!row) return { status: "invalid" as const };
@@ -51,9 +47,6 @@ export class InviteLookupSchoolService {
       return {
         status: "valid" as const,
         email: row.email,
-        organization: row.organization,
-        eventId: row.eventId,
-        eventName: row.eventName,
         orgName: row.orgName,
         orgSlug: row.orgSlug,
         brandColor: row.brandColor,

--- a/apps/backend/app/modules/orgs/invite-lookup-school/service.spec.ts
+++ b/apps/backend/app/modules/orgs/invite-lookup-school/service.spec.ts
@@ -1,0 +1,125 @@
+import { test } from "@japa/runner";
+import { eq } from "drizzle-orm";
+import { db } from "#database/connection";
+import { users } from "#database/schema/users";
+import { orgMemberships, organizations } from "#database/schema/organizations";
+import { eventRosters, orgEvents } from "#database/schema/org-events";
+import { schoolInvites, schoolProfiles } from "#database/schema/schools";
+import { seedOrganizations } from "#commands/backfill-organizations";
+import { randomBytes } from "node:crypto";
+
+function token() {
+  return randomBytes(32).toString("hex");
+}
+
+async function createEvent(name: string) {
+  const [summit] = await db
+    .select()
+    .from(organizations)
+    .where(eq(organizations.slug, "summit"));
+  const [event] = await db
+    .insert(orgEvents)
+    .values({
+      orgId: summit!.id,
+      name,
+      startDate: "2026-06-01",
+      endDate: "2026-06-02",
+    })
+    .returning();
+  return { summit: summit!, event: event! };
+}
+
+test.group("School invite lookup", (group) => {
+  group.each.setup(async () => {
+    await db.delete(eventRosters).execute();
+    await db.delete(orgEvents).execute();
+    await db.delete(schoolInvites).execute();
+    await db.delete(orgMemberships).execute();
+    await db.delete(schoolProfiles).execute();
+    await db.delete(users).execute();
+    await db.delete(organizations).execute();
+    await seedOrganizations();
+  });
+
+  test("valid token returns valid status with prefill fields", async ({
+    client,
+    assert,
+  }) => {
+    const { event } = await createEvent("Lookup Valid Event");
+    const tok = token();
+    await db.insert(schoolInvites).values({
+      eventId: event.id,
+      email: "valid@example.com",
+      organization: "Valid Academy",
+      token: tok,
+      expiresAt: new Date(Date.now() + 86400000),
+    });
+
+    const res = await client.get(`/orgs/invites/school/${tok}`);
+    res.assertStatus(200);
+    res.assertBodyContains({
+      status: "valid",
+      email: "valid@example.com",
+      organization: "Valid Academy",
+      eventName: "Lookup Valid Event",
+    });
+    assert.equal(res.body().eventId, event.id);
+    assert.isString(res.body().orgName);
+    assert.isString(res.body().orgSlug);
+    assert.isNotNull(res.body().expiresAt);
+  });
+
+  test("consumed token returns consumed status with null fields", async ({
+    client,
+    assert,
+  }) => {
+    const { event } = await createEvent("Lookup Consumed Event");
+    const tok = token();
+    await db.insert(schoolInvites).values({
+      eventId: event.id,
+      email: "consumed@example.com",
+      token: tok,
+      expiresAt: new Date(Date.now() + 86400000),
+      consumedAt: new Date(),
+    });
+
+    const res = await client.get(`/orgs/invites/school/${tok}`);
+    res.assertStatus(200);
+    res.assertBodyContains({ status: "consumed" });
+    assert.isNull(res.body().email);
+    assert.isNull(res.body().eventId);
+  });
+
+  test("expired token returns expired status with null fields", async ({
+    client,
+    assert,
+  }) => {
+    const { event } = await createEvent("Lookup Expired Event");
+    const tok = token();
+    await db.insert(schoolInvites).values({
+      eventId: event.id,
+      email: "expired@example.com",
+      token: tok,
+      expiresAt: new Date(Date.now() - 86400000),
+    });
+
+    const res = await client.get(`/orgs/invites/school/${tok}`);
+    res.assertStatus(200);
+    res.assertBodyContains({ status: "expired" });
+    assert.isNull(res.body().email);
+  });
+
+  test("unknown token returns invalid status", async ({ client }) => {
+    const res = await client.get(`/orgs/invites/school/${token()}`);
+    res.assertStatus(200);
+    res.assertBodyContains({ status: "invalid" });
+  });
+
+  test("too-short token returns invalid status without hitting db", async ({
+    client,
+  }) => {
+    const res = await client.get("/orgs/invites/school/short");
+    res.assertStatus(200);
+    res.assertBodyContains({ status: "invalid" });
+  });
+});

--- a/apps/backend/app/modules/orgs/register-dancer/service.spec.ts
+++ b/apps/backend/app/modules/orgs/register-dancer/service.spec.ts
@@ -144,6 +144,55 @@ test.group("POST /orgs/:slug/register", (group) => {
     res.assertStatus(400);
   });
 
+  test("returns a distinct 'expired' message for an expired token", async ({
+    client,
+    assert,
+  }) => {
+    const [summit] = await db
+      .select()
+      .from(organizations)
+      .where(eq(organizations.slug, "summit"));
+    await db.insert(dancerInvites).values({
+      orgId: summit!.id,
+      email: "expmsg@example.com",
+      token: "tok_expmsg_01234",
+      expiresAt: new Date(Date.now() - 1000),
+    });
+    const res = await client.post("/orgs/summit/register").json({
+      token: "tok_expmsg_01234",
+      firstName: "Exp",
+      lastName: "Msg",
+      password: "CorrectHorse1!",
+    });
+    res.assertStatus(400);
+    assert.include(res.body().message, "expired");
+  });
+
+  test("returns a distinct 'already created' message for a consumed token", async ({
+    client,
+    assert,
+  }) => {
+    const [summit] = await db
+      .select()
+      .from(organizations)
+      .where(eq(organizations.slug, "summit"));
+    await db.insert(dancerInvites).values({
+      orgId: summit!.id,
+      email: "consumedmsg@example.com",
+      token: "tok_consmsg_abc01",
+      expiresAt: new Date(Date.now() + 86400000),
+      consumedAt: new Date(),
+    });
+    const res = await client.post("/orgs/summit/register").json({
+      token: "tok_consmsg_abc01",
+      firstName: "Con",
+      lastName: "Sumed",
+      password: "CorrectHorse1!",
+    });
+    res.assertStatus(400);
+    assert.include(res.body().message, "already created");
+  });
+
   test("links all matching pending roster rows in the same org", async ({
     client,
     assert,

--- a/apps/backend/app/modules/orgs/register-dancer/service.ts
+++ b/apps/backend/app/modules/orgs/register-dancer/service.ts
@@ -8,7 +8,7 @@ import {
 import { eventRosters, orgEvents } from "#database/schema/org-events";
 import { inject } from "@adonisjs/core";
 import hash from "@adonisjs/core/services/hash";
-import { and, desc, eq, gt, inArray, isNull } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull } from "drizzle-orm";
 import type { Validator } from "./validator.ts";
 
 export class InviteInvalidError extends Error {
@@ -39,14 +39,24 @@ export class RegisterDancerService {
         .where(
           and(
             eq(dancerInvites.token, input.token),
-            eq(dancerInvites.orgId, org.id),
-            gt(dancerInvites.expiresAt, new Date()),
-            isNull(dancerInvites.consumedAt)
+            eq(dancerInvites.orgId, org.id)
           )
         )
         .limit(1);
       if (!invite) {
-        throw new InviteInvalidError();
+        throw new InviteInvalidError(
+          "This invite link is not valid. Check for a newer invitation email, or sign in if you already have an account."
+        );
+      }
+      if (invite.consumedAt) {
+        throw new InviteInvalidError(
+          "You've already created your account. Please sign in."
+        );
+      }
+      if (invite.expiresAt <= new Date()) {
+        throw new InviteInvalidError(
+          "This invite has expired. Ask your organization to resend your invitation."
+        );
       }
 
       // Org-provisioned accounts get a tier based on org features and paid status.

--- a/apps/backend/app/modules/orgs/register-school/service.spec.ts
+++ b/apps/backend/app/modules/orgs/register-school/service.spec.ts
@@ -174,7 +174,9 @@ test.group("School invite + activation paths", (group) => {
     assert.equal(membership!.type, "coach");
   });
 
-  test("Path B: second click on same token returns 410", async ({ client }) => {
+  test("Path B: second click on a consumed token returns 410 with already-registered message", async ({
+    client,
+  }) => {
     const [summit] = await db
       .select()
       .from(organizations)
@@ -207,6 +209,65 @@ test.group("School invite + activation paths", (group) => {
       location: "NY",
     });
     res.assertStatus(410);
+    res.assertBodyContains({
+      message: "You've already created your account. Please sign in.",
+    });
+  });
+
+  test("Expired token returns 410 with expired message", async ({ client }) => {
+    const [summit] = await db
+      .select()
+      .from(organizations)
+      .where(eq(organizations.slug, "summit"));
+    const [event] = await db
+      .insert(orgEvents)
+      .values({
+        orgId: summit!.id,
+        name: "Expired Event",
+        startDate: "2026-06-01",
+        endDate: "2026-06-02",
+      })
+      .returning();
+
+    const tok = token();
+    await db.insert(schoolInvites).values({
+      eventId: event!.id,
+      email: "expired@example.com",
+      token: tok,
+      expiresAt: new Date(Date.now() - 86400000),
+    });
+
+    const res = await client.post("/orgs/register/school").json({
+      token: tok,
+      firstName: "Ex",
+      lastName: "Pired",
+      password: "CorrectHorse1!",
+      name: "Expired School",
+      location: "NY",
+    });
+    res.assertStatus(410);
+    res.assertBodyContains({
+      message:
+        "This invite has expired. Ask your organization to resend your invitation.",
+    });
+  });
+
+  test("Unknown token returns 410 with not-valid message", async ({
+    client,
+  }) => {
+    const res = await client.post("/orgs/register/school").json({
+      token: token(),
+      firstName: "No",
+      lastName: "Body",
+      password: "CorrectHorse1!",
+      name: "Nobody School",
+      location: "NY",
+    });
+    res.assertStatus(410);
+    res.assertBodyContains({
+      message:
+        "This invite link is not valid. Check for a newer invitation email, or sign in if you already have an account.",
+    });
   });
 
   test("Path B: UPSERT on re-upload — same CSV row twice does not throw", async ({

--- a/apps/backend/app/modules/orgs/register-school/service.ts
+++ b/apps/backend/app/modules/orgs/register-school/service.ts
@@ -5,7 +5,7 @@ import { eventRosters, orgEvents } from "#database/schema/org-events";
 import { orgMemberships } from "#database/schema/organizations";
 import { inject } from "@adonisjs/core";
 import hash from "@adonisjs/core/services/hash";
-import { and, eq, gt, isNull } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import type { Validator } from "./validator.ts";
 
 export class InviteInvalidError extends Error {
@@ -24,17 +24,23 @@ export class RegisterSchoolService {
       const [invite] = await tx
         .select()
         .from(schoolInvites)
-        .where(
-          and(
-            eq(schoolInvites.token, input.token),
-            gt(schoolInvites.expiresAt, new Date()),
-            isNull(schoolInvites.consumedAt)
-          )
-        )
+        .where(eq(schoolInvites.token, input.token))
         .limit(1);
 
       if (!invite) {
-        throw new InviteInvalidError();
+        throw new InviteInvalidError(
+          "This invite link is not valid. Check for a newer invitation email, or sign in if you already have an account."
+        );
+      }
+      if (invite.consumedAt) {
+        throw new InviteInvalidError(
+          "You've already created your account. Please sign in."
+        );
+      }
+      if (invite.expiresAt <= new Date()) {
+        throw new InviteInvalidError(
+          "This invite has expired. Ask your organization to resend your invitation."
+        );
       }
 
       const usernameSeed = invite.email.split("@")[0] ?? "school";

--- a/apps/backend/app/modules/orgs/routes.ts
+++ b/apps/backend/app/modules/orgs/routes.ts
@@ -11,6 +11,8 @@ const RegisterSchoolController = () =>
   import("./register-school/controller.ts");
 const InviteLookupSchoolController = () =>
   import("./invite-lookup-school/controller.ts");
+const InviteLookupDancerController = () =>
+  import("./invite-lookup-dancer/controller.ts");
 const UpdateOrgSettingsController = () =>
   import("./update-settings/controller.ts");
 
@@ -55,6 +57,14 @@ router
         summary: "Look up a school invite by token",
         description:
           "Returns prefill data (email, organization, event/org names, brand color) for a school account invite. Returns 410 if the invite is invalid, expired, or already consumed.",
+      });
+
+    router
+      .get(":slug/invites/dancer/:token", [InviteLookupDancerController])
+      .openapi({
+        summary: "Look up a dancer invite by token",
+        description:
+          "Returns the invite state (valid | consumed | expired | invalid) plus prefill data (email, org name, brand color) when valid, so the dancer register page can show the right message. Always 200.",
       });
   })
   .prefix("orgs")

--- a/apps/backend/app/modules/orgs/routes.ts
+++ b/apps/backend/app/modules/orgs/routes.ts
@@ -56,7 +56,7 @@ router
       .openapi({
         summary: "Look up a school invite by token",
         description:
-          "Returns prefill data (email, organization, event/org names, brand color) for a school account invite. Returns 410 if the invite is invalid, expired, or already consumed.",
+          "Returns the invite state (valid | consumed | expired | invalid) plus prefill data (email, organization, event/org names, brand color) when valid, so the school register page can show the right message. Always 200.",
       });
 
     router

--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -3326,6 +3326,40 @@
         }
       }
     },
+    "/orgs/{slug}/events/{id}/rosters/check-in/reset": {
+      "post": {
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrgsIdEventsIdRostersCheckinResetResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/orgs/{slug}/events/{id}/checklist": {
       "get": {
         "parameters": [
@@ -5797,6 +5831,45 @@
         "description": "Consumes a one-time invite token and creates a new dancer account with an org membership and a time-limited premium grant."
       }
     },
+    "/orgs/{slug}/invites/dancer/{token}": {
+      "get": {
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "token",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrgsIdInvitesDancerIdResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Organizations"
+        ],
+        "summary": "Look up a dancer invite by token",
+        "description": "Returns the invite state (valid | consumed | expired | invalid) plus prefill data (email, org name, brand color) when valid, so the dancer register page can show the right message. Always 200."
+      }
+    },
     "/orgs/register/school": {
       "post": {
         "requestBody": {
@@ -5866,16 +5939,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OrgsInvitesSchoolIdResponse"
-                }
-              }
-            }
-          },
-          "410": {
-            "description": "Unknown Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
                 }
               }
             }
@@ -13885,6 +13948,17 @@
           ]
         }
       },
+      "OrgsIdEventsIdRostersCheckinResetResponse": {
+        "type": "object",
+        "properties": {
+          "reset": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "reset"
+        ]
+      },
       "OrgsIdEventsIdChecklistResponse": {
         "type": "array",
         "items": {
@@ -16392,6 +16466,78 @@
           "userId"
         ]
       },
+      "OrgsIdInvitesDancerIdResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "expired",
+              "invalid",
+              "valid",
+              "consumed"
+            ]
+          },
+          "email": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "orgName": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "orgSlug": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "brandColor": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "expiresAt": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "status",
+          "email",
+          "orgName",
+          "orgSlug",
+          "brandColor",
+          "expiresAt"
+        ]
+      },
       "OrgsRegisterSchoolRequest": {
         "type": "object",
         "properties": {
@@ -16447,8 +16593,24 @@
       "OrgsInvitesSchoolIdResponse": {
         "type": "object",
         "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "expired",
+              "invalid",
+              "valid",
+              "consumed"
+            ]
+          },
           "email": {
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "organization": {
             "oneOf": [
@@ -16461,16 +16623,44 @@
             ]
           },
           "eventId": {
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "eventName": {
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "orgName": {
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "orgSlug": {
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "brandColor": {
             "oneOf": [
@@ -16483,10 +16673,18 @@
             ]
           },
           "expiresAt": {
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "required": [
+          "status",
           "email",
           "organization",
           "eventId",

--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -3953,6 +3953,16 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Unknown Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       }
@@ -5948,7 +5958,7 @@
           "Organizations"
         ],
         "summary": "Look up a school invite by token",
-        "description": "Returns prefill data (email, organization, event/org names, brand color) for a school account invite. Returns 410 if the invite is invalid, expired, or already consumed."
+        "description": "Returns the invite state (valid | consumed | expired | invalid) plus prefill data (email, organization, event/org names, brand color) when valid, so the school register page can show the right message. Always 200."
       }
     },
     "/skills": {

--- a/apps/frontend/src/features/org/components/org-register-form.tsx
+++ b/apps/frontend/src/features/org/components/org-register-form.tsx
@@ -82,11 +82,13 @@ export function OrgRegisterForm({
     );
   }
 
+  // Only a definitive negative status from the server blocks the form. The
+  // lookup has retries disabled, so a transient failure must NOT dead-end a
+  // dancer holding a valid token — fall through and let the backend validate
+  // the token on submit.
   if (
-    inviteQuery.isError ||
-    !inviteQuery.data ||
-    inviteQuery.data.status === "expired" ||
-    inviteQuery.data.status === "invalid"
+    inviteQuery.data?.status === "expired" ||
+    inviteQuery.data?.status === "invalid"
   ) {
     return (
       <Frame>
@@ -111,7 +113,7 @@ export function OrgRegisterForm({
     );
   }
 
-  if (inviteQuery.data.status === "consumed") {
+  if (inviteQuery.data?.status === "consumed") {
     return (
       <Frame>
         <FramePanel className="flex flex-col gap-3 text-sm">
@@ -141,19 +143,21 @@ export function OrgRegisterForm({
     >
       <Frame>
         <FramePanel className="flex w-full flex-col gap-3 sm:gap-5">
-          <div className="flex gap-3 rounded-xl border border-border/70 bg-linear-to-br from-muted/50 to-muted/25 p-3 shadow-xs sm:gap-3.5 sm:p-4 dark:border-border/50 dark:from-muted/35 dark:to-muted/15">
-            <div className="bg-background/85 text-muted-foreground flex size-10 shrink-0 items-center justify-center rounded-lg border border-border/60 shadow-xs dark:bg-background/60">
-              <MailIcon aria-hidden className="size-4.5" strokeWidth={1.75} />
+          {inviteQuery.data?.email && (
+            <div className="flex gap-3 rounded-xl border border-border/70 bg-linear-to-br from-muted/50 to-muted/25 p-3 shadow-xs sm:gap-3.5 sm:p-4 dark:border-border/50 dark:from-muted/35 dark:to-muted/15">
+              <div className="bg-background/85 text-muted-foreground flex size-10 shrink-0 items-center justify-center rounded-lg border border-border/60 shadow-xs dark:bg-background/60">
+                <MailIcon aria-hidden className="size-4.5" strokeWidth={1.75} />
+              </div>
+              <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                <p className="text-muted-foreground text-[10px] font-semibold tracking-wide uppercase sm:text-xs">
+                  Invitation for
+                </p>
+                <p className="text-foreground truncate text-sm font-semibold tracking-tight sm:text-base">
+                  {inviteQuery.data?.email}
+                </p>
+              </div>
             </div>
-            <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-              <p className="text-muted-foreground text-[10px] font-semibold tracking-wide uppercase sm:text-xs">
-                Invitation for
-              </p>
-              <p className="text-foreground truncate text-sm font-semibold tracking-tight sm:text-base">
-                {inviteQuery.data.email}
-              </p>
-            </div>
-          </div>
+          )}
 
           <Controller
             control={control}

--- a/apps/frontend/src/features/org/components/org-register-form.tsx
+++ b/apps/frontend/src/features/org/components/org-register-form.tsx
@@ -11,6 +11,7 @@ import { useOrg } from "@/features/org/context/use-org";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { AuthPagesSelect } from "@/components/shared/auth-pages-select";
 import { Link } from "@tanstack/react-router";
+import { MailIcon } from "lucide-react";
 import { useRef } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { z } from "zod";
@@ -31,6 +32,14 @@ export function OrgRegisterForm({
   onSuccess: () => void;
 }) {
   const { org } = useOrg();
+
+  const inviteQuery = $api.useQuery(
+    "get",
+    "/orgs/{slug}/invites/dancer/{token}",
+    { params: { path: { slug: org.slug, token } } },
+    { retry: false },
+  );
+
   const { mutate, isPending } = $api.useMutation(
     "post",
     "/orgs/{slug}/register",
@@ -65,6 +74,66 @@ export function OrgRegisterForm({
     );
   };
 
+  if (inviteQuery.isLoading) {
+    return (
+      <div className="flex w-full justify-center py-12">
+        <Spinner label="Loading invite..." />
+      </div>
+    );
+  }
+
+  if (
+    inviteQuery.isError ||
+    !inviteQuery.data ||
+    inviteQuery.data.status === "expired" ||
+    inviteQuery.data.status === "invalid"
+  ) {
+    return (
+      <Frame>
+        <FramePanel className="flex flex-col gap-3 text-sm">
+          <p className="font-medium">This invite link is no longer valid.</p>
+          <p className="text-muted-foreground">
+            It may have expired or been replaced by a newer invitation from{" "}
+            {org.name}. Ask an admin to resend your invitation.
+          </p>
+          <Button
+            type="button"
+            variant="outline"
+            className="self-start"
+            render={
+              <Link to="/o/$orgSlug/login" params={{ orgSlug: org.slug }} />
+            }
+          >
+            Go to {org.name} sign in
+          </Button>
+        </FramePanel>
+      </Frame>
+    );
+  }
+
+  if (inviteQuery.data.status === "consumed") {
+    return (
+      <Frame>
+        <FramePanel className="flex flex-col gap-3 text-sm">
+          <p className="font-medium">You've already created your account.</p>
+          <p className="text-muted-foreground">
+            This invite has already been used. Please sign in to {org.name}.
+          </p>
+          <Button
+            type="button"
+            variant="outline"
+            className="self-start"
+            render={
+              <Link to="/o/$orgSlug/login" params={{ orgSlug: org.slug }} />
+            }
+          >
+            Go to {org.name} sign in
+          </Button>
+        </FramePanel>
+      </Frame>
+    );
+  }
+
   return (
     <form
       className="flex w-full flex-col gap-3"
@@ -72,6 +141,20 @@ export function OrgRegisterForm({
     >
       <Frame>
         <FramePanel className="flex w-full flex-col gap-3 sm:gap-5">
+          <div className="flex gap-3 rounded-xl border border-border/70 bg-linear-to-br from-muted/50 to-muted/25 p-3 shadow-xs sm:gap-3.5 sm:p-4 dark:border-border/50 dark:from-muted/35 dark:to-muted/15">
+            <div className="bg-background/85 text-muted-foreground flex size-10 shrink-0 items-center justify-center rounded-lg border border-border/60 shadow-xs dark:bg-background/60">
+              <MailIcon aria-hidden className="size-4.5" strokeWidth={1.75} />
+            </div>
+            <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+              <p className="text-muted-foreground text-[10px] font-semibold tracking-wide uppercase sm:text-xs">
+                Invitation for
+              </p>
+              <p className="text-foreground truncate text-sm font-semibold tracking-tight sm:text-base">
+                {inviteQuery.data.email}
+              </p>
+            </div>
+          </div>
+
           <Controller
             control={control}
             name="firstName"

--- a/apps/frontend/src/features/org/components/org-school-register-form.tsx
+++ b/apps/frontend/src/features/org/components/org-school-register-form.tsx
@@ -85,7 +85,12 @@ export function OrgSchoolRegisterForm({
     );
   }
 
-  if (inviteQuery.isError || !inviteQuery.data) {
+  if (
+    inviteQuery.isError ||
+    !inviteQuery.data ||
+    inviteQuery.data.status === "expired" ||
+    inviteQuery.data.status === "invalid"
+  ) {
     return (
       <Frame>
         <FramePanel className="flex flex-col gap-3 text-sm">
@@ -93,6 +98,29 @@ export function OrgSchoolRegisterForm({
           <p className="text-muted-foreground">
             Your invite may have expired, been used, or been replaced by a newer
             one from {org.name}. Ask the admin to resend your invitation.
+          </p>
+          <Button
+            type="button"
+            variant="outline"
+            className="self-start"
+            render={
+              <Link to="/o/$orgSlug/login" params={{ orgSlug: org.slug }} />
+            }
+          >
+            Go to {org.name} sign in
+          </Button>
+        </FramePanel>
+      </Frame>
+    );
+  }
+
+  if (inviteQuery.data.status === "consumed") {
+    return (
+      <Frame>
+        <FramePanel className="flex flex-col gap-3 text-sm">
+          <p className="font-medium">You've already created your account.</p>
+          <p className="text-muted-foreground">
+            This invite has already been used. Please sign in to {org.name}.
           </p>
           <Button
             type="button"

--- a/apps/frontend/src/features/org/components/org-school-register-form.tsx
+++ b/apps/frontend/src/features/org/components/org-school-register-form.tsx
@@ -85,11 +85,13 @@ export function OrgSchoolRegisterForm({
     );
   }
 
+  // Only a definitive negative status from the server blocks the form. The
+  // lookup has retries disabled, so a transient failure must NOT dead-end a
+  // coach holding a valid token — fall through and let the backend validate
+  // the token on submit.
   if (
-    inviteQuery.isError ||
-    !inviteQuery.data ||
-    inviteQuery.data.status === "expired" ||
-    inviteQuery.data.status === "invalid"
+    inviteQuery.data?.status === "expired" ||
+    inviteQuery.data?.status === "invalid"
   ) {
     return (
       <Frame>
@@ -114,7 +116,7 @@ export function OrgSchoolRegisterForm({
     );
   }
 
-  if (inviteQuery.data.status === "consumed") {
+  if (inviteQuery.data?.status === "consumed") {
     return (
       <Frame>
         <FramePanel className="flex flex-col gap-3 text-sm">
@@ -172,24 +174,26 @@ export function OrgSchoolRegisterForm({
     >
       <Frame>
         <FramePanel className="flex w-full flex-col gap-3 sm:gap-5">
-          <div className="flex gap-3 rounded-xl border border-border/70 bg-linear-to-br from-muted/50 to-muted/25 p-3 shadow-xs sm:gap-3.5 sm:p-4 dark:border-border/50 dark:from-muted/35 dark:to-muted/15">
-            <div className="bg-background/85 text-muted-foreground flex size-10 shrink-0 items-center justify-center rounded-lg border border-border/60 shadow-xs dark:bg-background/60">
-              <MailIcon aria-hidden className="size-4.5" strokeWidth={1.75} />
-            </div>
-            <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-              <p className="text-muted-foreground text-[10px] font-semibold tracking-wide uppercase sm:text-xs">
-                Invitation for
-              </p>
-              <p className="text-foreground truncate text-sm font-semibold tracking-tight sm:text-base">
-                {inviteQuery.data.email}
-              </p>
-              {inviteQuery.data.eventName ? (
-                <p className="text-muted-foreground line-clamp-2 text-xs leading-snug sm:text-sm">
-                  {inviteQuery.data.eventName}
+          {inviteQuery.data?.email && (
+            <div className="flex gap-3 rounded-xl border border-border/70 bg-linear-to-br from-muted/50 to-muted/25 p-3 shadow-xs sm:gap-3.5 sm:p-4 dark:border-border/50 dark:from-muted/35 dark:to-muted/15">
+              <div className="bg-background/85 text-muted-foreground flex size-10 shrink-0 items-center justify-center rounded-lg border border-border/60 shadow-xs dark:bg-background/60">
+                <MailIcon aria-hidden className="size-4.5" strokeWidth={1.75} />
+              </div>
+              <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                <p className="text-muted-foreground text-[10px] font-semibold tracking-wide uppercase sm:text-xs">
+                  Invitation for
                 </p>
-              ) : null}
+                <p className="text-foreground truncate text-sm font-semibold tracking-tight sm:text-base">
+                  {inviteQuery.data?.email}
+                </p>
+                {inviteQuery.data?.eventName ? (
+                  <p className="text-muted-foreground line-clamp-2 text-xs leading-snug sm:text-sm">
+                    {inviteQuery.data?.eventName}
+                  </p>
+                ) : null}
+              </div>
             </div>
-          </div>
+          )}
 
           <Controller
             control={control}

--- a/apps/frontend/src/lib/api/types.d.ts
+++ b/apps/frontend/src/lib/api/types.d.ts
@@ -3547,6 +3547,44 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/orgs/{slug}/events/{id}/rosters/check-in/reset": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    slug: string;
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["OrgsIdEventsIdRostersCheckinResetResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/orgs/{slug}/events/{id}/checklist": {
         parameters: {
             query?: never;
@@ -5744,6 +5782,48 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/orgs/{slug}/invites/dancer/{token}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Look up a dancer invite by token
+         * @description Returns the invite state (valid | consumed | expired | invalid) plus prefill data (email, org name, brand color) when valid, so the dancer register page can show the right message. Always 200.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    slug: string;
+                    token: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["OrgsIdInvitesDancerIdResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/orgs/register/school": {
         parameters: {
             query?: never;
@@ -5834,15 +5914,6 @@ export interface paths {
                     };
                     content: {
                         "application/json": components["schemas"]["OrgsInvitesSchoolIdResponse"];
-                    };
-                };
-                /** @description Unknown Response */
-                410: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
                     };
                 };
             };
@@ -10685,6 +10756,9 @@ export interface components {
             avatar: string | null;
             username: string;
         }[];
+        OrgsIdEventsIdRostersCheckinResetResponse: {
+            reset: number;
+        };
         OrgsIdEventsIdChecklistResponse: {
             id: string;
             createdAt: string;
@@ -11136,6 +11210,15 @@ export interface components {
         OrgsIdRegisterResponse: {
             userId: string;
         };
+        OrgsIdInvitesDancerIdResponse: {
+            /** @enum {string} */
+            status: "expired" | "invalid" | "valid" | "consumed";
+            email: string | null;
+            orgName: string | null;
+            orgSlug: string | null;
+            brandColor: string | null;
+            expiresAt: string | null;
+        };
         OrgsRegisterSchoolRequest: {
             city?: string | null;
             firstName: string;
@@ -11149,14 +11232,16 @@ export interface components {
             userId: string;
         };
         OrgsInvitesSchoolIdResponse: {
-            email: string;
+            /** @enum {string} */
+            status: "expired" | "invalid" | "valid" | "consumed";
+            email: string | null;
             organization: string | null;
-            eventId: string;
-            eventName: string;
-            orgName: string;
-            orgSlug: string;
+            eventId: string | null;
+            eventName: string | null;
+            orgName: string | null;
+            orgSlug: string | null;
             brandColor: string | null;
-            expiresAt: string;
+            expiresAt: string | null;
         };
         SkillsResponse: {
             name: string;

--- a/apps/frontend/src/lib/api/types.d.ts
+++ b/apps/frontend/src/lib/api/types.d.ts
@@ -3991,6 +3991,15 @@ export interface paths {
                         "application/json": components["schemas"]["Error"];
                     };
                 };
+                /** @description Unknown Response */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
             };
         };
         delete?: never;
@@ -5894,7 +5903,7 @@ export interface paths {
         };
         /**
          * Look up a school invite by token
-         * @description Returns prefill data (email, organization, event/org names, brand color) for a school account invite. Returns 410 if the invite is invalid, expired, or already consumed.
+         * @description Returns the invite state (valid | consumed | expired | invalid) plus prefill data (email, organization, event/org names, brand color) when valid, so the school register page can show the right message. Always 200.
          */
         get: {
             parameters: {


### PR DESCRIPTION
## What & why

Org invite links (dancers **and** coaches/schools) were silently invalidated whenever staff re-uploaded a roster or hit "resend invites": each action regenerated the per-`(org/event, email)` token and reset `consumedAt`, killing every previously-emailed link and re-opening already-claimed invites. Recipients who clicked an older email got a generic "invalid or expired" message even though they were already registered. This was the root cause behind real support tickets (dancers registering fine, then finding their emailed link dead).

## What the change does

**Stable tokens** — resend / re-upload / admin-resend now reuse the existing invite token, extend expiry without shortening, and never reset `consumedAt`. Covers all 5 write sites: `upload-dancers`, `upload-coaches`, both resend branches, and reconciliation.

**Clear states** — `register-dancer` / `register-school` return distinct messages (already-registered → "please sign in", expired, invalid); a new dancer invite-lookup and an upgraded school invite-lookup expose `valid | consumed | expired | invalid` so the register pages show tailored panels instead of one generic error.

Note: in this codebase org **coaches and recruiter schools share the same `schoolInvites` table and school-register flow**, so these changes improve both — that's inherent to the data model, not a separate scope.

## Code-review findings (high-effort multi-agent review, verified)

**Fixed (5 confirmed correctness issues):**
1. **upload-dancers re-emailed registered dancers** — added the `consumedAt` guard `upload-coaches` already had.
2. **upload-dancers unlinked registered dancers** — a registered dancer with no `dancerProfiles` row yet had their roster `userId` reset to `null` on re-upload; now preserved (`userId ?? existing.userId`). *(Pre-existing but data-losing and in-flow, so fixed here.)*
3. **reconciliation re-emailed registered coaches** — `resendInvite` now no-ops on a consumed invite and returns 409.
4. **register forms dead-ended valid invitees on a transient lookup failure** — now only a definitive `expired`/`invalid` blocks; a network blip falls through to the form (backend still validates on submit). Applied to both dancer and school forms.
5. **stale "returns 410" OpenAPI description** on the school lookup — corrected; spec + types regenerated.

**Fixed (1 plausible race):**
6. **resend-invites coach-branch SELECT-then-INSERT race** on the `(eventId,email)` unique index — replaced with an atomic `onConflictDoUpdate ... returning`.

**Deferred (with reasons):**
- *upload-coaches wasted per-row crypto* (cleanup) — micro-perf; fixing it would fight the atomic upsert.
- *resend dancer/coach branch duplication* (cleanup) — less pressing now that the branches diverged (coach uses upsert, dancer uses select-insert); left as a follow-up.
- *`*.spec.ts` vs `*.test.ts` naming* — our tests match the **actual** codebase convention; it's `CLAUDE.md` that's stale.
- *dancer-resend binding a duplicate consumed row* (plausible, harm contested) — requires pre-existing duplicate `dancerInvites` rows, which our code never creates.

## Verification

- Backend + frontend typecheck: **clean**.
- Lint (all changed files): **clean**.
- Tests: resend-invites **5/5**, reconciliation **2/2**, register-dancer **12/12**, register-school **9/9**, invite-lookup-school **5/5**, upload-dancers **6 pass / 1 fail**.
- **The one upload-dancers failure reproduces on `origin/main` and is NOT introduced by this change.** It's `assert.isNull(roster.expirationDate)` in the `matched dancer … no premium grant` test on the matched-dancer/premium-grant path — present verbatim on `origin/main`, untouched by any invite change. It's a pre-existing test/behavior mismatch, out of scope here.

## Remaining risks / edge cases

1. **Pre-existing failing test** (`matched dancer … no premium grant`) — worth reconciling with current `expirationDate` behavior separately.
2. **Coach = School**: these changes also affect recruiter-school invites (same code path).
3. **Reconciliation admin "resend" semantics changed**: it no longer mints a fresh token or re-opens a claim; consumed invites 409. "Revoke" still hard-kills a link. Confirm that's the desired admin behavior.
4. **dancer-resend + legacy duplicate invite rows** (residual): if duplicate `dancerInvites` rows for one `(org,email)` already exist, `limit(1)` with no `ORDER BY` could bind a consumed one. Not reachable through current code paths; flagged for awareness.
5. **Transient-error fallthrough**: on a lookup failure the form renders without the prefill card; the backend validates on submit — this restores the pre-change "always submittable" behavior.

## Generated artifacts

Regenerated and committed: `apps/backend/openapi.json`, `apps/frontend/src/lib/api/types.d.ts`, `apps/backend/.adonisjs/api.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
