### PR TITLE
fix(backend): extend the tier window from any roster row, not just paid ones

### DIFF
--- a/apps/backend/app/shared/org/grant-account-tier.spec.ts
+++ b/apps/backend/app/shared/org/grant-account-tier.spec.ts
@@ -180,7 +180,7 @@ test.group("grantOrgAccountTier", (group) => {
     assert.equal(after.tier, "standard");
   });
 
-  test("leaves a limited account alone while nothing is paid", async ({
+  test("does not upgrade a limited account while nothing is paid", async ({
     assert,
   }) => {
     const org = await createOrg("freeorg", true);
@@ -192,7 +192,10 @@ test.group("grantOrgAccountTier", (group) => {
       .set({ orgAccountTier: "limited" })
       .where(eq(users.id, dancer.id));
 
-    assert.isNull(await grant(dancer.id, org.id));
+    // Still not upgraded — the paid flag governs the level — though the window
+    // itself does move, which "extends a limited account" covers below.
+    const granted = await grant(dancer.id, org.id);
+    assert.equal(granted?.tier, "limited");
     const after = await tierOf(dancer.id);
     assert.equal(after.tier, "limited");
   });
@@ -277,7 +280,7 @@ test.group("grantOrgAccountTier", (group) => {
     assert.equal(after.expiresAt!.toISOString().split("T")[0], "2027-01-01");
   });
 
-  test("an unpaid later event does not stretch paid access", async ({
+  test("a later event extends the window even when that row is unpaid", async ({
     assert,
   }) => {
     const org = await createOrg("freeorg", true);
@@ -286,12 +289,59 @@ test.group("grantOrgAccountTier", (group) => {
     await addRoster(paidEvent.id, dancer.id, "paidthenfree@x.co", true);
     await grant(dancer.id, org.id);
 
-    // Shows up again but does not buy the upgrade this time.
+    // Shows up again without buying the upgrade. Being rostered is what keeps
+    // the window alive; the paid flag only governs the level.
     const freeEvent = await createEvent(org.id, "2026-08-23");
     await addRoster(freeEvent.id, dancer.id, "paidthenfree@x.co", false);
 
-    assert.isNull(await grant(dancer.id, org.id));
+    const granted = await grant(dancer.id, org.id);
+    assert.equal(granted?.tier, "standard");
     const after = await tierOf(dancer.id);
-    assert.equal(after.expiresAt!.toISOString().split("T")[0], "2026-08-10");
+    assert.equal(after.expiresAt!.toISOString().split("T")[0], "2026-11-23");
+  });
+
+  test("extends a limited account without upgrading it", async ({ assert }) => {
+    // The org that uses the paid flag is the only place 'limited' exists. An
+    // unpaid dancer still attends events, so her window still tracks them.
+    const org = await createOrg("freeorg", true);
+    const first = await createEvent(org.id, "2026-05-10", false);
+    const dancer = await createDancer("limitedreturn@x.co");
+    await addRoster(first.id, dancer.id, "limitedreturn@x.co", false);
+    await db
+      .update(users)
+      .set({
+        orgAccountTier: "limited",
+        orgAccountTierExpiresAt: new Date("2026-08-10T00:00:00.000Z"),
+      })
+      .where(eq(users.id, dancer.id));
+
+    const second = await createEvent(org.id, "2026-08-23");
+    await addRoster(second.id, dancer.id, "limitedreturn@x.co", false);
+
+    const granted = await grant(dancer.id, org.id);
+    assert.equal(granted?.tier, "limited");
+    const after = await tierOf(dancer.id);
+    assert.equal(after.tier, "limited");
+    assert.equal(after.expiresAt!.toISOString().split("T")[0], "2026-11-23");
+  });
+
+  test("extends on a new roster in an org with no paid flag at all", async ({
+    assert,
+  }) => {
+    // Most orgs never set `paid`; every roster row there earns the full window.
+    const org = await createOrg("noflags", false);
+    const first = await createEvent(org.id, "2026-05-10", false);
+    const dancer = await createDancer("noflag@x.co");
+    await addRoster(first.id, dancer.id, "noflag@x.co", null);
+    await grant(dancer.id, org.id);
+    const initial = await tierOf(dancer.id);
+    assert.equal(initial.expiresAt!.toISOString().split("T")[0], "2026-08-10");
+
+    const second = await createEvent(org.id, "2026-08-23");
+    await addRoster(second.id, dancer.id, "noflag@x.co", null);
+
+    await grant(dancer.id, org.id);
+    const after = await tierOf(dancer.id);
+    assert.equal(after.expiresAt!.toISOString().split("T")[0], "2026-11-23");
   });
 });

--- a/apps/backend/app/shared/org/grant-account-tier.ts
+++ b/apps/backend/app/shared/org/grant-account-tier.ts
@@ -5,7 +5,7 @@ import { eventRosters, orgEvents } from "#database/schema/org-events";
 import { and, eq } from "drizzle-orm";
 
 export interface GrantedOrgTier {
-  tier: "standard";
+  tier: "standard" | "limited";
   expiresAt: Date;
   /** True when the account already held a tier and only the window moved out. */
   extended: boolean;
@@ -76,19 +76,23 @@ export async function grantOrgAccountTier(
       )
     );
 
-  // Free-tier orgs sell the upgrade themselves, so only paid rows carry an
-  // entitlement there. Measuring the window from entitling rows alone means an
-  // unpaid appearance at a later event cannot stretch access someone paid for.
-  const entitlingRows = freeTier
-    ? rosterRows.filter((r) => r.paid === true)
-    : rosterRows;
+  if (rosterRows.length === 0) return null;
 
-  // Nothing to grant. Leave the account exactly as it is rather than pushing an
-  // unpaid dancer down to 'limited', which would revoke the photo upload a
-  // plain free account already has.
-  if (entitlingRows.length === 0) return null;
+  // The paid flag decides the *level*, not the duration, and only one org uses
+  // it at all: in a free-tier org an unpaid dancer is 'limited', everywhere else
+  // every roster row earns 'standard'.
+  const entitledToStandard =
+    !freeTier || rosterRows.some((r) => r.paid === true);
 
-  const latestEnd = entitlingRows
+  // Never downgrade. An unpaid dancer keeps whatever she already had, and an
+  // account with no tier keeps none — 'limited' is *more* restrictive than null,
+  // so granting it here would revoke the photo upload a free account has.
+  const tier = entitledToStandard ? "standard" : user.tier;
+  if (tier === null) return null;
+
+  // The duration comes from the roster, paid or not: being uploaded to another
+  // event means she is still attending, so her window runs from that event.
+  const latestEnd = rosterRows
     .map((r) => r.endDate)
     .reduce((a, b) => (a > b ? a : b));
 
@@ -101,15 +105,15 @@ export async function grantOrgAccountTier(
   const current = user.expiresAt;
   const expiresAt = current && current > earned ? current : earned;
 
-  const tierChanged = user.tier !== "standard";
+  const tierChanged = user.tier !== tier;
   const windowMoved =
     current === null || expiresAt.getTime() !== current.getTime();
   if (!tierChanged && !windowMoved) return null;
 
   await tx
     .update(users)
-    .set({ orgAccountTier: "standard", orgAccountTierExpiresAt: expiresAt })
+    .set({ orgAccountTier: tier, orgAccountTierExpiresAt: expiresAt })
     .where(eq(users.id, userId));
 
-  return { tier: "standard", expiresAt, extended: user.tier !== null };
+  return { tier, expiresAt, extended: user.tier !== null };
 }


### PR DESCRIPTION
Follow-up to #70. That PR tied **both** the access level and the window duration to the roster `paid` flag, which was too narrow — the correction was pushed after the merge went through, so it never landed.

## The problem

Only one org sets `paid` at all:

| org | free-tier | dancer rows | paid rows |
|---|---|---|---|
| prodigy | ✅ | 947 | 134 |
| dance-team-night | — | 284 | **0** |
| summit | — | 160 | **0** |
| core | — | 2 | **0** |

Measuring the window from paid rows alone froze the expiry for most org dancers. A `limited` dancer uploaded to next season's roster kept a window dated from her first event, and orgs that never touch the column got nothing at all from the extend logic.

## The fix

Separate the two concepts:

- **Duration ← the roster.** Being uploaded to another event means she is still attending, so her window runs from that event — paid or not, in every org.
- **Level ← the paid flag.** Paid → `standard`; unpaid → whatever level she already had.

| Scenario | #70 | This PR |
|---|---|---|
| `limited` dancer added to next season's roster | ❌ frozen | ✅ extended, still `limited` |
| Org that never sets `paid` | ❌ frozen | ✅ extended |
| Already `standard`, later unpaid event | ❌ frozen | ✅ extended |
| Already `limited`, later marked paid | ✅ upgraded | ✅ upgraded |
| Window already reaching further | ✅ untouched | ✅ untouched |

Downgrades remain impossible. An unpaid dancer keeps her level, and an account with no tier still gets none — `limited` is *more* restrictive than null, since it blocks the photo upload a plain free account has. Explicit revocation stays with `SetRosterPaidService`.

## Verification

| | Tests | Passed | Failed |
|---|---|---|---|
| `main` (post-#70) | 270 | 258 | 12 |
| This branch | 272 | 260 | **12** |

+2 tests; the 12 failures are identical to `main`'s and pre-existing. `tsc --noEmit` and `eslint` clean.

One test from #70 asserted the opposite behavior ("an unpaid later event does not stretch paid access") — that was my earlier design rather than a requirement, so it is inverted here, alongside new cases for the `limited` return visit and the no-paid-flag org.

## Production data

Already reconciled under this rule: 9 further accounts extended (6 Prodigy dancers, 3 in `s2s-test`), extend-only, verified 0 remaining. Notably `samantharoselaster@yahoo.com` — paid at Tempe, then attended Chicago unpaid — now correctly runs to 2026-11-16 off the Chicago event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
