### PR TITLE
fix(callbacks): keep the collapsed response readable by older frontend bundles

### DIFF
--- a/apps/backend/app/modules/orgs/scouting/callbacks/dancer-detail/service.spec.ts
+++ b/apps/backend/app/modules/orgs/scouting/callbacks/dancer-detail/service.spec.ts
@@ -150,6 +150,36 @@ test.group("DancerCallbackDetailService", (group) => {
     assert.equal(rows[1]!.organization, "University of Idaho");
   });
 
+  test("keeps the pre-collapse fields readable by older frontend bundles", async ({
+    assert,
+  }) => {
+    const { org, event } = await setup();
+    const published = await addShowcase(event.id, 1, "published");
+    const active = await addShowcase(event.id, 2, "active");
+    const released = await addCoach(event.id, "Rel", "Released University");
+    const mixed = await addCoach(event.id, "Mix", "Mixed University");
+    const dancer = await addDancer(event.id, 1);
+
+    await callback(event.id, published.id, released.id, dancer.id, true);
+    await callback(event.id, published.id, mixed.id, dancer.id, true);
+    await callback(event.id, active.id, mixed.id, dancer.id, false);
+
+    const rows = await new DancerCallbackDetailService().execute(
+      org.id,
+      dancer.id
+    );
+
+    const rel = rows.find((r) => r.organization === "Released University")!;
+    assert.equal(rel.showcaseNumber, 1);
+    assert.isTrue(rel.isPublished);
+
+    // A school with a pending callback must not read as fully released to an
+    // older bundle, which only has this boolean to go on.
+    const mix = rows.find((r) => r.organization === "Mixed University")!;
+    assert.equal(mix.showcaseNumber, 2);
+    assert.isFalse(mix.isPublished);
+  });
+
   test("counts released and pending callbacks separately on a collapsed row", async ({
     assert,
   }) => {

--- a/apps/backend/app/modules/orgs/scouting/callbacks/dancer-detail/service.ts
+++ b/apps/backend/app/modules/orgs/scouting/callbacks/dancer-detail/service.ts
@@ -87,6 +87,15 @@ export class DancerCallbackDetailService {
     return rows.map(({ avatar, ...row }) => ({
       ...row,
       avatarUrl: imageUrl(avatar, "avatar"),
+      // Transitional, for frontend bundles built before this endpoint started
+      // collapsing rows. The API and the SPA deploy separately, so an older
+      // cached bundle can read a newer response; without these it silently
+      // renders a blank showcase and "Not released" for callbacks that are
+      // released, which is worse than showing less detail. Safe to delete once
+      // both halves have shipped together.
+      showcaseNumber: row.latestShowcaseNumber,
+      isPublished:
+        row.callbackCount > 0 && row.releasedCount === row.callbackCount,
     }));
   }
 }

--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -16560,6 +16560,12 @@
             },
             "releasedCount": {
               "type": "number"
+            },
+            "showcaseNumber": {
+              "type": "number"
+            },
+            "isPublished": {
+              "type": "boolean"
             }
           },
           "required": [
@@ -16572,7 +16578,9 @@
             "showcaseNumbers",
             "latestShowcaseNumber",
             "callbackCount",
-            "releasedCount"
+            "releasedCount",
+            "showcaseNumber",
+            "isPublished"
           ]
         }
       },

--- a/apps/frontend/src/lib/api/types.d.ts
+++ b/apps/frontend/src/lib/api/types.d.ts
@@ -11402,6 +11402,8 @@ export interface components {
             latestShowcaseNumber: number;
             callbackCount: number;
             releasedCount: number;
+            showcaseNumber: number;
+            isPublished: boolean;
         }[];
         OrgsIdShowcasesResponse: {
             number: number;


### PR DESCRIPTION
## The problem

Collapsing the admin callback list (#73) was a **breaking response change**: it removed `showcaseNumber` and `isPublished` and replaced them with aggregates.

The API and the SPA deploy separately — Fly for the backend, Cloudflare for the frontend — so a bundle built before that change can read a response from after it. When that happens, the old component reads two fields that no longer exist:

| Old component reads | Gets | Renders |
|---|---|---|
| `· Showcase {cb.showcaseNumber}` | `undefined` | `· Showcase` — JSX drops `undefined` silently |
| `{cb.isPublished ? "Released" : "Not released"}` | `undefined` (falsy) | **"Not released"**, for every school |

This was observed in a real environment, not theorised. It is the dangerous kind of wrong: not a crash, but confident, plausible, incorrect data. An admin reading that screen would tell a dancer that no school released a callback when schools did — which is the exact support failure this whole line of work set out to fix.

## The change

The response now returns both field sets. No frontend change; the new component keeps using the aggregates.

| School | New fields | Compatibility fields |
|---|---|---|
| Duke | `showcaseNumbers: [3, 1]` · 1 of 2 released | `showcaseNumber: 3` · `isPublished: false` |
| Oregon | `[3]` · 0 of 1 | `3` · `false` |
| Ohio State | `[2]` · 1 of 1 | `2` · `true` |
| Alabama | `[2, 1]` · 2 of 2 | `2` · `true` |

Two deliberate choices:

- **`showcaseNumber` is the latest showcase**, not the first. A collapsed row has several; the most recent interest is the one worth surfacing when only one can be.
- **`isPublished` is true only when every callback from that school is released.** Duke has a pending callback in the active showcase, so an old bundle shows "Not released" rather than claiming everything is out. Understating is safe; overstating would have an admin tell a dancer a callback is public when it is not.

These are transitional. The code comment says so, and they should be deleted once the API and SPA have shipped together — I would rather they come out than quietly ossify into contract.

## Verification

- A new test pins both fields, including the mixed released/pending case, so they cannot be dropped by accident before both halves ship. 4 tests on this service, all passing.
- Backend `tsc --noEmit` clean; frontend `tsc -b --force` clean.
- Confirmed against the live endpoint — the table above is the actual response.

## Note on the base branch

Targets `fix/callbacks-visibility-and-admin-attribution`, which is where #73's collapse currently lives. Note that `main` does **not** have the collapse yet — #73 merged into that branch, not into main, and main's merge of #72 was cut just before it. So main is currently self-consistent (old response + old component); the split only exists on the branch.

## Caveat

This makes an old bundle *correct*, not *current*. It will show "Showcase 3" rather than "Showcases 3, 1", and "Not released" rather than "1 of 2 released". Rebuilding the frontend is still what gets the full detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
