### PR TITLE
fix(frontend): recover from stale chunks after a redeploy

### DIFF
--- a/apps/frontend/public/_headers
+++ b/apps/frontend/public/_headers
@@ -1,0 +1,18 @@
+# Cloudflare Pages header rules. Copied verbatim from public/ into the build
+# output root, which is where Pages expects this file.
+
+# Vite emits content-hashed filenames into /assets, so the bytes behind any one
+# of these URLs never change. Cache them for a year and skip revalidation.
+# Only /assets/* is safe here -- files served straight out of public/ (such as
+# background.jpg) keep stable names across deploys and must stay revalidated.
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# index.html is the one file whose URL is stable across deploys, and it is what
+# points the app at the current chunk hashes. It must always be revalidated, or
+# an open tab will keep requesting chunks that the latest deploy no longer has.
+/
+  Cache-Control: public, max-age=0, must-revalidate
+
+/index.html
+  Cache-Control: public, max-age=0, must-revalidate

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -55,13 +55,42 @@ declare module "@tanstack/react-router" {
   }
 }
 
+// A redeploy replaces every content-hashed file in /assets. Tabs that are
+// already open still reference the previous filenames, and Cloudflare answers
+// those with the SPA fallback -- index.html, 200, text/html -- instead of a 404,
+// so the browser refuses the module on MIME grounds and the dynamic import
+// fails. Reloading fetches the new index.html (served must-revalidate) and with
+// it the new chunk names.
+//
+// Only call preventDefault() when we are actually reloading. Vite's preload
+// helper rethrows unless the event is cancelled, so cancelling without
+// reloading makes the failed import resolve to `undefined` instead -- which is
+// what the router then reads `.errorComponent` off of, crashing the app with
+// "Cannot read properties of undefined" rather than showing a real error.
+const CHUNK_RELOAD_KEY = "chunk-reload-at";
+const CHUNK_RELOAD_COOLDOWN_MS = 10_000;
+
+let reloadingForStaleChunk = false;
+
 window.addEventListener("vite:preloadError", (event) => {
-  event.preventDefault();
-  const reloaded = sessionStorage.getItem("chunk-reload");
-  if (!reloaded) {
-    sessionStorage.setItem("chunk-reload", "1");
-    window.location.reload();
+  // A single navigation usually fails several chunks at once. The first one
+  // schedules the reload; the rest just stay quiet until it commits.
+  if (reloadingForStaleChunk) {
+    event.preventDefault();
+    return;
   }
+
+  const now = Date.now();
+  const lastReload = Number(sessionStorage.getItem(CHUNK_RELOAD_KEY)) || 0;
+
+  // We just reloaded and the chunk still will not load, so it is genuinely
+  // missing rather than stale. Let the error through instead of looping.
+  if (now - lastReload < CHUNK_RELOAD_COOLDOWN_MS) return;
+
+  reloadingForStaleChunk = true;
+  event.preventDefault();
+  sessionStorage.setItem(CHUNK_RELOAD_KEY, String(now));
+  window.location.reload();
 });
 
 ReactDOM.createRoot(document.getElementById("root")!).render(


### PR DESCRIPTION
## The problem

Every redeploy, open tabs threw a wall of these and the page died with **"Something went wrong! Cannot read properties of undefined (reading 'errorComponent')"**:

```
Failed to load module script: Expected a JavaScript-or-Wasm module script but the
server responded with a MIME type of "text/html".
```

Two things stack up here.

**1. Stale chunks (the trigger).** Vite emits content-hashed filenames, so each deploy produces a new set of `/assets/*.js` names. A tab that's already open still references the old ones. Those files are gone from the new deployment, and Cloudflare answers with the SPA fallback instead of a 404 — confirmed against production:

```
$ curl -sSI https://app.studio2stadium.com/assets/does-not-exist-AAAAAAAA.js
HTTP/2 200
content-type: text/html; charset=utf-8      ← not a 404, an HTML page
```

That's the MIME error verbatim. Expected, and the existing `vite:preloadError` handler was supposed to cover it.

**2. The handler was swallowing the error instead of recovering (the actual bug).** Vite's preload helper (`vite@7.3.1`, `dist/node/chunks/config.js:23345`) only rethrows when the event is left uncancelled:

```js
window.dispatchEvent(e$1);
if (!e$1.defaultPrevented) throw err$2;
```

So `preventDefault()` means *"don't rethrow"* — the failed `import()` then resolves to **`undefined`**. The old code cancelled unconditionally, *before* deciding whether to reload:

```js
event.preventDefault();                              // always swallows
const reloaded = sessionStorage.getItem("chunk-reload");
if (!reloaded) { ...; window.location.reload(); }     // but only reloads once, ever
```

`chunk-reload` was never cleared, and sessionStorage survives `location.reload()` in the same tab. So after a tab's *first* recovery it was permanently poisoned: every later deploy hit the suppress path with no reload, handing the router an `undefined` module. It reads `.errorComponent` off it and crashes, which TanStack Router's default boundary renders as "Something went wrong!".

That's why it reproduced on *every* redeploy for anyone keeping long-lived tabs.

## The fix

**`src/main.tsx`** — only cancel the event when actually reloading:

- Cancel-and-reload on a stale chunk. Fresh `index.html` is served `max-age=0, must-revalidate`, so the reload reliably picks up the new chunk names.
- If a chunk still fails within 10s of a reload it's genuinely missing rather than stale, so the error is left to propagate to a real error boundary instead of looping.
- An in-memory flag keeps the ~10 sibling chunk failures from one navigation quiet once the reload is committed.
- The new key (`chunk-reload-at`) also means tabs currently stuck with `chunk-reload=1` recover on their next load rather than staying poisoned.

**`public/_headers`** (new) — the caching cleanup:

- `/assets/*` → `max-age=31536000, immutable`. Content-hashed, so the bytes behind a given URL never change. Production was serving these `max-age=14400, must-revalidate`.
- `/` and `/index.html` → `max-age=0, must-revalidate`, made explicit because it's what maps the app to the current chunk hashes and therefore what makes the reload above work.
- Files served straight out of `public/` (`background.jpg`, `vite.svg`) are deliberately **not** covered — they keep stable names across deploys, so `immutable` would be wrong for them.

## Verification

- `tsc -b` clean, `eslint` clean, `vite build` succeeds
- New handler confirmed present in the entry bundle (`dist/assets/index-*.js`)
- `_headers` confirmed copied to the build output root, where Pages expects it

## One caveat worth knowing

Cloudflare's docs don't state whether `_headers` rules apply to SPA-fallback responses. If they do, a request for a *missing* `/assets/*.js` would get the fallback HTML cached `immutable`. Harmless in normal operation — that URL is never requested again once the app reloads onto new hashes — but it could bite on a **deployment rollback**, where old chunk names become valid again. Worth knowing before using Pages' "Rollback to this deployment". Happy to drop `immutable` and keep just the long `max-age` if you'd rather not carry that risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
