### PR TITLE
fix: org dancers get S2S freemium email + LocationSelect infinite loop

### DIFF
--- a/apps/backend/app/modules/dancers/profile/create-dancer/event.spec.ts
+++ b/apps/backend/app/modules/dancers/profile/create-dancer/event.spec.ts
@@ -1,0 +1,91 @@
+import { test } from "@japa/runner";
+import mail from "@adonisjs/mail/services/main";
+import { db } from "#database/connection";
+import { users } from "#database/schema/users";
+import {
+  organizations,
+  orgMemberships,
+} from "#database/schema/organizations";
+import { DancerCreatedEvent, DancerCreatedHandler } from "./event.ts";
+import DancerWelcomeEmail from "./email.ts";
+
+async function makeUser(overrides: Partial<typeof users.$inferInsert> = {}) {
+  const seed = `${Date.now()}-${Math.random()}`;
+  const [user] = await db
+    .insert(users)
+    .values({
+      username: `dancer_${seed}`,
+      email: `dancer_${seed}@example.com`,
+      displayEmail: `dancer_${seed}@example.com`,
+      firstName: "Dana",
+      lastName: "Dancer",
+      password: "x",
+      role: "user",
+      type: "dancer",
+      verified: true,
+      ...overrides,
+    })
+    .returning();
+  return user!;
+}
+
+async function makeOrg() {
+  const [org] = await db
+    .insert(organizations)
+    .values({ name: "T", slug: `t-${Date.now()}-${Math.random()}` })
+    .returning();
+  return org!;
+}
+
+test.group("DancerCreatedHandler welcome email", (group) => {
+  group.each.setup(async () => {
+    await db.delete(orgMemberships).execute();
+    await db.delete(organizations).execute();
+    await db.delete(users).execute();
+    mail.fake();
+  });
+
+  group.each.teardown(() => {
+    mail.restore();
+  });
+
+  test("sends the welcome email to a standalone S2S dancer", async () => {
+    const fake = mail.fake();
+    const user = await makeUser();
+
+    await new DancerCreatedHandler().handle(
+      new DancerCreatedEvent({ userId: user.id })
+    );
+
+    fake.mails.assertSent(DancerWelcomeEmail);
+  });
+
+  test("does NOT send the welcome email to an org dancer", async () => {
+    const fake = mail.fake();
+    const user = await makeUser({ orgAccountTier: "limited" });
+    const org = await makeOrg();
+    await db.insert(orgMemberships).values({
+      userId: user.id,
+      orgId: org.id,
+      type: "dancer",
+      role: "member",
+    });
+
+    await new DancerCreatedHandler().handle(
+      new DancerCreatedEvent({ userId: user.id })
+    );
+
+    fake.mails.assertNotSent(DancerWelcomeEmail);
+  });
+
+  test("respects the notifications opt-out for standalone dancers", async () => {
+    const fake = mail.fake();
+    const user = await makeUser({ notifications: false });
+
+    await new DancerCreatedHandler().handle(
+      new DancerCreatedEvent({ userId: user.id })
+    );
+
+    fake.mails.assertNotSent(DancerWelcomeEmail);
+  });
+});

--- a/apps/backend/app/modules/dancers/profile/create-dancer/event.ts
+++ b/apps/backend/app/modules/dancers/profile/create-dancer/event.ts
@@ -1,5 +1,7 @@
 import { db } from "#database/connection";
+import { orgMemberships } from "#database/schema/organizations";
 import { AppEvent } from "#shared/event";
+import { eq } from "drizzle-orm";
 import emitter from "@adonisjs/core/services/emitter";
 import mail from "@adonisjs/mail/services/main";
 import DancerWelcomeEmail from "./email.ts";
@@ -14,7 +16,7 @@ export class DancerCreatedEvent extends AppEvent {
   }
 }
 
