### PR TITLE
chore(deploy): scale backend to shared-cpu-4x, always-on

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -17,14 +17,15 @@ primary_region = 'iad'
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = 'stop'
+  auto_stop_machines = 'off'
   auto_start_machines = true
-  min_machines_running = 1
+  min_machines_running = 2
   processes = ['app']
 
 [[vm]]
   memory = '1gb'
-  cpus = 1
+  cpus = 4
+  cpu_kind = 'shared'
 
 [[http_service.checks]]
   grace_period = "10s"


### PR DESCRIPTION
## What

Bring `fly.toml` in sync with the machine config currently deployed to `studio2stadium-dev`:

- **Resize** app machines `shared-cpu-1x` → **`shared-cpu-4x` @ 1gb** (2 → **8 cores** total).
- **Always-on**: `auto_stop_machines` `'stop'` → `'off'`, `min_machines_running` `1` → `2`.

## Why

Login is CPU-bound on **argon2** (`parallelism: 1`, so one core per hash) → throughput scales with cores. Load testing the old `2× shared-cpu-1x`:

| Concurrency | Throughput | p50 | p95 |
|---|---|---|---|
| 10 | ~4/s | 2.4s | 3.1s |
| 100 | ~6/s | 13.2s | 23.3s |

Throughput was flat from 10→100 concurrent — the signature of a serialized (single-core, throttled) bottleneck. `shared-cpu-4x` gives 4 cores/machine, which also aligns with Node's default `UV_THREADPOOL_SIZE=4` (argon2 hashes run on the libuv threadpool).

> ⚠️ If a machine is ever resized beyond 4 CPUs, also set `UV_THREADPOOL_SIZE` to match or the extra cores sit idle for hashing.

## Notes

- Change is **already live** on prod (deployed manually); this commit prevents a future CI deploy from `main` silently reverting the resize back to `shared-cpu-1x`.
- Config-only: no image or schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)