### PR TITLE
feat(location): Canadian provinces + two-step country/region picker

### DIFF
--- a/apps/frontend/src/components/shared/location-select.tsx
+++ b/apps/frontend/src/components/shared/location-select.tsx
@@ -13,64 +13,23 @@ import {
   ComboboxTrigger,
   ComboboxValue,
 } from "@/components/ui/combobox";
+import { US_STATES, CA_PROVINCES } from "@/utils/constants/states";
 
 interface State {
   value: string | null;
   label: string;
 }
 
+// Built from the shared region source so the picker options and the display
+// lookups can't drift. Canadian provinces are suffixed for clarity; the stored
+// value is still the bare 2-letter code.
 const states: State[] = [
-  { label: "Select state", value: null },
-  { value: "AL", label: "Alabama" },
-  { value: "AK", label: "Alaska" },
-  { value: "AZ", label: "Arizona" },
-  { value: "AR", label: "Arkansas" },
-  { value: "CA", label: "California" },
-  { value: "CO", label: "Colorado" },
-  { value: "CT", label: "Connecticut" },
-  { value: "DE", label: "Delaware" },
-  { value: "FL", label: "Florida" },
-  { value: "GA", label: "Georgia" },
-  { value: "HI", label: "Hawaii" },
-  { value: "ID", label: "Idaho" },
-  { value: "IL", label: "Illinois" },
-  { value: "IN", label: "Indiana" },
-  { value: "IA", label: "Iowa" },
-  { value: "KS", label: "Kansas" },
-  { value: "KY", label: "Kentucky" },
-  { value: "LA", label: "Louisiana" },
-  { value: "ME", label: "Maine" },
-  { value: "MD", label: "Maryland" },
-  { value: "MA", label: "Massachusetts" },
-  { value: "MI", label: "Michigan" },
-  { value: "MN", label: "Minnesota" },
-  { value: "MS", label: "Mississippi" },
-  { value: "MO", label: "Missouri" },
-  { value: "MT", label: "Montana" },
-  { value: "NE", label: "Nebraska" },
-  { value: "NV", label: "Nevada" },
-  { value: "NH", label: "New Hampshire" },
-  { value: "NJ", label: "New Jersey" },
-  { value: "NM", label: "New Mexico" },
-  { value: "NY", label: "New York" },
-  { value: "NC", label: "North Carolina" },
-  { value: "ND", label: "North Dakota" },
-  { value: "OH", label: "Ohio" },
-  { value: "OK", label: "Oklahoma" },
-  { value: "OR", label: "Oregon" },
-  { value: "PA", label: "Pennsylvania" },
-  { value: "RI", label: "Rhode Island" },
-  { value: "SC", label: "South Carolina" },
-  { value: "SD", label: "South Dakota" },
-  { value: "TN", label: "Tennessee" },
-  { value: "TX", label: "Texas" },
-  { value: "UT", label: "Utah" },
-  { value: "VT", label: "Vermont" },
-  { value: "VA", label: "Virginia" },
-  { value: "WA", label: "Washington" },
-  { value: "WV", label: "West Virginia" },
-  { value: "WI", label: "Wisconsin" },
-  { value: "WY", label: "Wyoming" },
+  { label: "Select location", value: null },
+  ...Object.entries(US_STATES).map(([value, label]) => ({ value, label })),
+  ...Object.entries(CA_PROVINCES).map(([value, label]) => ({
+    value,
+    label: `${label} (Canada)`,
+  })),
 ];
 
 /** Normalize `items` entries (State objects) and the controlled `value` (state code string). */

--- a/apps/frontend/src/components/shared/location-select.tsx
+++ b/apps/frontend/src/components/shared/location-select.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ChevronsUpDownIcon, SearchIcon } from "lucide-react";
+import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -13,30 +14,43 @@ import {
   ComboboxTrigger,
   ComboboxValue,
 } from "@/components/ui/combobox";
