### PR TITLE
fix(frontend): drop immutable Cache-Control from /assets (URGENT — reverts part of #57)

### DIFF
--- a/apps/frontend/public/_headers
+++ b/apps/frontend/public/_headers
@@ -1,12 +1,20 @@
 # Cloudflare Pages header rules. Copied verbatim from public/ into the build
 # output root, which is where Pages expects this file.
 
-# Vite emits content-hashed filenames into /assets, so the bytes behind any one
-# of these URLs never change. Cache them for a year and skip revalidation.
-# Only /assets/* is safe here -- files served straight out of public/ (such as
-# background.jpg) keep stable names across deploys and must stay revalidated.
-/assets/*
-  Cache-Control: public, max-age=31536000, immutable
+# NOTE: do not add a long-lived Cache-Control rule for /assets/* here.
+#
+# Pages answers a request for a missing asset with the SPA fallback -- index.html,
+# 200, text/html -- rather than a 404, and header rules are applied to that
+# fallback response too. A `/assets/* immutable` rule therefore tells browsers and
+# the edge to store an HTML body under a .js URL and never revalidate it, which
+# turns a transient stale-chunk error into a permanent one that a reload cannot
+# clear. Verified against production: a cache MISS on a missing chunk returned
+# `content-type: text/html` alongside `max-age=31536000, immutable`.
+#
+# Caching /assets/* aggressively is only safe once missing assets stop falling
+# back to HTML, which on Pages needs a Function in front of /assets. Until then
+# the platform default (max-age=14400, must-revalidate) is what we want, because
+# it expires on its own.
 
 # index.html is the one file whose URL is stable across deploys, and it is what
 # points the app at the current chunk hashes. It must always be revalidated, or


### PR DESCRIPTION
**Urgent — reverts the `_headers` half of #57. Merge this ahead of anything else.**

## What went wrong

The caveat I flagged at the bottom of #57 turned out to be real, and worse than I estimated.

Cloudflare Pages answers a request for a *missing* asset with the SPA fallback — `index.html`, 200, `text/html` — instead of a 404, and it **does** apply `_headers` rules to that fallback response. So `/assets/* → immutable` told browsers and the edge to store an HTML body under a `.js` URL and never revalidate it.

That inverts the fix in #57. A stale chunk went from a transient error that a reload clears to a permanent one that a reload **cannot** clear, because `immutable` suppresses revalidation even on a normal reload.

Confirmed against production — note `cf-cache-status: MISS`, so this came from origin, not a poisoned edge entry:

```
$ curl -sSI 'https://app.studio2stadium.com/assets/login-CIHtTse0.js?cachebust=771231'
content-type: text/html; charset=utf-8
cache-control: public, max-age=31536000, immutable
cf-cache-status: MISS
```

I got this wrong twice on the way here, and both are worth recording:

- I first tested a made-up filename, got `max-age=14400, must-revalidate` back, and concluded `_headers` was *not* applied to the fallback. That request took a different cache path; the rule does apply.
- I then measured the chunk list of an entry bundle that a newer deployment had already replaced mid-diagnosis, and read the expected 404s as "158 chunks missing from the deploy". They weren't. **The deployment itself is complete** — re-measured against the current entry bundle, 0 of 314 chunks fail.

## The change

Drop the `/assets/*` rule and fall back to the platform default (`max-age=14400, must-revalidate`), which expires on its own. A comment records why, so it doesn't get re-added blind.

The `index.html` revalidation rules stay — those are what let the reload recovery in `main.tsx` pick up new chunk hashes, and they're safe because `index.html` always exists.

The `main.tsx` change from #57 is **not** reverted. It's still correct and is unaffected by this.

## Deploying this is not sufficient on its own

Chunk hashes don't change when only `_headers` changes, so the poisoned URLs stay poisoned after this deploys. Two manual steps are needed — see the PR discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
