### PR TITLE
fix(backend): grant org tier when a roster links a pre-existing account

### DIFF
--- a/apps/backend/app/modules/orgs/events/rosters/attach/service.ts
+++ b/apps/backend/app/modules/orgs/events/rosters/attach/service.ts
@@ -1,9 +1,6 @@
 // apps/backend/app/modules/orgs/events/rosters/attach/service.ts
 import { DatabaseService } from "#database/service";
-import {
-  dancerInvites,
-  orgMemberships,
-} from "#database/schema/organizations";
+import { dancerInvites, orgMemberships } from "#database/schema/organizations";
 import {
   eventDancerProfiles,
   eventRosters,
@@ -11,6 +8,7 @@ import {
 } from "#database/schema/org-events";
 import { users } from "#database/schema/users";
 import { dancerProfiles } from "#database/schema/dancers";
+import { grantOrgAccountTier } from "#shared/org/grant-account-tier";
 import { inject } from "@adonisjs/core";
 import { and, eq, isNull, ne, sql } from "drizzle-orm";
 
@@ -147,6 +145,8 @@ export class AttachAccountService {
         .where(eq(orgEvents.id, eventId))
         .limit(1);
 
+      let tierGranted: "standard" | null = null;
+
       if (event?.orgId) {
         const orgId = event.orgId;
 
@@ -162,6 +162,16 @@ export class AttachAccountService {
           .onConflictDoNothing({
             target: [orgMemberships.userId, orgMemberships.orgId],
           });
+
+        // The account existed before this link, so it never went through the
+        // invite flow that assigns a tier. Grant what the roster entitles it to,
+        // otherwise a paid dancer is stuck on the plain free tier and cannot add
+        // any video at all. Runs after the roster update above so the row this
+        // reads already carries `userId`.
+        tierGranted = await grantOrgAccountTier(tx, {
+          userId: targetUserId,
+          orgId,
+        });
 
         // Consume pending dancer invites for the old email
         await tx
@@ -185,6 +195,7 @@ export class AttachAccountService {
           targetUserId,
           previousEmail: oldEmail,
           newEmail: targetUser.email,
+          tierGranted,
         },
       });
 

--- a/apps/backend/app/modules/orgs/events/rosters/set-paid/service.ts
+++ b/apps/backend/app/modules/orgs/events/rosters/set-paid/service.ts
@@ -1,7 +1,8 @@
 import { DatabaseService } from "#database/service";
 import { inject } from "@adonisjs/core";
-import { eventRosters } from "#database/schema/org-events";
+import { eventRosters, orgEvents } from "#database/schema/org-events";
 import { users } from "#database/schema/users";
+import { grantOrgAccountTier } from "#shared/org/grant-account-tier";
 import { and, eq } from "drizzle-orm";
 import type { AuditContext } from "#database/audit";
 
@@ -62,13 +63,26 @@ export class SetRosterPaidService {
         const userId = row.userId;
 
         if (paid) {
-          // Bump limited → standard (leave null accounts untouched)
+          // Bump limited → standard
           await tx
             .update(users)
             .set({ orgAccountTier: "standard" })
             .where(
               and(eq(users.id, userId), eq(users.orgAccountTier, "limited"))
             );
+
+          // A null-tier account is one that existed before it was linked to this
+          // roster, so it never received a tier. Now that it is marked paid it is
+          // entitled to one; without this it stays on the plain free tier, which
+          // cannot add video at all.
+          const [event] = await tx
+            .select({ orgId: orgEvents.orgId })
+            .from(orgEvents)
+            .where(eq(orgEvents.id, eventId))
+            .limit(1);
+          if (event?.orgId) {
+            await grantOrgAccountTier(tx, { userId, orgId: event.orgId });
+          }
         } else {
           // Downgrade standard → limited (leave null accounts untouched)
           await tx

--- a/apps/backend/app/modules/orgs/events/upload-dancers/service.spec.ts
+++ b/apps/backend/app/modules/orgs/events/upload-dancers/service.spec.ts
@@ -108,14 +108,15 @@ dancer1@x.co,Dancer,One,101`;
     assert.equal(result.rowsAdded, 1);
     assert.equal(result.rowsErrored, 0);
 
-    // Roster row has userId set; expirationDate is null (no grant window)
+    // Roster row has userId set, and a matched dancer gets the tier window
+    // dated from the event end (2026-06-14) plus the default 3 months.
     const [roster] = await db
       .select()
       .from(eventRosters)
       .where(eq(eventRosters.email, "dancer1@x.co"));
     assert.equal(roster!.userId, dancer.id);
     assert.isNotNull(roster!.userId);
-    assert.isNull(roster!.expirationDate);
+    assert.equal(roster!.expirationDate, "2026-09-14");
 
     // No premium grant created
     const grants = await db
@@ -130,6 +131,100 @@ dancer1@x.co,Dancer,One,101`;
       .from(orgMemberships)
       .where(eq(orgMemberships.userId, dancer.id));
     assert.equal(mem!.type, "dancer");
+  });
+
+  test("matched dancer with a pre-existing account gets an org tier", async ({
+    assert,
+  }) => {
+    // Regression: a dancer who already had an S2S account never goes through
+    // the invite flow that assigns a tier, so she used to be left on NULL —
+    // the plain free tier, which cannot add any video at all, not even YouTube.
+    const dancer = await createUser({
+      username: "preexisting",
+      email: "preexisting@x.co",
+    });
+
+    const svc = new UploadDancersService();
+    await svc.execute({
+      orgId: summit.id,
+      eventId: event.id,
+      uploaderId: uploader.id,
+      fileUrl: "test://dancers.csv",
+      csv: `email,firstName,lastName,bibNumber
+preexisting@x.co,Pre,Existing,201`,
+    });
+
+    const [u] = await db
+      .select({
+        tier: users.orgAccountTier,
+        expiresAt: users.orgAccountTierExpiresAt,
+      })
+      .from(users)
+      .where(eq(users.id, dancer.id));
+    assert.equal(u!.tier, "standard");
+    assert.equal(u!.expiresAt!.toISOString().split("T")[0], "2026-09-14");
+  });
+
+  test("free-tier org grants a tier to paid dancers only", async ({
+    assert,
+  }) => {
+    const [freeOrg] = await db
+      .insert(organizations)
+      .values({
+        slug: "freetier",
+        name: "Free Tier Org",
+        features: { freeTierUsers: true },
+        settings: {},
+      })
+      .returning();
+    const [freeEvent] = await db
+      .insert(orgEvents)
+      .values({
+        orgId: freeOrg!.id,
+        name: "Free Tier Event",
+        startDate: "2026-08-22",
+        endDate: "2026-08-23",
+        isActive: true,
+      })
+      .returning();
+
+    const paid = await createUser({ username: "paid", email: "paid@x.co" });
+    const unpaid = await createUser({
+      username: "unpaid",
+      email: "unpaid@x.co",
+    });
+
+    const svc = new UploadDancersService();
+    await svc.execute({
+      orgId: freeOrg!.id,
+      eventId: freeEvent!.id,
+      uploaderId: uploader.id,
+      fileUrl: "test://dancers.csv",
+      csv: `email,firstName,lastName,bibNumber,paid
+paid@x.co,Paid,Dancer,301,yes
+unpaid@x.co,Unpaid,Dancer,302,no`,
+    });
+
+    const [paidUser] = await db
+      .select({
+        tier: users.orgAccountTier,
+        expiresAt: users.orgAccountTierExpiresAt,
+      })
+      .from(users)
+      .where(eq(users.id, paid.id));
+    assert.equal(paidUser!.tier, "standard");
+    assert.equal(
+      paidUser!.expiresAt!.toISOString().split("T")[0],
+      "2026-11-23"
+    );
+
+    // Unpaid stays null rather than being pushed down to 'limited', which
+    // would revoke the photo upload a plain free account already has.
+    const [unpaidUser] = await db
+      .select({ tier: users.orgAccountTier })
+      .from(users)
+      .where(eq(users.id, unpaid.id));
+    assert.isNull(unpaidUser!.tier);
   });
 
   test("unmatched dancer gets dancer_invite token", async ({ assert }) => {

--- a/apps/backend/app/modules/orgs/events/upload-dancers/service.ts
+++ b/apps/backend/app/modules/orgs/events/upload-dancers/service.ts
@@ -22,6 +22,7 @@ import {
   type EmailSendTask,
 } from "#shared/org/throttled-email-sender";
 import { enforceEmailRole } from "#shared/org/role-guard";
+import { grantOrgAccountTier } from "#shared/org/grant-account-tier";
 import { verifyPreviewToken } from "#shared/org/preview-token";
 import { and, eq, inArray } from "drizzle-orm";
 import logger from "@adonisjs/core/services/logger";
@@ -280,6 +281,12 @@ export class UploadDancersService {
                 .onConflictDoNothing({
                   target: [orgMemberships.userId, orgMemberships.orgId],
                 });
+
+              // Matched dancers already had an account, so they never got a tier
+              // from the invite flow. Grant what their roster entitles them to —
+              // without this a paid dancer sits on the plain free tier and the
+              // video dialog tells her to buy premium she has already paid for.
+              await grantOrgAccountTier(tx, { userId, orgId });
             } else {
               // Create dancer invite for unmatched rows
               const inviteExpiry = new Date(

--- a/apps/backend/app/shared/org/grant-account-tier.spec.ts
+++ b/apps/backend/app/shared/org/grant-account-tier.spec.ts
@@ -1,0 +1,218 @@
+import { test } from "@japa/runner";
+import { db } from "#database/connection";
+import { users } from "#database/schema/users";
+import { dancerProfiles } from "#database/schema/dancers";
+import {
+  organizations,
+  orgMemberships,
+  premiumGrants,
+  dancerInvites,
+} from "#database/schema/organizations";
+import {
+  orgEvents,
+  eventRosters,
+  csvUploads,
+} from "#database/schema/org-events";
+import { eq } from "drizzle-orm";
+import { grantOrgAccountTier } from "./grant-account-tier.ts";
+
+async function createDancer(email: string) {
+  const [u] = await db
+    .insert(users)
+    .values({
+      username: email.split("@")[0]!,
+      email,
+      displayEmail: email,
+      firstName: "Test",
+      lastName: "Dancer",
+      password: "x",
+      role: "user",
+      type: "dancer",
+      verified: true,
+    })
+    .returning();
+  await db.insert(dancerProfiles).values({
+    userId: u!.id,
+    birthday: "2000-01-01",
+    location: "Anywhere",
+  });
+  return u!;
+}
+
+async function createOrg(slug: string, freeTier: boolean, months?: number) {
+  const [org] = await db
+    .insert(organizations)
+    .values({
+      slug,
+      name: slug,
+      features: freeTier ? { freeTierUsers: true } : {},
+      settings: months ? { tierExpiryMonths: months } : {},
+    })
+    .returning();
+  return org!;
+}
+
+// Only one event per org may be active at a time, so callers creating a second
+// event mark the earlier one inactive — which is the real shape anyway: a past
+// competition is closed by the time the next one opens.
+async function createEvent(orgId: string, endDate: string, isActive = true) {
+  const [ev] = await db
+    .insert(orgEvents)
+    .values({
+      orgId,
+      name: "Event",
+      startDate: endDate,
+      endDate,
+      isActive,
+    })
+    .returning();
+  return ev!;
+}
+
+async function addRoster(
+  eventId: string,
+  userId: string | null,
+  email: string,
+  paid: boolean | null
+) {
+  await db.insert(eventRosters).values({
+    eventId,
+    userId,
+    type: "dancer",
+    email,
+    firstName: "Test",
+    lastName: "Dancer",
+    paid,
+  });
+}
+
+function grant(userId: string, orgId: string) {
+  return db.transaction((tx) => grantOrgAccountTier(tx, { userId, orgId }));
+}
+
+async function tierOf(userId: string) {
+  const [u] = await db
+    .select({
+      tier: users.orgAccountTier,
+      expiresAt: users.orgAccountTierExpiresAt,
+    })
+    .from(users)
+    .where(eq(users.id, userId));
+  return u!;
+}
+
+test.group("grantOrgAccountTier", (group) => {
+  group.each.setup(async () => {
+    await db.delete(premiumGrants).execute();
+    await db.delete(dancerInvites).execute();
+    await db.delete(csvUploads).execute();
+    await db.delete(eventRosters).execute();
+    await db.delete(orgEvents).execute();
+    await db.delete(orgMemberships).execute();
+    await db.delete(dancerProfiles).execute();
+    await db.delete(users).execute();
+    await db.delete(organizations).execute();
+  });
+
+  test("grants standard to a paid dancer in a free-tier org", async ({
+    assert,
+  }) => {
+    const org = await createOrg("freeorg", true);
+    const event = await createEvent(org.id, "2026-08-23");
+    const dancer = await createDancer("paid@x.co");
+    await addRoster(event.id, dancer.id, "paid@x.co", true);
+
+    const result = await grant(dancer.id, org.id);
+
+    assert.equal(result, "standard");
+    const { tier, expiresAt } = await tierOf(dancer.id);
+    assert.equal(tier, "standard");
+    // Event end + the default 3 month window.
+    assert.equal(expiresAt!.toISOString().split("T")[0], "2026-11-23");
+  });
+
+  test("leaves an unpaid dancer in a free-tier org on null", async ({
+    assert,
+  }) => {
+    const org = await createOrg("freeorg", true);
+    const event = await createEvent(org.id, "2026-08-23");
+    const dancer = await createDancer("unpaid@x.co");
+    await addRoster(event.id, dancer.id, "unpaid@x.co", false);
+
+    const result = await grant(dancer.id, org.id);
+
+    assert.isNull(result);
+    // Not downgraded to 'limited': that would revoke the photo upload a plain
+    // free account already has.
+    const after = await tierOf(dancer.id);
+    assert.isNull(after.tier);
+  });
+
+  test("grants standard in a non-free-tier org regardless of paid", async ({
+    assert,
+  }) => {
+    const org = await createOrg("paidorg", false);
+    const event = await createEvent(org.id, "2026-06-14");
+    const dancer = await createDancer("any@x.co");
+    await addRoster(event.id, dancer.id, "any@x.co", false);
+
+    assert.equal(await grant(dancer.id, org.id), "standard");
+    const after = await tierOf(dancer.id);
+    assert.equal(after.tier, "standard");
+  });
+
+  test("never overwrites a tier the account already has", async ({
+    assert,
+  }) => {
+    const org = await createOrg("freeorg", true);
+    const event = await createEvent(org.id, "2026-08-23");
+    const dancer = await createDancer("limited@x.co");
+    await addRoster(event.id, dancer.id, "limited@x.co", true);
+    await db
+      .update(users)
+      .set({ orgAccountTier: "limited" })
+      .where(eq(users.id, dancer.id));
+
+    assert.isNull(await grant(dancer.id, org.id));
+    const after = await tierOf(dancer.id);
+    assert.equal(after.tier, "limited");
+  });
+
+  test("dates the tier from the latest event the dancer is rostered on", async ({
+    assert,
+  }) => {
+    const org = await createOrg("freeorg", true);
+    const early = await createEvent(org.id, "2026-05-10", false);
+    const late = await createEvent(org.id, "2026-08-23");
+    const dancer = await createDancer("multi@x.co");
+    await addRoster(early.id, dancer.id, "multi@x.co", false);
+    await addRoster(late.id, dancer.id, "multi@x.co", true);
+
+    assert.equal(await grant(dancer.id, org.id), "standard");
+    const { expiresAt } = await tierOf(dancer.id);
+    assert.equal(expiresAt!.toISOString().split("T")[0], "2026-11-23");
+  });
+
+  test("honours a custom tierExpiryMonths setting", async ({ assert }) => {
+    const org = await createOrg("freeorg", true, 6);
+    const event = await createEvent(org.id, "2026-08-23");
+    const dancer = await createDancer("custom@x.co");
+    await addRoster(event.id, dancer.id, "custom@x.co", true);
+
+    await grant(dancer.id, org.id);
+    const { expiresAt } = await tierOf(dancer.id);
+    assert.equal(expiresAt!.toISOString().split("T")[0], "2027-02-23");
+  });
+
+  test("does nothing when the user holds no roster row in the org", async ({
+    assert,
+  }) => {
+    const org = await createOrg("freeorg", true);
+    await createEvent(org.id, "2026-08-23");
+    const dancer = await createDancer("stranger@x.co");
+
+    assert.isNull(await grant(dancer.id, org.id));
+    const after = await tierOf(dancer.id);
+    assert.isNull(after.tier);
+  });
+});

--- a/apps/backend/app/shared/org/grant-account-tier.ts
+++ b/apps/backend/app/shared/org/grant-account-tier.ts
@@ -1,0 +1,93 @@
+import type { Transaction } from "#database/service";
+import { users } from "#database/schema/users";
+import { organizations } from "#database/schema/organizations";
+import { eventRosters, orgEvents } from "#database/schema/org-events";
+import { and, eq, isNull } from "drizzle-orm";
+
+/**
+ * Gives a pre-existing account the org tier its roster entitles it to.
+ *
+ * `RegisterDancerService` assigns a tier when it *creates* an account from an
+ * invite. A dancer who already had an S2S account — or who made one outside the
+ * invite link — instead gets joined to a roster row by the CSV upload or the
+ * attach flow, and those paths used to leave `org_account_tier` NULL.
+ *
+ * NULL is the plain free tier: no direct video, *no YouTube video*, 4 photos.
+ * So a paid dancer who happened to already have an account ended up with
+ * strictly less access than the unpaid 'limited' dancers beside her on the same
+ * roster, and the video dialog told her to buy premium she had already paid for.
+ *
+ * This only ever grants. It never downgrades: an account that already carries a
+ * tier is left untouched, and an unpaid dancer in a free-tier org keeps NULL
+ * rather than being pushed to 'limited' (which would revoke the photo upload
+ * she currently has).
+ *
+ * Returns the tier granted, or null when nothing changed.
+ */
+export async function grantOrgAccountTier(
+  tx: Transaction,
+  { userId, orgId }: { userId: string; orgId: string }
+): Promise<"standard" | null> {
+  const [user] = await tx
+    .select({ tier: users.orgAccountTier })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+
+  // Already tiered (org-provisioned, or reconciled by an earlier link).
+  if (!user || user.tier !== null) return null;
+
+  const [org] = await tx
+    .select({
+      features: organizations.features,
+      settings: organizations.settings,
+    })
+    .from(organizations)
+    .where(eq(organizations.id, orgId))
+    .limit(1);
+  if (!org) return null;
+
+  const orgFeatures =
+    (org.features as Record<string, unknown> | undefined) ?? {};
+  const orgSettings =
+    (org.settings as Record<string, unknown> | undefined) ?? {};
+  const freeTier = Boolean(orgFeatures.freeTierUsers);
+  const tierExpiryMonths =
+    Number(orgSettings.tierExpiryMonths ?? orgFeatures.tierExpiryMonths) || 3;
+
+  // Every dancer roster row this user holds in this org. A dancer can appear on
+  // several events of a recurring competition; paid on any one of them counts,
+  // and the tier runs from the latest event.
+  const rosterRows = await tx
+    .select({ paid: eventRosters.paid, endDate: orgEvents.endDate })
+    .from(eventRosters)
+    .innerJoin(orgEvents, eq(orgEvents.id, eventRosters.eventId))
+    .where(
+      and(
+        eq(eventRosters.type, "dancer"),
+        eq(eventRosters.userId, userId),
+        eq(orgEvents.orgId, orgId)
+      )
+    );
+
+  if (rosterRows.length === 0) return null;
+
+  // Free-tier orgs sell the upgrade themselves: unpaid dancers are not
+  // entitled to 'standard', and we leave them NULL rather than downgrading.
+  if (freeTier && !rosterRows.some((r) => r.paid === true)) return null;
+
+  const latestEnd = rosterRows
+    .map((r) => r.endDate)
+    .reduce((a, b) => (a > b ? a : b));
+
+  const expiresAt = new Date(latestEnd);
+  expiresAt.setMonth(expiresAt.getMonth() + tierExpiryMonths);
+
+  const updated = await tx
+    .update(users)
+    .set({ orgAccountTier: "standard", orgAccountTierExpiresAt: expiresAt })
+    .where(and(eq(users.id, userId), isNull(users.orgAccountTier)))
+    .returning({ id: users.id });
+
+  return updated.length > 0 ? "standard" : null;
+}


### PR DESCRIPTION
## The bug

A dancer who already had an S2S account never goes through the invite flow that assigns `org_account_tier`. The CSV upload and attach paths link her roster row but left the tier `NULL`.

`NULL` is the plain free tier — **no direct video, no YouTube video, 4 photos**. That is strictly *less* access than the `limited` dancers standing beside her on the same roster, and a dancer who had paid her convention registration was shown "Direct video uploads require a premium subscription" for premium she had already paid for.

This surfaced as a support ticket: a Prodigy dancer redeemed her invite under a parent's email, created a second account under her own three minutes later, and the coach linked the roster to the second one. The entitlement stayed stranded on the abandoned first account.

## The fix

Adds `grantOrgAccountTier`, called from the three paths that can link a pre-existing account:

- `upload-dancers` — matches by email on CSV upload (the path that caused the ticket)
- `rosters/attach` — the coach-facing "attach to account" action
- `rosters/set-paid` — previously bumped `limited → standard` only, ignoring `NULL`

It mirrors `RegisterDancerService`'s existing computation (org `freeTierUsers` + roster `paid`, expiry from latest event end + `tierExpiryMonths`), keyed on `userId` rather than email.

**It only ever grants.** It skips accounts that already carry a tier, and leaves unpaid free-tier dancers on `NULL` rather than downgrading them to `limited` — a downgrade would revoke the photo upload those accounts have today.

No product rules changed: `standard` remains YouTube-only, direct file upload still requires Stripe/grant/admin.

## Verification

| | Tests | Passed | Failed |
|---|---|---|---|
| Clean `main` | 209 | 196 | 13 |
| This branch | 218 | 206 | **12** |

+9 tests, one fewer failure. `tsc --noEmit` clean; `eslint` clean on every file touched.

The removed failure was a stale assertion in the upload-dancers spec expecting a matched dancer's roster `expirationDate` to be null — the service has set it since the freemium work landed, so that test was red on `main`. It sits in the code path this PR changes, so it is corrected here.

> [!NOTE]
> `main` carries 12 other test failures and 129 lint errors that predate this branch. They are untouched.

## Production data

Already reconciled directly against prod, so this PR is the forward fix only:

- The reported dancer restored to `standard` / 2026-11-23 (matching what her abandoned account already held).
- 9 further users with a paid, linked roster row and `NULL` tier backfilled, expiry derived per-user from their event. Verified 0 remaining in that state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
