### PR TITLE
fix(frontend): keep org logins inside the org instead of /feed

### DIFF
--- a/apps/frontend/src/features/org/lib/org-destination.spec.ts
+++ b/apps/frontend/src/features/org/lib/org-destination.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveOrgArea, resolveOrgDestination } from "./org-destination";
+
+const dancerRoster = { id: "r1", type: "dancer" };
+const coachRoster = { id: "r2", type: "coach" };
+
+describe("resolveOrgArea", () => {
+  it("sends org admins to the admin area", () => {
+    expect(
+      resolveOrgArea({ membership: { role: "admin", type: "coach" } }),
+    ).toBe("admin");
+  });
+
+  it("sends coaches to the coach area", () => {
+    expect(
+      resolveOrgArea({
+        membership: { role: "member", type: "coach" },
+        myRosters: [coachRoster],
+      }),
+    ).toBe("coach");
+  });
+
+  it("sends dancers to the dancer area", () => {
+    expect(
+      resolveOrgArea({
+        membership: { role: "member", type: "dancer" },
+        myRosters: [dancerRoster],
+      }),
+    ).toBe("dancer");
+  });
+
+  it("falls back to rosters when the user has no membership row", () => {
+    expect(resolveOrgArea({ myRosters: [dancerRoster] })).toBe("dancer");
+    expect(resolveOrgArea({ myRosters: [coachRoster] })).toBe("coach");
+  });
+
+  it("reports no access when the user is on no roster", () => {
+    expect(resolveOrgArea({ membership: null, myRosters: [] })).toBe(
+      "no-access",
+    );
+    expect(resolveOrgArea(null)).toBe("no-access");
+    expect(
+      resolveOrgArea({
+        membership: { role: "member", type: "dancer" },
+        myRosters: [],
+      }),
+    ).toBe("no-access");
+  });
+});
+
+describe("resolveOrgDestination", () => {
+  it("keeps signed-in users inside their org instead of the s2s feed", () => {
+    expect(
+      resolveOrgDestination("hoosier", { myRosters: [dancerRoster] }),
+    ).toBe("/o/hoosier/dancer");
+    expect(resolveOrgDestination("hoosier", null)).toBe("/o/hoosier/no-access");
+  });
+});

--- a/apps/frontend/src/features/org/lib/org-destination.ts
+++ b/apps/frontend/src/features/org/lib/org-destination.ts
@@ -1,0 +1,54 @@
+export interface OrgAccess {
+  membership?: { role: string; type: string } | null;
+  myRoster?: { id: string } | null;
+  myRosters?: Array<{ id: string; type: string }>;
+}
+
+export type OrgArea = "admin" | "coach" | "dancer" | "no-access";
+
+const hasRoster = (access: OrgAccess | null | undefined, type: string) =>
+  access?.myRosters?.some((roster) => roster.type === type) ?? false;
+
+/**
+ * Where a member of this org belongs once they are signed in. Membership is the
+ * source of truth when it exists, but users can be put on an event roster
+ * without a membership row, so rosters act as the fallback signal.
+ */
+export function resolveOrgArea(access: OrgAccess | null | undefined): OrgArea {
+  const role = access?.membership?.role;
+  const type = access?.membership?.type;
+
+  if (role === "admin") return "admin";
+  if (type === "coach") {
+    return hasRoster(access, "coach") || access?.myRoster
+      ? "coach"
+      : "no-access";
+  }
+  if (type === "dancer") {
+    return hasRoster(access, "dancer") ? "dancer" : "no-access";
+  }
+
+  if (hasRoster(access, "coach")) return "coach";
+  if (hasRoster(access, "dancer")) return "dancer";
+  return "no-access";
+}
+
+export function orgAreaPath(orgSlug: string, area: OrgArea): string {
+  return `/o/${orgSlug}/${area}`;
+}
+
+/** Landing route for a signed-in user inside a given org. */
+export function resolveOrgDestination(
+  orgSlug: string,
+  access: OrgAccess | null | undefined,
+): string {
+  return orgAreaPath(orgSlug, resolveOrgArea(access));
+}
+
+/** Typed route paths for each org area, keyed by area. */
+export const ORG_AREA_ROUTES = {
+  admin: "/o/$orgSlug/admin",
+  coach: "/o/$orgSlug/coach",
+  dancer: "/o/$orgSlug/dancer",
+  "no-access": "/o/$orgSlug/no-access",
+} as const;

