### PR TITLE
feat(schools): add NJCAA, Community College, and Other divisions

### DIFF
--- a/apps/backend/app/shared/constants/divisions.ts
+++ b/apps/backend/app/shared/constants/divisions.ts
@@ -4,6 +4,9 @@ export const DIVISIONS = {
   "division-ii": "Division II",
   "division-iii": "Division III",
   "naia": "NAIA",
+  "njcaa": "NJCAA",
+  "community-college": "Community College",
+  "other": "Other",
 } as const;
 
 export type DivisionCode = keyof typeof DIVISIONS;

--- a/apps/frontend/src/utils/constants/divisions.ts
+++ b/apps/frontend/src/utils/constants/divisions.ts
@@ -4,4 +4,7 @@ export const DIVISIONS = {
   "division-ii": "Division II",
   "division-iii": "Division III",
   naia: "NAIA",
+  njcaa: "NJCAA",
+  "community-college": "Community College",
+  other: "Other",
 } as const;


### PR DESCRIPTION
## Summary

Adds three new school division categories — **NJCAA**, **Community College**, and **Other** — to the shared division taxonomy.

Division is the app's single school-category concept, stored as a free-text column and enforced only in application code by two parallel constant files. Both are updated here and kept in sync:

- `apps/backend/app/shared/constants/divisions.ts`
- `apps/frontend/src/utils/constants/divisions.ts`

## Where these appear (all data-driven from the constants)

- **School signup/edit dropdown** — Program Details form and admin editor build options from `DIVISIONS`.
- **Dancer "Division" filter** — backend `divisionOptions` (filter options) and `divisionCodes` (validator allow-list) derive from the backend constant, so the new values are both selectable and accepted.
- **School profile hero badge** and explore school card — map the stored code to its label via `DIVISIONS`.

## Notes

- No DB migration needed — `division` is a free-text column, so existing data is unaffected.
- The dancer-facing filter tab is labeled "Division"; "Community College" and "Other" will appear under it. Happy to relabel the tab (e.g. "Division / Type") in a follow-up if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)