### PR TITLE
fix(profile): show raw dancer location when it isn't a US state code

### DIFF
--- a/apps/frontend/src/features/dancer/components/profile/hero/hero-content.tsx
+++ b/apps/frontend/src/features/dancer/components/profile/hero/hero-content.tsx
@@ -73,6 +73,7 @@ export function HeroContent({
               <MapPinIcon className="text-brand size-3.5 shrink-0" />
               <span className="text-nowrap">
                 {US_STATES[dancer.location as keyof typeof US_STATES] ||
+                  dancer.location ||
                   "Unknown"}
               </span>
             </div>

--- a/apps/frontend/src/features/explore/components/dancers/dancer-card.tsx
+++ b/apps/frontend/src/features/explore/components/dancers/dancer-card.tsx
@@ -48,7 +48,9 @@ export function DancerCard({ dancer, isFollowing }: DancerCardProps) {
           </div>
           <p className="text-muted-foreground flex items-center gap-1 text-sm">
             <MapPinIcon className="text-brand size-3.5 shrink-0" />{" "}
-            {US_STATES[dancer.location as keyof typeof US_STATES] || "Unknown"}
+            {US_STATES[dancer.location as keyof typeof US_STATES] ||
+              dancer.location ||
+              "Unknown"}
           </p>
         </div>
         <div className="flex flex-wrap gap-1.5">


### PR DESCRIPTION
## What & why

The dancer profile hero (`features/dancer/components/profile/hero/hero-content.tsx`) and the explore dancer card (`features/explore/components/dancers/dancer-card.tsx`) render `location` by looking it up in a **US-states-only** map and falling back to **"Unknown"**. Any non-US location (e.g. a Canadian province) therefore displays as "Unknown" even when a real value is stored.

## Change

Fall back to the raw stored `location` value before "Unknown":

```tsx
{US_STATES[dancer.location] || dancer.location || "Unknown"}
```

So a US state code still renders its full name, and a non-US value (e.g. `Alberta`) displays as entered instead of "Unknown".

## Notes

- Motivated by a real profile (dancer based in Alberta, Canada) whose location could only ever show "Unknown" under the US-states-only mapping. Her stored value was corrected to `Alberta` directly.
- The location picker is still US-states-only; this only affects **display** of already-stored values. No picker/data-entry change.
- Frontend typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)