### PR TITLE
feat(dancer): always show Callbacks nav with empty state

### DIFF
--- a/apps/frontend/src/features/org/components/dancer-sidebar.tsx
+++ b/apps/frontend/src/features/org/components/dancer-sidebar.tsx
@@ -60,7 +60,7 @@ export function DancerSidebar() {
   const navigate = useNavigate();
   const qc = useQueryClient();
 
-  const { data: dancerCallbacks } = useQuery({
+  useQuery({
     ...scoutingQueries.dancerCallbacks(orgSlug),
     enabled: hasFeature("callbacks"),
   });
@@ -74,14 +74,11 @@ export function DancerSidebar() {
     },
   );
 
-  const hasCallbacks =
-    Array.isArray(dancerCallbacks) && dancerCallbacks.length > 0;
-
   const navSections: {
     title: string;
     items: { label: string; icon: any; to: string }[];
   }[] = [
-    ...(hasCallbacks
+    ...(hasFeature("callbacks")
       ? [
           {
             title: "Event",

--- a/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/dancer/callbacks.tsx
+++ b/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/dancer/callbacks.tsx
@@ -37,12 +37,9 @@ export const Route = createFileRoute(
     if (!eventId) {
       throw redirect({ to: "/o/$orgSlug/dancer", params });
     }
-    const data = await context.queryClient.ensureQueryData(
+    await context.queryClient.ensureQueryData(
       scoutingQueries.dancerCallbacks(params.orgSlug, eventId),
     );
-    if (!data || (Array.isArray(data) && data.length === 0)) {
-      throw redirect({ to: "/o/$orgSlug/dancer", params });
-    }
   },
   component: DancerCallbacksPage,
 });
@@ -85,8 +82,17 @@ function DancerCallbacksPage() {
           <MegaphoneIcon className="text-muted-foreground size-4 opacity-40" />
         </div>
 
-        <div className="divide-border divide-y">
-          {schools.map((cb) => (
+        {schools.length === 0 ? (
+          <div className="text-muted-foreground flex flex-col items-center justify-center gap-2 py-24">
+            <MegaphoneIcon className="size-8 opacity-40" />
+            <p className="text-sm">No callbacks yet</p>
+            <p className="text-xs opacity-60">
+              Schools that call you back will appear here.
+            </p>
+          </div>
+        ) : (
+          <div className="divide-border divide-y">
+            {schools.map((cb) => (
             <Link
               key={cb.coachRosterId}
               to="/o/$orgSlug/dancer/schools"
@@ -106,8 +112,9 @@ function DancerCallbacksPage() {
                 </p>
               </div>
             </Link>
-          ))}
-        </div>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

For org dancers in org events, the Callbacks feature was invisible until a school called them back:

- The **Callbacks nav button** in the dancer sidebar only appeared when `dancerCallbacks.length > 0`.
- The **callbacks page loader** redirected back to the dashboard on an empty result.

This made it look like the feature didn't exist for dancers who hadn't received any callbacks yet.

## Changes

1. **`dancer-sidebar.tsx`** — The Callbacks nav button now shows whenever the `callbacks` feature is enabled (`hasFeature("callbacks")`) instead of gating on callback count. Removed the now-unused `hasCallbacks` variable; the `useQuery` still runs so the transmit subscription keeps data live.
2. **`dancer/callbacks.tsx` loader** — Removed only the empty-array redirect. The **feature-flag** and **eventId** guards are intact.
3. **`DancerCallbacksPage`** — Added an empty state for `schools.length === 0`, reusing the existing admin-callbacks empty-state styling (centered Megaphone icon):
   - **No callbacks yet**
   - Schools that call you back will appear here.

Net effect: an org dancer always sees the Callbacks button, and opening it with zero callbacks shows the empty state rather than disappearing or redirecting.

## Testing

- `tsc --noEmit` passes.
- ESLint: no new errors introduced (baseline pre-existing `any` errors in `dancer-sidebar.tsx` unchanged, count identical before/after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUj52FzRGYnABP8mvTNjXt