### PR TITLE
fix(recruiting): CRV dialog footer + school list filtering

### DIFF
--- a/apps/backend/app/modules/dancers/common-recruiting/get-submission-schools/service.ts
+++ b/apps/backend/app/modules/dancers/common-recruiting/get-submission-schools/service.ts
@@ -1,10 +1,16 @@
 import { crvSubmissions } from "#database/schema/crv";
-import { schoolProfiles } from "#database/schema/schools";
+import { schoolApplications, schoolProfiles } from "#database/schema/schools";
 import { users } from "#database/schema/users";
 import { DatabaseService } from "#database/service";
 import { imageUrl } from "#utils/image-url";
 import { inject } from "@adonisjs/core";
-import { and, eq, not, notInArray } from "drizzle-orm";
+import { and, eq, isNull, not, notInArray, or } from "drizzle-orm";
+
+// TODO: make this admin-managed (a per-school "hide from common recruiting"
+// toggle) instead of a hardcoded list.
+const HIDDEN_SCHOOL_USER_IDS = [
+  "04be95ed-ca37-4acc-94cf-c02691798bf8", // University of Tennessee
+];
 
 @inject()
 export class Service {
@@ -30,10 +36,20 @@ export class Service {
                 .from(crvSubmissions)
                 .where(eq(crvSubmissions.dancerId, profileId))
             ),
-            not(eq(users.role, "admin"))
+            not(eq(users.role, "admin")),
+            eq(users.verified, true),
+            notInArray(users.id, HIDDEN_SCHOOL_USER_IDS),
+            or(
+              isNull(schoolApplications.status),
+              eq(schoolApplications.status, "accepted")
+            )
           )
         )
         .leftJoin(users, eq(schoolProfiles.userId, users.id))
