### PR TITLE
fix(search): match account search across the whole name

### DIFF
--- a/apps/backend/app/modules/orgs/events/reconciliation/service.spec.ts
+++ b/apps/backend/app/modules/orgs/events/reconciliation/service.spec.ts
@@ -1,10 +1,11 @@
 import { test } from "@japa/runner";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { db } from "#database/connection";
 import { DatabaseService } from "#database/service";
 import { organizations } from "#database/schema/organizations";
 import { orgEvents, eventRosters } from "#database/schema/org-events";
 import { schoolInvites } from "#database/schema/schools";
+import { users } from "#database/schema/users";
 import mail from "@adonisjs/mail/services/main";
 import { ReconciliationService } from "./service.ts";
 
@@ -100,5 +101,91 @@ test.group("ReconciliationService.resendInvite", (group) => {
     // Expiry pushed out to ~14 days.
     assert.isAbove(after!.expiresAt.getTime(), Date.now() + 13 * 86400000);
     assert.isNull(after!.consumedAt);
+  });
+});
+
+const SEARCH_EMAILS = [
+  "recon-search-wilson@test.com",
+  "recon-search-harman@test.com",
+];
+
+test.group("ReconciliationService.searchSchoolUsers", (group) => {
+  group.each.setup(async () => {
+    await db.delete(users).where(inArray(users.email, SEARCH_EMAILS)).execute();
+
+    await db.insert(users).values([
+      {
+        username: "recon_search_wilson",
+        email: SEARCH_EMAILS[0]!,
+        displayEmail: SEARCH_EMAILS[0]!,
+        firstName: "Jane",
+        lastName: "Wilson",
+        password: "x",
+        role: "user" as const,
+        type: "school" as const,
+        verified: true,
+      },
+      {
+        username: "recon_search_harman",
+        email: SEARCH_EMAILS[1]!,
+        displayEmail: SEARCH_EMAILS[1]!,
+        firstName: "Jane",
+        lastName: "Harman",
+        password: "x",
+        role: "user" as const,
+        type: "school" as const,
+        verified: true,
+      },
+    ]);
+
+    return async () => {
+      await db
+        .delete(users)
+        .where(inArray(users.email, SEARCH_EMAILS))
+        .execute();
+    };
+  });
+
+  test("matches a query spanning first and last name", async ({ assert }) => {
+    const service = new ReconciliationService(new DatabaseService());
+    const results = await service.searchSchoolUsers("Jane Wil");
+    const emails = results.map((r) => r.email);
+
+    assert.include(emails, SEARCH_EMAILS[0]);
+    assert.notInclude(emails, SEARCH_EMAILS[1]);
+  });
+
+  test("still matches on a single name fragment and on email", async ({
+    assert,
+  }) => {
+    const service = new ReconciliationService(new DatabaseService());
+
+    const byName = await service.searchSchoolUsers("Jane");
+    const nameEmails = byName.map((r) => r.email);
+    assert.include(nameEmails, SEARCH_EMAILS[0]);
+    assert.include(nameEmails, SEARCH_EMAILS[1]);
+
+    const byEmail = await service.searchSchoolUsers("recon-search-harman@");
+    const emailEmails = byEmail.map((r) => r.email);
+    assert.include(emailEmails, SEARCH_EMAILS[1]);
+  });
+
+  test("ranks name prefixes above mid-string matches", async ({ assert }) => {
+    const service = new ReconciliationService(new DatabaseService());
+    const results = await service.searchSchoolUsers("Jane H");
+
+    assert.equal(results[0]?.email, SEARCH_EMAILS[1]);
+  });
+
+  test("ignores surrounding whitespace and short queries", async ({
+    assert,
+  }) => {
+    const service = new ReconciliationService(new DatabaseService());
+
+    assert.isEmpty(await service.searchSchoolUsers(" J "));
+
+    const results = await service.searchSchoolUsers("  Jane Wilson  ");
+    const emails = results.map((r) => r.email);
+    assert.include(emails, SEARCH_EMAILS[0]);
   });
 });