+import {
+  Select,
+  SelectItem,
+  SelectPopup,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { US_STATES, CA_PROVINCES } from "@/utils/constants/states";
 
-interface State {
+type Country = "US" | "CA";
+
+const COUNTRIES: { value: Country; label: string }[] = [
+  { value: "US", label: "United States of America" },
+  { value: "CA", label: "Canada" },
+];
+
+const REGIONS_BY_COUNTRY: Record<Country, Record<string, string>> = {
+  US: US_STATES,
+  CA: CA_PROVINCES,
+};
+
+// A stored 2-letter code implies its country — US state and CA province codes
+// never overlap — so the country is derived, not stored.
+function countryForCode(code: string | null | undefined): Country {
+  return code && code in CA_PROVINCES ? "CA" : "US";
+}
+
+interface Region {
   value: string | null;
   label: string;
 }
 
-// Built from the shared region source so the picker options and the display
-// lookups can't drift. Canadian provinces are suffixed for clarity; the stored
-// value is still the bare 2-letter code.
-const states: State[] = [
-  { label: "Select location", value: null },
-  ...Object.entries(US_STATES).map(([value, label]) => ({ value, label })),
-  ...Object.entries(CA_PROVINCES).map(([value, label]) => ({
-    value,
-    label: `${label} (Canada)`,
-  })),
-];
-
-/** Normalize `items` entries (State objects) and the controlled `value` (state code string). */
+/** Normalize `items` entries (Region objects) and the controlled `value` (region code string). */
 function locationItemEquals(a: unknown, b: unknown): boolean {
   const code = (x: unknown) =>
     x != null && typeof x === "object" && "value" in (x as object)
-      ? (x as State).value
+      ? (x as Region).value
       : (x as string | null | undefined);
   return code(a) === code(b);
 }
@@ -50,54 +64,98 @@ export default function LocationSelect({
   value,
   onChange,
 }: LocationSelectProps) {
-  // Item values are `state.value` (string | null). Root `value` must use the same
-  // shape so Base UI can match selection (Object.is is the default comparator).
-  const selectedCode =
-    value && states.some((s) => s.value === value) ? value : null;
+  const [country, setCountry] = useState<Country>(() => countryForCode(value));
+  const [seenValue, setSeenValue] = useState(value);
+
+  // Follow the stored value's country when it loads or changes to a code from
+  // the other country (e.g. an async profile fetch on the edit form). Adjusting
+  // state during render is React's recommended pattern and avoids a sync effect.
+  // An empty value — set when the user switches country to clear the region — is
+  // ignored, so the user's country choice sticks.
+  if (value !== seenValue) {
+    setSeenValue(value);
+    const next = countryForCode(value);
+    if (value && next !== country) setCountry(next);
+  }
+
+  const regionMap = REGIONS_BY_COUNTRY[country];
+  const regionNoun = country === "CA" ? "province/territory" : "state";
+  const regionNounPlural =
+    country === "CA" ? "provinces/territories" : "states";
+  const regions: Region[] = [
+    { label: `Select ${regionNoun}`, value: null },
+    ...Object.entries(regionMap).map(([value, label]) => ({ value, label })),
+  ];
+
+  // Root `value` must use the same shape as item values so Base UI can match.
+  const selectedCode = value && value in regionMap ? value : null;
 
   return (
-    <Combobox
-      onValueChange={(v) => {
-        onChange((v as string) ?? "");
-      }}
-      value={selectedCode}
-      items={states}
-      isItemEqualToValue={locationItemEquals}
-      autoHighlight
-    >
-      <ComboboxTrigger
-        render={
-          <Button
-            className="w-full justify-between font-normal"
-            variant="outline"
-          />
-        }
+    <div className="flex w-full flex-col gap-2">
+      <Select
+        items={COUNTRIES}
+        value={country}
+        onValueChange={(next) => {
+          setCountry(next as Country);
+          // The previously selected region belongs to the old country; clear it.
+          onChange("");
+        }}
       >
-        <ComboboxValue />
-        <ChevronsUpDownIcon className="-me-1!" />
-      </ComboboxTrigger>
-      <ComboboxPopup aria-label="Select state">
-        <div className="border-b p-2">
-          <ComboboxInput
-            size="sm"
-            className="rounded-md before:rounded-[calc(var(--radius-md)-1px)]"
-            placeholder="e.g. Colorado"
-            showTrigger={false}
-            startAddon={<SearchIcon />}
-          />
-        </div>
-        <ComboboxEmpty>No states found.</ComboboxEmpty>
-        <ComboboxList>
-          {(state: State) => (
-            <ComboboxItem
-              key={state.value ?? "__placeholder__"}
-              value={state.value}
-            >
-              {state.label}
-            </ComboboxItem>
-          )}
-        </ComboboxList>
-      </ComboboxPopup>
-    </Combobox>
+        <SelectTrigger className="w-full justify-between font-normal">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectPopup>
+          {COUNTRIES.map((c) => (
+            <SelectItem key={c.value} value={c.value}>
+              {c.label}
+            </SelectItem>
+          ))}
+        </SelectPopup>
+      </Select>
+
+      <Combobox
+        onValueChange={(v) => {
+          onChange((v as string) ?? "");
+        }}
+        value={selectedCode}
+        items={regions}
+        isItemEqualToValue={locationItemEquals}
+        autoHighlight
+      >
+        <ComboboxTrigger
+          render={
+            <Button
+              className="w-full justify-between font-normal"
+              variant="outline"
+            />
+          }
+        >
+          <ComboboxValue />
+          <ChevronsUpDownIcon className="-me-1!" />
+        </ComboboxTrigger>
+        <ComboboxPopup aria-label={`Select ${regionNoun}`}>
+          <div className="border-b p-2">
+            <ComboboxInput
+              size="sm"
+              className="rounded-md before:rounded-[calc(var(--radius-md)-1px)]"
+              placeholder={country === "CA" ? "e.g. Alberta" : "e.g. Colorado"}
+              showTrigger={false}
+              startAddon={<SearchIcon />}
+            />
+          </div>
+          <ComboboxEmpty>No {regionNounPlural} found.</ComboboxEmpty>
+          <ComboboxList>
+            {(region: Region) => (
+              <ComboboxItem
+                key={region.value ?? "__placeholder__"}
+                value={region.value}
+              >
+                {region.label}
+              </ComboboxItem>
+            )}
+          </ComboboxList>
+        </ComboboxPopup>
+      </Combobox>
+    </div>
   );
 }

--- a/apps/frontend/src/features/dancer/components/profile/hero/hero-content.tsx
+++ b/apps/frontend/src/features/dancer/components/profile/hero/hero-content.tsx
@@ -8,7 +8,7 @@ import type { DancerProfile } from "@/features/dancer/types";
 import { AvatarUploadDialog } from "@/shared/images/components/avatar-upload/avatar-upload-dialog";
 import { ProfilePicture } from "@/shared/images/components/profile-picture";
 import { calculateAge } from "@/utils/calculate-age";
-import { US_STATES } from "@/utils/constants/states";
+import { REGIONS } from "@/utils/constants/states";
 import {
   MailIcon,
   MapPinIcon,
@@ -72,9 +72,7 @@ export function HeroContent({
             <div className="flex items-center gap-1.5">
               <MapPinIcon className="text-brand size-3.5 shrink-0" />
               <span className="text-nowrap">
-                {US_STATES[dancer.location as keyof typeof US_STATES] ||
-                  dancer.location ||
-                  "Unknown"}
+                {REGIONS[dancer.location as keyof typeof REGIONS] || "Unknown"}
               </span>
             </div>
             <div className="flex min-w-0 items-center gap-1.5">

--- a/apps/frontend/src/features/explore/components/dancers/dancer-card.tsx
+++ b/apps/frontend/src/features/explore/components/dancers/dancer-card.tsx
@@ -4,7 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { Dancer } from "@/shared/types";
 import { calculateAge } from "@/utils/calculate-age";
-import { US_STATES } from "@/utils/constants/states";
+import { REGIONS } from "@/utils/constants/states";
 import { Link } from "@tanstack/react-router";
 import {
   CalendarIcon,
@@ -48,9 +48,7 @@ export function DancerCard({ dancer, isFollowing }: DancerCardProps) {
           </div>
           <p className="text-muted-foreground flex items-center gap-1 text-sm">
             <MapPinIcon className="text-brand size-3.5 shrink-0" />{" "}
-            {US_STATES[dancer.location as keyof typeof US_STATES] ||
-              dancer.location ||
-              "Unknown"}
+            {REGIONS[dancer.location as keyof typeof REGIONS] || "Unknown"}
           </p>
         </div>
         <div className="flex flex-wrap gap-1.5">

--- a/apps/frontend/src/utils/constants/states.ts
+++ b/apps/frontend/src/utils/constants/states.ts
@@ -50,3 +50,23 @@ export const US_STATES = {
   WI: "Wisconsin",
   WY: "Wyoming",
 } as const;
+
+export const CA_PROVINCES = {
+  AB: "Alberta",
+  BC: "British Columbia",
+  MB: "Manitoba",
+  NB: "New Brunswick",
+  NL: "Newfoundland and Labrador",
+  NS: "Nova Scotia",
+  NT: "Northwest Territories",
+  NU: "Nunavut",
+  ON: "Ontario",
+  PE: "Prince Edward Island",
+  QC: "Quebec",
+  SK: "Saskatchewan",
+  YT: "Yukon",
+} as const;
+
+// Combined region lookup for display. Safe to merge: US state codes and
+// Canadian province codes do not overlap.
+export const REGIONS = { ...US_STATES, ...CA_PROVINCES } as const;


### PR DESCRIPTION
## Summary

Adds Canadian provinces to the location picker and displays them on dancer profiles, alongside a redesigned two-step location selector.

- **Two-step country-then-region picker** — the location selector now asks for country first, then shows the relevant regions (US states or Canadian provinces).
- **Canadian provinces** — added province constants and surfaced them on dancer profile hero content and dancer cards in explore.

## Changes

- `location-select.tsx` — reworked into a two-step country → region flow
- `states.ts` — added Canadian provinces
- `hero-content.tsx` / `dancer-card.tsx` — render province/region on dancer profiles

## Test plan

- [ ] Select United States → verify state list appears and saves
- [ ] Select Canada → verify province list appears and saves
- [ ] Confirm the selected region renders on the dancer profile hero and dancer card

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pa8fVoHpJ2QXz4EyrCkyC1
