### PR TITLE
chore(frontend): remove share button from dancer profile

### DIFF
--- a/apps/frontend/src/features/dancer/components/profile/hero/hero-background.tsx
+++ b/apps/frontend/src/features/dancer/components/profile/hero/hero-background.tsx
@@ -1,10 +1,4 @@
-import { Button } from "@/components/ui/button";
-import { Share2Icon } from "lucide-react";
-import { useProfile } from "../context/use-profile";
-
 export function HeroBackground() {
-  const { showOwnerControls } = useProfile();
-
   return (
     <div className="relative isolate transform-gpu overflow-clip sm:border-b">
       <img
@@ -13,16 +7,6 @@ export function HeroBackground() {
         className="hidden h-32 w-full scale-105 rounded-2xl object-cover blur-sm sm:block sm:h-48"
       />
       <div className="pointer-events-none absolute inset-0 bg-linear-to-b from-black/70 via-black/20 to-transparent" />
-
-      {showOwnerControls ? (
-        <Button
-          className="absolute top-3 right-3 flex items-center gap-2 text-white"
-          size="xs"
-          variant="ghost"
-        >
-          <Share2Icon /> Share
-        </Button>
-      ) : null}
     </div>
   );
 }

--- a/apps/frontend/src/features/dancer/components/profile/hero/hero-footer.tsx
+++ b/apps/frontend/src/features/dancer/components/profile/hero/hero-footer.tsx
@@ -3,7 +3,7 @@ import { dancerQueries } from "@/features/dancer/api/queries";
 import { queries } from "@/shared/engagement/api/queries";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { EyeIcon, EyeOffIcon, Share2Icon } from "lucide-react";
+import { EyeIcon, EyeOffIcon } from "lucide-react";
 import { DancerFollowersDialog } from "../../followers-dialog";
 import { DancerFollowingDialog } from "../../following-dialog";
 import { useProfile } from "../context/use-profile";
@@ -30,29 +30,22 @@ export function HeroFooter({ dancerId }: { dancerId: string }) {
     <div className="flex w-full flex-wrap items-center justify-between gap-2">
       <div className="flex items-center gap-2 max-sm:w-full">
         {isOwner && (
-          <>
-            {!isPreview && (
-              <Button size="sm" className="flex-1 sm:hidden">
-                <Share2Icon className="size-4" /> Share
-              </Button>
+          <Button
+            size="sm"
+            variant={isPreview ? "destructive-outline" : "outline"}
+            className="flex-1"
+            onClick={handlePreview}
+          >
+            {isPreview ? (
+              <>
+                <EyeOffIcon className="size-4" /> End Preview
+              </>
+            ) : (
+              <>
+                <EyeIcon className="size-4" /> Preview
+              </>
             )}
-            <Button
-              size="sm"
-              variant={isPreview ? "destructive-outline" : "outline"}
-              className="flex-1"
-              onClick={handlePreview}
-            >
-              {isPreview ? (
-                <>
-                  <EyeOffIcon className="size-4" /> End Preview
-                </>
-              ) : (
-                <>
-                  <EyeIcon className="size-4" /> Preview
-                </>
-              )}
-            </Button>
-          </>
+          </Button>
         )}
 
         {!isOwner ? <FavoriteButton dancerId={dancerId} /> : null}


### PR DESCRIPTION
Removes the Share button from the dancer profile.

## What was there

Two of them, both on the profile hero:

- **Desktop** — `hero-background.tsx`, top-right overlay, rendered when `showOwnerControls`
- **Mobile** — `hero-footer.tsx`, `sm:hidden`, rendered when `isOwner && !isPreview`

Neither had an `onClick`. They rendered a `Button` with an icon and a label and did nothing when pressed — no `navigator.share`, no copy-link, no handler of any kind.

## Changes

`HeroBackground` no longer consumes profile context at all — with the button gone it needs neither `useProfile` nor `showOwnerControls`, so it reduces to the background image and its gradient overlay.

In `HeroFooter`, removing the mobile button left the owner fragment with a single child, so the fragment and the `!isPreview` wrapper that only guarded the share button both collapse — the Preview / End Preview button is now rendered directly. `showOwnerControls` is still used further down for the followers/following dialogs and is unchanged.

## Scope

Dancer profile only. The school profile (`features/school/components/profile/`) has no equivalent control, and the remaining repo-wide matches for "share" are prose, not UI.

## Verification

`tsc --noEmit` clean. ESLint reports no errors in either changed file (the frontend has 129 pre-existing errors elsewhere, untouched by this branch).

Not verified in a browser — worth a glance at the profile hero on both breakpoints to confirm the spacing still reads well now that the mobile row has one fewer button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