--- a/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/admin/route.tsx
+++ b/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/admin/route.tsx
@@ -15,6 +15,11 @@ import { useAdminEvent } from "@/features/org/context/use-admin-event";
 import { AdminCommandsProvider } from "@/features/org/hooks/use-admin-commands";
 import { orgQueries } from "@/features/org/api/queries";
 import { queries } from "@/lib/session";
+import {
+  ORG_AREA_ROUTES,
+  resolveOrgArea,
+  type OrgAccess,
+} from "@/features/org/lib/org-destination";
 
 export const Route = createFileRoute("/_org/o/$orgSlug/_authenticated/admin")({
   beforeLoad: async ({ context, params }) => {
@@ -25,10 +30,13 @@ export const Route = createFileRoute("/_org/o/$orgSlug/_authenticated/admin")({
 
     const data = (await context.queryClient.ensureQueryData(
       orgQueries.org(params.orgSlug),
-    )) as { membership?: { role: string; type: string } | null } | null;
-    const role = data?.membership?.role;
-    if (role !== "admin") {
-      throw redirect({ to: "/" });
+    )) as OrgAccess | null;
+    const area = resolveOrgArea(data);
+    if (area !== "admin") {
+      throw redirect({
+        to: ORG_AREA_ROUTES[area],
+        params: { orgSlug: params.orgSlug },
+      });
     }
   },
   component: AdminLayout,

--- a/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/coach/route.tsx
+++ b/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/coach/route.tsx
@@ -9,6 +9,11 @@ import { CoachSidebar } from "@/features/org/components/coach-sidebar";
 import { PreviewModeBanner } from "@/features/org/components/preview-mode-banner";
 import { orgQueries } from "@/features/org/api/queries";
 import { queries } from "@/lib/session";
+import {
+  ORG_AREA_ROUTES,
+  resolveOrgArea,
+  type OrgAccess,
+} from "@/features/org/lib/org-destination";
 
 export const Route = createFileRoute("/_org/o/$orgSlug/_authenticated/coach")({
   beforeLoad: async ({ context, params }) => {
@@ -22,18 +27,11 @@ export const Route = createFileRoute("/_org/o/$orgSlug/_authenticated/coach")({
     ) ??
       (await context.queryClient.ensureQueryData(
         orgQueries.org(params.orgSlug),
-      ))) as {
-      membership?: { role: string; type: string } | null;
-      myRoster?: { id: string } | null;
-    } | null;
-    const role = data?.membership?.role;
-    const type = data?.membership?.type;
-    if (role !== "admin" && type !== "coach") {
-      throw redirect({ to: "/" });
-    }
-    if (role !== "admin" && !data?.myRoster) {
+      ))) as OrgAccess | null;
+    const area = resolveOrgArea(data);
+    if (area !== "coach") {
       throw redirect({
-        to: "/o/$orgSlug/no-access",
+        to: ORG_AREA_ROUTES[area],
         params: { orgSlug: params.orgSlug },
       });
     }

--- a/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/dancer/route.tsx
+++ b/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/dancer/route.tsx
@@ -9,6 +9,11 @@ import { DancerSidebar } from "@/features/org/components/dancer-sidebar";
 import { PreviewModeBanner } from "@/features/org/components/preview-mode-banner";
 import { orgQueries } from "@/features/org/api/queries";
 import { queries } from "@/lib/session";
+import {
+  ORG_AREA_ROUTES,
+  resolveOrgArea,
+  type OrgAccess,
+} from "@/features/org/lib/org-destination";
 
 export const Route = createFileRoute("/_org/o/$orgSlug/_authenticated/dancer")({
   beforeLoad: async ({ context, params }) => {
@@ -22,21 +27,11 @@ export const Route = createFileRoute("/_org/o/$orgSlug/_authenticated/dancer")({
     ) ??
       (await context.queryClient.ensureQueryData(
         orgQueries.org(params.orgSlug),
-      ))) as {
-      membership?: { role: string; type: string } | null;
-      myRosters?: Array<{ id: string; type: string }>;
-    } | null;
-    const role = data?.membership?.role;
-    const type = data?.membership?.type;
-    if (role !== "admin" && role !== "owner" && type !== "dancer") {
-      throw redirect({ to: "/" });
-    }
-    const hasDancerRoster = data?.myRosters?.some(
-      (roster) => roster.type === "dancer",
-    );
-    if (role !== "admin" && !hasDancerRoster) {
+      ))) as OrgAccess | null;
+    const area = resolveOrgArea(data);
+    if (area !== "dancer") {
       throw redirect({
-        to: "/o/$orgSlug/no-access",
+        to: ORG_AREA_ROUTES[area],
         params: { orgSlug: params.orgSlug },
       });
     }

--- a/apps/frontend/src/routes/_org/o/$orgSlug/login.tsx
+++ b/apps/frontend/src/routes/_org/o/$orgSlug/login.tsx
@@ -3,6 +3,10 @@ import { OrgAuthLayout } from "@/features/org/components/org-auth-layout";
 import { OrgLoginForm } from "@/features/org/components/org-login-form";
 import { orgQueries } from "@/features/org/api/queries";
 import { isReservedOrgSlug } from "@/features/org/lib/reserved-slugs";
+import {
+  resolveOrgDestination,
+  type OrgAccess,
+} from "@/features/org/lib/org-destination";
 import { useQueryClient } from "@tanstack/react-query";
 import { z } from "zod";
 
@@ -31,19 +35,11 @@ function OrgLoginPage() {
       <OrgLoginForm
         onSuccess={async () => {
           queryClient.clear();
-          const org = await queryClient.fetchQuery(orgQueries.org(orgSlug));
-          const membership = (org as { membership?: { role: string; type: string } | null }).membership;
+          const org = (await queryClient.fetchQuery(
+            orgQueries.org(orgSlug),
+          )) as OrgAccess;
 
-          let destination: string;
-          if (redirect) {
-            destination = redirect;
-          } else if (membership?.role === "admin") {
-            destination = `/o/${orgSlug}/admin`;
-          } else if (membership?.type === "coach") {
-            destination = `/o/${orgSlug}/coach`;
-          } else {
-            destination = `/o/${orgSlug}/dancer`;
-          }
+          const destination = redirect ?? resolveOrgDestination(orgSlug, org);
 
           navigate({ to: destination, replace: true });
         }}


### PR DESCRIPTION
## Problem

Signing in on `/o/$orgSlug/login` could land the user on `/feed` instead of the org's event.

The login page derived its destination only from the `orgMemberships` row. A user who is on an event roster **without** a membership row got `membership: null`, fell through to `/o/$slug/dancer`, and the dancer route guard rejected them with `throw redirect({ to: "/" })` — and `/` redirects to `/feed`. The coach and admin guards had the same escape hatch out of the org.

## Fix

- New `features/org/lib/org-destination.ts` — `resolveOrgArea()` picks admin → coach → dancer from membership, falls back to event rosters when there is no membership row, and returns `no-access` when the user is on no roster.
- `/o/$orgSlug/login` uses `resolveOrgDestination()`; an explicit `?redirect=` still wins.
- The dancer/coach/admin guards now redirect a rejected user to the org area they *do* belong to, or `/o/$orgSlug/no-access` — never out of the org.
- `/login` is untouched: it still defaults to `/feed` (or `/onboarding`).

## Verification

- `tsc -b` clean
- `eslint` clean on the changed files (pre-existing errors elsewhere untouched)
- `vitest run` — 15/15 passing, including 6 new specs for `resolveOrgArea` / `resolveOrgDestination`

Not exercised in a browser: the roster-without-membership path needs real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)