### PR TITLE
fix(recruiting): hide Studio 2 Stadium and SummitTesting from CRV school picker

### DIFF
--- a/apps/backend/app/modules/dancers/common-recruiting/get-submission-schools/service.ts
+++ b/apps/backend/app/modules/dancers/common-recruiting/get-submission-schools/service.ts
@@ -10,6 +10,8 @@ import { and, eq, isNull, not, notInArray, or } from "drizzle-orm";
 // toggle) instead of a hardcoded list.
 const HIDDEN_SCHOOL_USER_IDS = [
   "04be95ed-ca37-4acc-94cf-c02691798bf8", // University of Tennessee
+  "c5f879a1-42b8-4fd1-a38d-76a567cbb6d3", // Studio 2 Stadium
+  "cb4d3f31-ec01-4466-8ce9-bb0bc0bc12b6", // SummitTesting
 ];
 
 @inject()


### PR DESCRIPTION
Follow-up to #55, which merged before these two were added.

Adds Studio 2 Stadium and SummitTesting to the `HIDDEN_SCHOOL_USER_IDS` list alongside University of Tennessee.

## Why hardcoded and not an org-admin flag

Checked whether org admin could serve as the flag instead. It can't:

| user | school | org role / type |
|---|---|---|
| `s_gunnarnugent_mpbjdpru` | Studio 2 Stadium | `member` / `coach` ×3 orgs |
| `summittesting` | SummitTesting | `member` / `coach` ×2 orgs |
| `UTDTrecruiting` | University of Tennessee | `member` / `coach` ×2 orgs |

All three are plain coach members, not admins. Org membership itself is no good either — 209 coach memberships, 206 attached to school profiles, so filtering on it would hide nearly every legitimate school.

The real org admins (`cameron_admin`, `testforonboard`, `velocity`, `ProdigyU`, `S2SAdmin`) are all internal/test accounts and are already excluded today by the verified/accepted filters — 0 of them reach the picker. Worth noting for whoever builds the admin toggle: they're only kept out because they happen to be unverified or rejected, so any of them getting verified would surface it.

The existing TODO to replace this list with an admin-managed per-school toggle stands.

## Testing

- Backend `pnpm typecheck` passes.
- Verified read-only against prod: picker query returns 145 schools with 0 of the three leaking through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)