--- a/apps/backend/app/modules/orgs/events/reconciliation/service.ts
+++ b/apps/backend/app/modules/orgs/events/reconciliation/service.ts
@@ -194,6 +194,21 @@ export class ReconciliationService {
   }
 
   async searchSchoolUsers(query: string) {
+    const trimmed = query.trim();
+    if (trimmed.length < 2) return [];
+
+    // A query like "Jane Wil" spans two columns, so matching it against each
+    // column on its own finds nothing. Every whitespace-separated token has to
+    // match somewhere — the joined full name included — which keeps typing
+    // more of a name narrowing the list instead of emptying it.
+    const tokens = trimmed.toLowerCase().split(/\s+/).filter(Boolean);
+    const fullName = sql`lower(coalesce(${users.firstName}, '') || ' ' || coalesce(${users.lastName}, ''))`;
+
+    const matchesToken = tokens.map((token) => {
+      const term = `%${token}%`;
+      return sql`(lower(${users.email}) like ${term} OR ${fullName} like ${term})`;
+    });
+
     return this.db.use((db) =>
       db
         .select({
@@ -203,11 +218,14 @@ export class ReconciliationService {
           lastName: users.lastName,
         })
         .from(users)
-        .where(
-          and(
-            eq(users.type, "school"),
-            sql`(lower(${users.email}) like ${"%" + query.toLowerCase() + "%"} OR lower(${users.firstName}) like ${"%" + query.toLowerCase() + "%"} OR lower(${users.lastName}) like ${"%" + query.toLowerCase() + "%"})`
-          )
+        .where(and(eq(users.type, "school"), ...matchesToken))
+        // The limit truncates, so order it: names that start with the query
+        // come first, then alphabetically, so the list stays stable as the
+        // admin keeps typing.
+        .orderBy(
+          sql`case when ${fullName} like ${`${trimmed.toLowerCase()}%`} then 0 else 1 end`,
+          sql`${fullName}`,
+          users.email
         )
         .limit(20)
     );

--- a/apps/backend/app/modules/orgs/events/rosters/attach/service.spec.ts
+++ b/apps/backend/app/modules/orgs/events/rosters/attach/service.spec.ts
@@ -194,3 +194,111 @@ test.group("AttachAccountService", (group) => {
     assert.isTrue(meta.confirmed);
   });
 });
+
+const SEARCH_EMAILS = [
+  "search-wilson@test.com",
+  "search-harman@test.com",
+  "search-nolastname@test.com",
+];
+
+test.group("AttachAccountService.searchDancerUsers", (group) => {
+  group.each.setup(async () => {
+    await db.delete(users).where(inArray(users.email, SEARCH_EMAILS)).execute();
+
+    await db.insert(users).values([
+      {
+        username: "search_wilson",
+        email: SEARCH_EMAILS[0],
+        displayEmail: SEARCH_EMAILS[0],
+        firstName: "Lucy",
+        lastName: "Wilson",
+        password: "x",
+        role: "user" as const,
+        type: "dancer" as const,
+        verified: true,
+      },
+      {
+        username: "search_harman",
+        email: SEARCH_EMAILS[1],
+        displayEmail: SEARCH_EMAILS[1],
+        firstName: "Lucy",
+        lastName: "Harman",
+        password: "x",
+        role: "user" as const,
+        type: "dancer" as const,
+        verified: true,
+      },
+      {
+        username: "search_nolastname",
+        email: SEARCH_EMAILS[2],
+        displayEmail: SEARCH_EMAILS[2],
+        firstName: "Lucille",
+        lastName: "",
+        password: "x",
+        role: "user" as const,
+        type: "dancer" as const,
+        verified: true,
+      },
+    ]);
+
+    return async () => {
+      await db
+        .delete(users)
+        .where(inArray(users.email, SEARCH_EMAILS))
+        .execute();
+    };
+  });
+
+  test("matches a query spanning first and last name", async ({ assert }) => {
+    const svc = new AttachAccountService();
+    const results = await svc.searchDancerUsers("Lucy Wil");
+    const emails = results.map((r) => r.email);
+
+    assert.include(emails, SEARCH_EMAILS[0]);
+    assert.notInclude(emails, SEARCH_EMAILS[1]);
+  });
+
+  test("still matches on a single name fragment", async ({ assert }) => {
+    const svc = new AttachAccountService();
+    const results = await svc.searchDancerUsers("Lucy");
+    const emails = results.map((r) => r.email);
+
+    assert.include(emails, SEARCH_EMAILS[0]);
+    assert.include(emails, SEARCH_EMAILS[1]);
+  });
+
+  test("matches on email", async ({ assert }) => {
+    const svc = new AttachAccountService();
+    const results = await svc.searchDancerUsers("search-harman@");
+    const emails = results.map((r) => r.email);
+
+    assert.include(emails, SEARCH_EMAILS[1]);
+  });
+
+  test("matches accounts with a blank last name", async ({ assert }) => {
+    const svc = new AttachAccountService();
+    const results = await svc.searchDancerUsers("Lucille");
+    const emails = results.map((r) => r.email);
+
+    assert.include(emails, SEARCH_EMAILS[2]);
+  });
+
+  test("ranks name prefixes above mid-string matches", async ({ assert }) => {
+    const svc = new AttachAccountService();
+    const results = await svc.searchDancerUsers("Lucy H");
+
+    assert.equal(results[0]?.email, SEARCH_EMAILS[1]);
+  });
+
+  test("ignores surrounding whitespace and short queries", async ({
+    assert,
+  }) => {
+    const svc = new AttachAccountService();
+
+    assert.isEmpty(await svc.searchDancerUsers(" L "));
+
+    const results = await svc.searchDancerUsers("  Lucy Wilson  ");
+    const emails = results.map((r) => r.email);
+    assert.include(emails, SEARCH_EMAILS[0]);
+  });
+});

--- a/apps/backend/app/modules/orgs/events/rosters/attach/service.ts
+++ b/apps/backend/app/modules/orgs/events/rosters/attach/service.ts
@@ -309,9 +309,20 @@ export class AttachAccountService {
   }
 
   async searchDancerUsers(query: string) {
-    if (query.length < 2) return [];
+    const trimmed = query.trim();
+    if (trimmed.length < 2) return [];
 
-    const term = `%${query.toLowerCase()}%`;
+    // "Lucy Wil" spans two columns, so matching the raw query against each
+    // column on its own finds nothing. Every whitespace-separated token has to
+    // match somewhere — the joined full name included — which keeps typing
+    // more of a name narrowing the list instead of emptying it.
+    const tokens = trimmed.toLowerCase().split(/\s+/).filter(Boolean);
+    const fullName = sql`lower(coalesce(${users.firstName}, '') || ' ' || coalesce(${users.lastName}, ''))`;
+
+    const matchesToken = tokens.map((token) => {
+      const term = `%${token}%`;
+      return sql`(lower(${users.email}) like ${term} OR ${fullName} like ${term})`;
+    });
 
     return this.db.use((db) =>
       db
@@ -324,11 +335,14 @@ export class AttachAccountService {
           username: users.username,
         })
         .from(users)
-        .where(
-          and(
-            eq(users.type, "dancer"),
-            sql`(lower(${users.email}) like ${term} OR lower(${users.firstName}) like ${term} OR lower(${users.lastName}) like ${term})`
-          )
+        .where(and(eq(users.type, "dancer"), ...matchesToken))
+        // The limit truncates, so order it: names that start with the query
+        // come first, then alphabetically, so the list stays stable as the
+        // admin keeps typing.
+        .orderBy(
+          sql`case when ${fullName} like ${`${trimmed.toLowerCase()}%`} then 0 else 1 end`,
+          sql`${fullName}`,
+          users.email
         )
         .limit(20)
     );


### PR DESCRIPTION
Typing more of a dancer's name in the org admin's **Change Account** dialog emptied the list: "Lucy" returned matches, "Lucy Wil" returned "No users found."

## Cause

`AttachAccountService.searchDancerUsers` compared the whole query string to `email`, `first_name`, and `last_name` *individually*. "Lucy" matched `first_name`; "Lucy Wil" spans two columns, so no single column contained it and nothing matched. `ReconciliationService.searchSchoolUsers` had the identical defect on the coach side.

## Fix

Both searches now:

- split the query on whitespace and require every token to match the email or the joined `first_name || ' ' || last_name` (coalesced, so a blank last name doesn't null the row out)
- trim before the 2-character minimum, so ` L ` still returns nothing and `  Lucy Wilson  ` works
- order results — full-name prefix matches first, then alphabetically by name and email — because the query has a `LIMIT 20` and previously truncated in whatever order Postgres returned

### Behavior change

`searchSchoolUsers` had no minimum length, so an empty `q` produced `%%` and returned the first twenty school accounts. It now returns `[]` under two characters, matching the dancer endpoint. That endpoint (`/search-users`) is registered but has no frontend caller, so nothing depended on the old behavior.

## Verification

- 10 new tests across the two service specs. Against the old queries, 3 fail in each file (the multi-token match, the ranking, the whitespace case); all pass with the fix.
- `pnpm typecheck` clean; eslint clean on all four changed files.
- Full functional suite: same pre-existing failures as the baseline on `origin/main` (check-in, CSV export, roster stats, one middleware test — order-dependent, unrelated to search). No new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)