-class DancerCreatedHandler {
+export class DancerCreatedHandler {
   async handle(event: DancerCreatedEvent) {
     const { userId } = event.data;
 
@@ -27,6 +29,19 @@ class DancerCreatedHandler {
     }
 
     if (!user.notifications) {
+      return;
+    }
+
+    // Org-provisioned dancers are freemium and must not receive the S2S
+    // welcome email. If they later pay for full S2S access, the Stripe
+    // SubscriptionCreatedEvent sends the premium welcome email instead.
+    const [orgMembership] = await db
+      .select({ userId: orgMemberships.userId })
+      .from(orgMemberships)
+      .where(eq(orgMemberships.userId, userId))
+      .limit(1);
+
+    if (orgMembership) {
       return;
     }
 

--- a/apps/frontend/src/components/shared/location-select.tsx
+++ b/apps/frontend/src/components/shared/location-select.tsx
@@ -1,7 +1,8 @@
 "use client";
 
+import { Field as FieldPrimitive } from "@base-ui/react/field";
 import { ChevronsUpDownIcon, SearchIcon } from "lucide-react";
-import { useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -41,20 +42,6 @@ function countryForCode(code: string | null | undefined): Country {
   return code && code in CA_PROVINCES ? "CA" : "US";
 }
 
-interface Region {
-  value: string | null;
-  label: string;
-}
-
-/** Normalize `items` entries (Region objects) and the controlled `value` (region code string). */
-function locationItemEquals(a: unknown, b: unknown): boolean {
-  const code = (x: unknown) =>
-    x != null && typeof x === "object" && "value" in (x as object)
-      ? (x as Region).value
-      : (x as string | null | undefined);
-  return code(a) === code(b);
-}
-
 interface LocationSelectProps {
   value: string | undefined;
   onChange: (value: string) => void;
@@ -65,61 +52,90 @@ export default function LocationSelect({
   onChange,
 }: LocationSelectProps) {
   const [country, setCountry] = useState<Country>(() => countryForCode(value));
-  const [seenValue, setSeenValue] = useState(value);
 
   // Follow the stored value's country when it loads or changes to a code from
-  // the other country (e.g. an async profile fetch on the edit form). Adjusting
-  // state during render is React's recommended pattern and avoids a sync effect.
-  // An empty value — set when the user switches country to clear the region — is
-  // ignored, so the user's country choice sticks.
-  if (value !== seenValue) {
-    setSeenValue(value);
-    const next = countryForCode(value);
-    if (value && next !== country) setCountry(next);
-  }
+  // the other country (e.g. an async profile fetch on the edit form). This runs
+  // only when `value` changes — deliberately NOT on `country` — so setting the
+  // country here can't re-trigger the effect. An empty value (set when the user
+  // switches country to clear the region) is ignored, so the country choice
+  // sticks.
+  //
+  // This was previously done by adjusting state during render. That caused an
+  // infinite "Maximum update depth exceeded" loop: LocationSelect re-rendered on
+  // every commit, which thrashed the child Base UI Select's layout effects (the
+  // setState surfaced from a layout-effect cleanup in <SelectTrigger>).
+  useEffect(() => {
+    if (value && countryForCode(value) !== country) {
+      setCountry(countryForCode(value));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value]);
 
   const regionMap = REGIONS_BY_COUNTRY[country];
   const regionNoun = country === "CA" ? "province/territory" : "state";
   const regionNounPlural =
     country === "CA" ? "provinces/territories" : "states";
-  const regions: Region[] = [
-    { label: `Select ${regionNoun}`, value: null },
-    ...Object.entries(regionMap).map(([value, label]) => ({ value, label })),
-  ];
+  // Items, the controlled `value`, and `onValueChange` all use a single shape —
+  // the region code string. The empty/unselected state is a null `value` (not a
+  // null item — Base UI reads `.value` on every item and a raw null throws), and
+  // its placeholder text lives on <ComboboxValue> below.
+  //
+  // `items` and `itemToStringLabel` MUST keep a stable identity across renders.
+  // Base UI's Combobox feeds them into memos that several layout effects depend
+  // on (syncSelectedIndex, etc.); a fresh array/function each render re-runs
+  // those effects, which call setState, which re-renders — an infinite
+  // "Maximum update depth exceeded" loop. `regionMap` is a module-level constant
+  // reference (stable per country), so keying the memos on it is safe.
+  const regionCodes = useMemo(() => Object.keys(regionMap), [regionMap]);
+  const labelForCode = useCallback(
+    (code: string) => regionMap[code] ?? "",
+    [regionMap],
+  );
 
-  // Root `value` must use the same shape as item values so Base UI can match.
   const selectedCode = value && value in regionMap ? value : null;
 
   return (
     <div className="flex w-full flex-col gap-2">
-      <Select
-        items={COUNTRIES}
-        value={country}
-        onValueChange={(next) => {
-          setCountry(next as Country);
-          // The previously selected region belongs to the old country; clear it.
-          onChange("");
-        }}
-      >
-        <SelectTrigger className="w-full justify-between font-normal">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectPopup>
-          {COUNTRIES.map((c) => (
-            <SelectItem key={c.value} value={c.value}>
-              {c.label}
-            </SelectItem>
-          ))}
-        </SelectPopup>
-      </Select>
+      {/*
+        The country Select gets its OWN Field.Root context. Parent forms wrap
+        this whole component in a Base UI <Field> (labelable context), which
+        expects a single control. With both the country Select and the region
+        Combobox registering against that one context, they fight over its
+        control id via useLabelableId — an infinite setControlId toggle
+        ("Maximum update depth exceeded"). Scoping the Select to its own field
+        leaves only the Combobox in the outer Field, so the "State" label still
+        associates with the actual region input.
+      */}
+      <FieldPrimitive.Root>
+        <Select
+          items={COUNTRIES}
+          value={country}
+          onValueChange={(next) => {
+            setCountry(next as Country);
+            // The previously selected region belongs to the old country; clear it.
+            onChange("");
+          }}
+        >
+          <SelectTrigger className="w-full justify-between font-normal">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectPopup>
+            {COUNTRIES.map((c) => (
+              <SelectItem key={c.value} value={c.value}>
+                {c.label}
+              </SelectItem>
+            ))}
+          </SelectPopup>
+        </Select>
+      </FieldPrimitive.Root>
 
       <Combobox
-        onValueChange={(v) => {
-          onChange((v as string) ?? "");
+        onValueChange={(code) => {
+          onChange(code ?? "");
         }}
         value={selectedCode}
-        items={regions}
-        isItemEqualToValue={locationItemEquals}
+        items={regionCodes}
+        itemToStringLabel={labelForCode}
         autoHighlight
       >
         <ComboboxTrigger
@@ -130,7 +146,11 @@ export default function LocationSelect({
             />
           }
         >
-          <ComboboxValue />
+          <ComboboxValue>
+            {(code: string | null) =>
+              code ? regionMap[code] : `Select ${regionNoun}`
+            }
+          </ComboboxValue>
           <ChevronsUpDownIcon className="-me-1!" />
         </ComboboxTrigger>
         <ComboboxPopup aria-label={`Select ${regionNoun}`}>
@@ -145,12 +165,9 @@ export default function LocationSelect({
           </div>
           <ComboboxEmpty>No {regionNounPlural} found.</ComboboxEmpty>
           <ComboboxList>
-            {(region: Region) => (
-              <ComboboxItem
-                key={region.value ?? "__placeholder__"}
-                value={region.value}
-              >
-                {region.label}
+            {(code: string) => (
+              <ComboboxItem key={code} value={code}>
+                {regionMap[code]}
               </ComboboxItem>
             )}
           </ComboboxList>


### PR DESCRIPTION
Two independent bug fixes.

## 1. Org dancers were receiving the S2S freemium/welcome email

**Symptom:** when an org sends "create your account" invites, the invited dancer also ends up getting the generic "Welcome to Studio2Stadium – Let's get you recruited!" email.

**Cause:** the org invite only creates the account + org membership — no dancer profile. The dancer still completes onboarding via the standard `create-dancer` endpoint, which unconditionally dispatched `DancerCreatedEvent → DancerWelcomeEmail`, gated only on `user.notifications` with **no org check**. (The `outbox → SQS → S2S main site` path is *not* involved — org registration never dispatches `SignupEvent`, and there's no DB trigger.)

**Fix:** `create-dancer/event.ts` now skips the welcome email for any user with an org membership. Org dancers are freemium; if they later pay for full S2S, the Stripe `SubscriptionCreatedEvent` already sends the premium welcome email. Adds `event.spec.ts` covering standalone-sent / org-skipped / notifications-off.

## 2. LocationSelect "Maximum update depth exceeded" loop

**Symptom:** selecting a state during account creation — or editing an existing profile's state — threw `Maximum update depth exceeded`.

**Cause:** parent forms wrap `LocationSelect` in a Base UI `<Field>`, whose labelable context expects a single control. `LocationSelect` rendered **two** controls (country `Select` + region `Combobox`); both called `useLabelableId` and fought over the field's `controlId`, toggling it forever. This appeared with the two-step country+region redesign.

**Fix:** scope the country `Select` into its own `Field.Root` so only the `Combobox` registers with the outer `<Field>` (label stays tied to the region input). Also normalizes the region items to a consistent string contract with `itemToStringLabel`, memoizes `items`/`itemToStringLabel` to avoid Base UI recompute churn, and syncs country via an effect.

**Verified** end-to-end in real Chrome: page loads with no crash; selecting a state persists with no loop; switching country to Canada updates the province list with no loop.

## Test plan
- Backend: `cd apps/backend && node ace test --files "app/modules/dancers/profile/create-dancer/event.spec.ts"` (needs the `s2s_test` DB)
- Frontend: `pnpm typecheck` + `pnpm lint` pass; manual: signup/onboarding/profile-edit state selection and country switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)