+        .leftJoin(
+          schoolApplications,
+          eq(schoolApplications.schoolId, schoolProfiles.id)
+        )
     );
 
     return data.flatMap((school) => {

--- a/apps/frontend/src/features/recruiting/components/school/school-submission-card.tsx
+++ b/apps/frontend/src/features/recruiting/components/school/school-submission-card.tsx
@@ -1,21 +1,5 @@
 import { ProfileCard } from "@/components/shared/profile-card/profile-card";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogFooter,
-  DialogTrigger,
-} from "@/components/ui/dialog";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Spinner } from "@/components/ui/spinner";
 import { US_STATES } from "@/utils/constants/states";
 import { Link } from "@tanstack/react-router";
 import {
@@ -24,23 +8,17 @@ import {
   ClockIcon,
   EyeIcon,
   MapPinIcon,
-  PlayIcon,
 } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { recruitingQueries } from "../../api/queries";
 import { useUpdateSubmissionStatus } from "../../api/mutations";
 import type { SchoolSubmission } from "../../types";
+import { SubmissionStatusSelect } from "./submission-status-select";
+import { SubmissionVideoDialog } from "./submission-video-dialog";
 
 interface SchoolSubmissionCardProps {
   submission: SchoolSubmission;
 }
-
-const STATUS_OPTIONS = [
-  { value: "pending", label: "Pending" },
-  { value: "in_review", label: "In Review" },
-  { value: "accepted", label: "Accepted" },
-  { value: "released", label: "Released" },
-] as const;
 
 function statusBadge(status: SchoolSubmission["status"]) {
   switch (status) {
@@ -124,8 +102,7 @@ export function SchoolSubmissionCard({
     }
   };
 
-  const handleStatusChange = (status: string) => {
-    const newStatus = status as SchoolSubmission["status"];
+  const handleStatusChange = (newStatus: SchoolSubmission["status"]) => {
     const previous = optimisticUpdate({ status: newStatus });
     updateMutation.mutate(
       {
@@ -150,8 +127,8 @@ export function SchoolSubmissionCard({
         username: dancer.username,
       }}
     >
-      <div className="flex min-w-0 flex-1 flex-col gap-2">
-        <div className="flex items-start justify-between gap-2">
+      <div className="flex min-w-0 flex-1 flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex min-w-0 flex-col gap-2">
           <div className="flex min-w-0 flex-col">
             <h3 className="flex min-w-0 items-center gap-1 text-base leading-tight font-semibold">
               <Link
@@ -170,67 +147,25 @@ export function SchoolSubmissionCard({
               </p>
             )}
           </div>
-          {submission.youtubeId && (
-            <Dialog onOpenChange={handleOpenChange}>
-              <DialogTrigger
-                render={
-                  <Button
-                    variant="outline"
-                    size="xs"
-                    className="relative z-10 shrink-0 gap-1"
-                  />
-                }
-              >
-                <PlayIcon className="size-3" /> Watch Video
-              </DialogTrigger>
-              <DialogContent
-                showCloseButton={false}
-                className="max-w-7xl overflow-clip"
-              >
-                <iframe
-                  src={`https://www.youtube.com/embed/${submission.youtubeId}`}
-                  title={`${dancer.name}'s CRV`}
-                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                  allowFullScreen
-                  className="aspect-video h-full w-full"
-                />
-                <DialogFooter className="flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                  <div className="flex items-center gap-2">
-                    <span className="text-muted-foreground text-sm">
-                      Status:
-                    </span>
-                    <Select
-                      items={STATUS_OPTIONS}
-                      value={submission.status}
-                      onValueChange={(value) =>
-                        value && handleStatusChange(value)
-                      }
-                      disabled={updateMutation.isPending}
-                    >
-                      <SelectTrigger className="w-32">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {STATUS_OPTIONS.map((option) => (
-                          <SelectItem key={option.value} value={option.value}>
-                            {option.label}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                    {updateMutation.isPending && <Spinner />}
-                  </div>
-                  <DialogClose render={<Button variant="secondary" />}>
-                    Close
-                  </DialogClose>
-                </DialogFooter>
-              </DialogContent>
-            </Dialog>
-          )}
+          <div className="flex flex-wrap items-center gap-1.5">
+            {statusBadge(submission.status)}
+            {watchedBadge(submission.watched)}
+          </div>
         </div>
-        <div className="flex flex-wrap items-center gap-1.5">
-          {statusBadge(submission.status)}
-          {watchedBadge(submission.watched)}
+        <div className="flex shrink-0 flex-col gap-2 sm:flex-row sm:items-center">
+          {submission.youtubeId && (
+            <SubmissionVideoDialog
+              youtubeId={submission.youtubeId}
+              title={`${dancer.name}'s CRV`}
+              onOpenChange={handleOpenChange}
+              className="w-full sm:w-auto"
+            />
+          )}
+          <SubmissionStatusSelect
+            value={submission.status}
+            onValueChange={handleStatusChange}
+            pending={updateMutation.isPending}
+          />
         </div>
       </div>
     </ProfileCard>

--- a/apps/frontend/src/features/recruiting/components/school/submission-status-select.tsx
+++ b/apps/frontend/src/features/recruiting/components/school/submission-status-select.tsx
@@ -1,0 +1,56 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Spinner } from "@/components/ui/spinner";
+import { cn } from "@/components/utils/cn";
+import type { SchoolSubmission } from "../../types";
+
+const STATUS_OPTIONS = [
+  { value: "pending", label: "Pending" },
+  { value: "in_review", label: "In Review" },
+  { value: "accepted", label: "Accepted" },
+  { value: "released", label: "Released" },
+] as const;
+
+interface SubmissionStatusSelectProps {
+  value: SchoolSubmission["status"];
+  onValueChange: (status: SchoolSubmission["status"]) => void;
+  pending?: boolean;
+  className?: string;
+}
+
+export function SubmissionStatusSelect({
+  value,
+  onValueChange,
+  pending,
+  className,
+}: SubmissionStatusSelectProps) {
+  return (
+    <div className={cn("relative z-10 flex items-center gap-2", className)}>
+      <Select
+        items={STATUS_OPTIONS}
+        value={value}
+        onValueChange={(next) =>
+          next && onValueChange(next as SchoolSubmission["status"])
+        }
+        disabled={pending}
+      >
+        <SelectTrigger size="sm" className="w-full sm:w-32">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {STATUS_OPTIONS.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {pending && <Spinner />}
+    </div>
+  );
+}

--- a/apps/frontend/src/features/recruiting/components/school/submission-video-dialog.tsx
+++ b/apps/frontend/src/features/recruiting/components/school/submission-video-dialog.tsx
@@ -1,0 +1,57 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { cn } from "@/components/utils/cn";
+import { PlayIcon } from "lucide-react";
+
+interface SubmissionVideoDialogProps {
+  youtubeId: string;
+  title: string;
+  onOpenChange?: (open: boolean) => void;
+  className?: string;
+}
+
+export function SubmissionVideoDialog({
+  youtubeId,
+  title,
+  onOpenChange,
+  className,
+}: SubmissionVideoDialogProps) {
+  return (
+    <Dialog onOpenChange={onOpenChange}>
+      <DialogTrigger
+        render={
+          <Button
+            variant="outline"
+            size="sm"
+            className={cn("relative z-10 shrink-0 gap-1", className)}
+          />
+        }
+      >
+        <PlayIcon className="size-3" /> Watch Video
+      </DialogTrigger>
+      <DialogContent
+        showCloseButton={false}
+        className="max-w-7xl overflow-clip"
+      >
+        <iframe
+          src={`https://www.youtube.com/embed/${youtubeId}`}
+          title={title}
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+          className="aspect-video min-h-0 w-full shrink"
+        />
+        <DialogFooter className="shrink-0 sm:justify-end">
+          <DialogClose render={<Button variant="secondary" />}>
+            Close
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Watch Video dialog

- **Footer was hidden.** The iframe's `min-height: auto` (it's a replaced element) stopped it from shrinking inside the popup's `max-h-full` flex column, so the footer was pushed past the viewport unless you zoomed out. It's now `min-h-0 shrink` with a `shrink-0` footer — the video still fills all remaining dialog height, it just yields to the footer instead of overflowing.
- Extracted the trigger + dialog into `SubmissionVideoDialog`.

## Status select moved onto the card

- Extracted into `SubmissionStatusSelect` — just the select, no "Status:" label. `size="sm"` matches the `size="sm"` Watch Video button height exactly (`h-8 sm:h-7` / `min-h-8 sm:min-h-7`).
- On `sm` and up it sits next to Watch Video, top-right of the card. Below `sm` the wrapper stacks so both go full-width under the Accepted/Watched badges — button on top, select beneath — instead of squeezing the name column.
- No logic changes; `handleStatusChange` now takes the typed status instead of casting a string.

## Submit-video school picker

- Added `users.verified = true` and an application-status check (absent or `accepted`), mirroring what the public schools directory already does. Rejected and pending schools no longer appear.
- Hardcoded block for University of Tennessee, with a TODO to replace it with an admin-managed per-school toggle.

Verified against prod with read-only queries: the picker query returns 147 schools, down from 176 non-admin rows, with 0 University of Tennessee rows. The 29 dropped are 20 rejected + 3 pending + 5 unverified-without-application + UT.

## Testing

- `pnpm typecheck` (backend) and `tsc --noEmit` (frontend) pass; eslint clean on changed files.
- **Not verified in a browser** — no dev server was up. The dialog footer fix and the mobile stacking are worth an eyeball before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)