### PR TITLE
fix(roster-claims): tighten the roster request UI and copy

### DIFF
--- a/apps/backend/app/modules/orgs/roster-claims/create/service.ts
+++ b/apps/backend/app/modules/orgs/roster-claims/create/service.ts
@@ -21,7 +21,7 @@ export class CreateRosterClaimService {
 
   async execute(orgId: string, requesterId: string, input: CreateClaimValidator) {
     return this.db.use(async (db) => {
-      // Nothing to claim if she can already see her registration — this is the
+      // Nothing to claim if they can already see their registration — this is the
       // path for dancers who find nothing, and saying so is more useful than
       // queuing a request an admin would only close again.
       const [existing] = await db

--- a/apps/backend/app/modules/orgs/roster-claims/create/validator.ts
+++ b/apps/backend/app/modules/orgs/roster-claims/create/validator.ts
@@ -3,12 +3,12 @@ import { type Infer } from "@vinejs/vine/types";
 
 export const createClaimSchema = vine.compile(
   vine.object({
-    // The name the org would have registered her under, which is not
-    // necessarily the name on her account.
+    // The name the org would have registered them under, which is not
+    // necessarily the name on their account.
     claimedFirstName: vine.string().trim().minLength(1).maxLength(80),
     claimedLastName: vine.string().trim().minLength(1).maxLength(80),
-    // The address she believes was used — often a parent's. Optional, because
-    // not knowing it is the usual reason she is here.
+    // The address they believe was used, often a parent's. Optional, because
+    // not knowing it is the usual reason they are here.
     claimedEmail: vine.string().trim().email().optional(),
     note: vine.string().trim().maxLength(500).optional(),
   })

--- a/apps/backend/app/modules/orgs/roster-claims/list/service.ts
+++ b/apps/backend/app/modules/orgs/roster-claims/list/service.ts
@@ -41,7 +41,7 @@ export class ListRosterClaimsService {
       return {
         data: rows.map((r) => ({
           id: r.id,
-          // What she says she was registered as — the admin matches this
+          // What they say they were registered as — the admin matches this
           // against the roster.
           claimed: {
             firstName: r.claimedFirstName,

--- a/apps/frontend/src/features/org/api/roster-claim-queries.ts
+++ b/apps/frontend/src/features/org/api/roster-claim-queries.ts
@@ -9,7 +9,7 @@ const CLAIM_LIST_KEY_PREFIX = [
 ] as const;
 
 /**
- * Files a dancer's request that a roster entry belongs to her. Creates a
+ * Files a dancer's request that a roster entry belongs to them. Creates a
  * pending request for an org admin — it never links anything on its own.
  */
 export function useCreateRosterClaim() {

--- a/apps/frontend/src/features/org/components/admin-sidebar.tsx
+++ b/apps/frontend/src/features/org/components/admin-sidebar.tsx
@@ -64,7 +64,15 @@ export function AdminSidebar() {
   const { org, membership, hasFeature } = useOrg();
 
   const navSections = useMemo(() => {
-    const sections: { title: string; items: { label: string; icon: any; to: string }[] }[] = [
+    const sections: {
+      title: string;
+      items: {
+        label: string;
+        icon: any;
+        to: string;
+        fullWidth?: boolean;
+      }[];
+    }[] = [
       {
         title: "Rosters",
         items: [
@@ -82,6 +90,7 @@ export function AdminSidebar() {
             label: "Requests",
             icon: InboxIcon,
             to: "/o/$orgSlug/admin/roster-claims",
+            fullWidth: true,
           },
         ],
       },
@@ -165,7 +174,8 @@ export function AdminSidebar() {
     : location.pathname.includes("/coach")
       ? "Coach"
       : "Dancer";
-  const canSwitchView = membership?.role === "admin" || session.role === "admin";
+  const canSwitchView =
+    membership?.role === "admin" || session.role === "admin";
 
   function handleSelectView(view: "Admin" | "Coach" | "Dancer") {
     if (view === "Admin") {
@@ -255,33 +265,41 @@ export function AdminSidebar() {
                   <SidebarGroupLabel className="text-muted-foreground px-3 pt-2 pb-1 text-[10px] font-semibold tracking-widest uppercase">
                     {section.title}
                   </SidebarGroupLabel>
-                  <div className={`border-sidebar-border border-t ${section.items.length > 1 ? "grid grid-cols-2" : ""}`}>
-                    {section.items.map(({ label, icon: Icon, to }) => {
-                      const isActive = isItemActive(to);
-                      return (
-                        <Link
-                          key={label}
-                          to={to}
-                          params={{ orgSlug }}
-                          className={`border-sidebar-border flex min-h-10 items-center gap-2 border-t-2 border-r px-3 py-2 transition-colors even:border-r-0 ${
-                            isActive
-                              ? "border-t-primary text-primary bg-sidebar-accent/40"
-                              : "text-sidebar-foreground hover:bg-sidebar-accent/20 border-t-transparent"
-                          }`}
-                        >
-                          <Icon
-                            className={`size-3.5 shrink-0 ${
+                  <div
+                    className={`border-sidebar-border border-t ${section.items.length > 1 ? "grid grid-cols-2" : ""}`}
+                  >
+                    {section.items.map(
+                      ({ label, icon: Icon, to, fullWidth }) => {
+                        const isActive = isItemActive(to);
+                        return (
+                          <Link
+                            key={label}
+                            to={to}
+                            params={{ orgSlug }}
+                            className={`border-sidebar-border flex min-h-10 items-center gap-2 border-t-2 px-3 py-2 transition-colors ${
+                              fullWidth
+                                ? "col-span-2"
+                                : "border-r even:border-r-0"
+                            } ${
                               isActive
-                                ? "text-primary/80"
-                                : "text-muted-foreground"
+                                ? "border-t-primary text-primary bg-sidebar-accent/40"
+                                : "text-sidebar-foreground hover:bg-sidebar-accent/20 border-t-transparent"
                             }`}
-                          />
-                          <span className="text-xs leading-none font-semibold">
-                            {label}
-                          </span>
-                        </Link>
-                      );
-                    })}
+                          >
+                            <Icon
+                              className={`size-3.5 shrink-0 ${
+                                isActive
+                                  ? "text-primary/80"
+                                  : "text-muted-foreground"
+                              }`}
+                            />
+                            <span className="text-xs leading-none font-semibold">
+                              {label}
+                            </span>
+                          </Link>
+                        );
+                      },
+                    )}
                   </div>
                 </section>
               ))}
@@ -362,7 +380,11 @@ export function AdminSidebar() {
                     closeOnClick
                     render={
                       <Link
-                        to={session.type === "school" ? "/explore/$username" : "/$username"}
+                        to={
+                          session.type === "school"
+                            ? "/explore/$username"
+                            : "/$username"
+                        }
                         params={{ username: session.username }}
                       />
                     }
@@ -402,7 +424,11 @@ export function AdminSidebar() {
                         [
                           { value: "light", label: "Light", icon: SunIcon },
                           { value: "dark", label: "Dark", icon: MoonIcon },
-                          { value: "system", label: "System", icon: MonitorIcon },
+                          {
+                            value: "system",
+                            label: "System",
+                            icon: MonitorIcon,
+                          },
                         ] as const
                       ).map(({ value, label, icon: Icon }) => (
                         <MenuItem
@@ -435,4 +461,3 @@ export function AdminSidebar() {
     </Sidebar>
   );
 }
-

--- a/apps/frontend/src/features/org/components/resolve-claim-dialog.tsx
+++ b/apps/frontend/src/features/org/components/resolve-claim-dialog.tsx
@@ -37,7 +37,7 @@ import {
   type RosterClaim,
 } from "@/features/org/api/roster-claim-queries";
 import { useQuery } from "@tanstack/react-query";
-import { SearchIcon, TriangleAlertIcon } from "lucide-react";
+import { ArrowDown, SearchIcon, TriangleAlertIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 interface ResolveClaimDialogProps {
@@ -61,7 +61,7 @@ export function ResolveClaimDialog({
   claim,
   onSuccess,
 }: ResolveClaimDialogProps) {
-  // Seeded with the name she gave, since that is what the roster was most
+  // Seeded with the name they gave, since that is what the roster was most
   // likely uploaded under.
   const [query, setQuery] = useState(claim.claimed.lastName);
   const [debouncedQuery, setDebouncedQuery] = useState(claim.claimed.lastName);
@@ -86,7 +86,7 @@ export function ResolveClaimDialog({
   // Must stay referentially stable — Base UI reads it in a layout effect.
   const entries = useMemo<RosterEntry[]>(
     () => rosterQuery.data?.data ?? [],
-    [rosterQuery.data]
+    [rosterQuery.data],
   );
   // Module-scope, so already referentially stable — Base UI requires that.
 
@@ -101,7 +101,7 @@ export function ResolveClaimDialog({
       if (!next) reset();
       onOpenChange(next);
     },
-    [onOpenChange, reset]
+    [onOpenChange, reset],
   );
 
   const handleConfirm = async () => {
@@ -144,16 +144,18 @@ export function ResolveClaimDialog({
       <Dialog open={open} onOpenChange={handleOpenChange}>
         <DialogPopup>
           <DialogHeader>
-            <DialogTitle>Find her roster entry</DialogTitle>
+            <DialogTitle>Find their roster entry</DialogTitle>
             <DialogDescription>
-              Choose the entry that belongs to {requesterName}. Her account will
-              be linked to it and the entry updated to match.
+              Pick the entry that belongs to {requesterName}. Their account gets
+              linked to it.
             </DialogDescription>
           </DialogHeader>
           <DialogPanel>
             <div className="flex flex-col gap-3">
               <div className="bg-muted/50 rounded-md border p-3 text-sm">
-                <p className="text-muted-foreground text-xs">She says she registered as</p>
+                <p className="text-muted-foreground text-xs">
+                  They say they registered as
+                </p>
                 <p className="font-medium">
                   {claim.claimed.firstName} {claim.claimed.lastName}
                 </p>
@@ -207,7 +209,9 @@ export function ResolveClaimDialog({
             </div>
           </DialogPanel>
           <DialogFooter>
-            <DialogClose render={<Button variant="ghost" />}>Cancel</DialogClose>
+            <DialogClose render={<Button variant="ghost" />}>
+              Cancel
+            </DialogClose>
           </DialogFooter>
         </DialogPopup>
       </Dialog>
@@ -226,47 +230,56 @@ export function ResolveClaimDialog({
                 : "Connect this roster entry?"}
             </AlertDialogTitle>
             <AlertDialogDescription>
-              {picked?.linkedUser ? (
-                <>
-                  <span className="font-medium">
-                    {picked.firstName} {picked.lastName}
-                  </span>{" "}
-                  is currently linked to{" "}
-                  <span className="font-medium">
-                    {[
-                      picked.linkedUser.firstName,
-                      picked.linkedUser.lastName,
-                    ]
-                      .filter(Boolean)
-                      .join(" ")}
-                  </span>{" "}
-                  ({picked.linkedUser.email}). Connecting it to{" "}
-                  <span className="font-medium">{requesterName}</span> will
-                  unregister them from this event, along with any callbacks they
-                  have received.
-                </>
-              ) : (
-                <>
-                  <span className="font-medium">{requesterName}</span> will be
-                  linked to{" "}
-                  <span className="font-medium">
-                    {picked?.firstName} {picked?.lastName}
-                  </span>{" "}
-                  ({picked?.email}).
-                </>
-              )}
+              Roster entry{" "}
+              <span className="text-foreground font-medium">
+                {picked?.firstName} {picked?.lastName}
+              </span>{" "}
+              ({picked?.email}) will be linked to a different account.
             </AlertDialogDescription>
           </AlertDialogHeader>
 
-          {picked?.linkedUser && (
-            <div className="border-destructive/30 bg-destructive/5 text-destructive mx-6 flex gap-2 rounded-md border p-3 text-sm">
-              <TriangleAlertIcon className="mt-0.5 size-4 shrink-0" />
-              <p>
-                If a parent registered on her behalf this is expected. If it is
-                a different dancer, stop and check first.
-              </p>
+          <div className="mx-6 mb-4 flex flex-col gap-3">
+            <div className="border-border flex flex-col gap-2 rounded-md border p-3 text-sm">
+              <div className="flex flex-col gap-0.5">
+                <span className="text-muted-foreground text-xs">From</span>
+                {picked?.linkedUser ? (
+                  <>
+                    <span className="font-medium">
+                      {[picked.linkedUser.firstName, picked.linkedUser.lastName]
+                        .filter(Boolean)
+                        .join(" ")}
+                    </span>
+                    <span className="text-muted-foreground text-xs break-all">
+                      {picked.linkedUser.email}
+                    </span>
+                  </>
+                ) : (
+                  <span className="text-muted-foreground">
+                    No account linked
+                  </span>
+                )}
+              </div>
+              <ArrowDown className="text-muted-foreground size-4" />
+              <div className="flex flex-col gap-0.5">
+                <span className="text-muted-foreground text-xs">To</span>
+                <span className="font-medium">{requesterName}</span>
+                <span className="text-muted-foreground text-xs break-all">
+                  {claim.requester.email}
+                </span>
+              </div>
             </div>
-          )}
+
+            {picked?.linkedUser && (
+              <div className="border-destructive/30 bg-destructive/5 text-destructive flex gap-2 rounded-md border p-3 text-sm">
+                <TriangleAlertIcon className="mt-0.5 size-4 shrink-0" />
+                <p>
+                  This unregisters the current account from the event and drops
+                  any callbacks it received. If it is a different dancer, stop
+                  and check first.
+                </p>
+              </div>
+            )}
+          </div>
 
           <AlertDialogFooter>
             <AlertDialogClose render={<Button variant="ghost" />}>

--- a/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/admin/roster-claims.tsx
+++ b/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/admin/roster-claims.tsx
@@ -1,3 +1,12 @@
+import {
+  AlertDialog,
+  AlertDialogClose,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogPopup,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
@@ -16,16 +25,22 @@ import { InboxIcon } from "lucide-react";
 import { useState } from "react";
 
 export const Route = createFileRoute(
-  "/_org/o/$orgSlug/_authenticated/admin/roster-claims"
+  "/_org/o/$orgSlug/_authenticated/admin/roster-claims",
 )({
   component: RosterClaimsPage,
 });
 
-function initials(person: { firstName: string | null; lastName: string | null }) {
+function initials(person: {
+  firstName: string | null;
+  lastName: string | null;
+}) {
   return `${person.firstName?.[0] ?? ""}${person.lastName?.[0] ?? ""}`;
 }
 
-function fullName(person: { firstName: string | null; lastName: string | null }) {
+function fullName(person: {
+  firstName: string | null;
+  lastName: string | null;
+}) {
   return [person.firstName, person.lastName].filter(Boolean).join(" ");
 }
 
@@ -70,13 +85,6 @@ function RosterClaimsPage() {
       </header>
 
       <div className="min-h-0 flex-1 overflow-y-auto p-4">
-        <p className="text-muted-foreground mb-4 max-w-2xl text-sm">
-          Dancers who could not find their registration. This usually means the
-          roster was uploaded with a parent&rsquo;s or studio&rsquo;s email, so
-          the entry is linked to that account instead of hers. Match the request
-          to the right roster entry to connect it.
-        </p>
-
         {claims.isLoading ? (
           <div className="flex justify-center py-12">
             <Spinner label="Loading requests..." />
@@ -87,7 +95,7 @@ function RosterClaimsPage() {
             <p className="text-sm">No pending requests.</p>
           </div>
         ) : (
-          <ul className="flex max-w-3xl flex-col gap-3">
+          <ul className="flex flex-col gap-2">
             {rows.map((claim) => (
               <ClaimCard
                 key={claim.id}
@@ -121,66 +129,104 @@ function ClaimCard({
   onReject: () => void;
   onResolved: () => void;
 }) {
+  const [confirmDismiss, setConfirmDismiss] = useState(false);
+
   return (
-    <li className="border-border rounded-lg border p-4">
-      <div className="flex items-start gap-3">
-        <Avatar className="size-9">
-          <AvatarImage src={claim.requester.avatarUrl ?? undefined} />
-          <AvatarFallback className="text-xs">
-            {initials(claim.requester)}
-          </AvatarFallback>
-        </Avatar>
-        <div className="min-w-0 flex-1">
-          <p className="text-sm font-medium">{fullName(claim.requester)}</p>
-          <p className="text-muted-foreground text-xs">
-            {claim.requester.email}
-          </p>
-          <p className="text-muted-foreground mt-0.5 text-xs">
-            Asked {formatDistanceToNow(new Date(claim.createdAt), {
-              addSuffix: true,
-            })}
-          </p>
+    <li className="border-border rounded-lg border px-3 py-2.5">
+      <div className="flex flex-col gap-2 md:flex-row md:items-center md:gap-4">
+        <div className="flex min-w-0 items-center gap-2.5 md:w-64 md:shrink-0">
+          <Avatar className="size-8 shrink-0">
+            <AvatarImage src={claim.requester.avatarUrl ?? undefined} />
+            <AvatarFallback className="text-xs">
+              {initials(claim.requester)}
+            </AvatarFallback>
+          </Avatar>
+          <div className="min-w-0">
+            <p className="truncate text-sm font-medium">
+              {fullName(claim.requester)}
+            </p>
+            <p className="text-muted-foreground truncate text-xs">
+              {claim.requester.email} ·{" "}
+              {formatDistanceToNow(new Date(claim.createdAt), {
+                addSuffix: true,
+              })}
+            </p>
+          </div>
+        </div>
+
+        <dl className="min-w-0 flex-1 md:pl-4">
+          <dt className="text-foreground text-xs font-medium">Registered as</dt>
+          <dd className="truncate text-sm">
+            <span className="font-medium">
+              {claim.claimed.firstName} {claim.claimed.lastName}
+            </span>
+            {claim.claimed.email && (
+              <span className="text-muted-foreground">
+                {" "}
+                · {claim.claimed.email}
+              </span>
+            )}
+          </dd>
+        </dl>
+
+        <div className="flex shrink-0 gap-2 md:justify-end">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setConfirmDismiss(true)}
+            disabled={rejecting}
+          >
+            {rejecting ? <Spinner label="Dismissing…" /> : "Dismiss"}
+          </Button>
+          <FindEntryButton
+            claim={claim}
+            orgSlug={orgSlug}
+            eventId={eventId}
+            onResolved={onResolved}
+          />
         </div>
       </div>
-
-      <dl className="mt-3 grid gap-x-6 gap-y-1 text-sm sm:grid-cols-2">
-        <div className="flex gap-2">
-          <dt className="text-muted-foreground">Registered as</dt>
-          <dd className="font-medium">
-            {claim.claimed.firstName} {claim.claimed.lastName}
-          </dd>
-        </div>
-        {claim.claimed.email && (
-          <div className="flex gap-2">
-            <dt className="text-muted-foreground">Email used</dt>
-            <dd className="font-medium">{claim.claimed.email}</dd>
-          </div>
-        )}
-      </dl>
 
       {claim.note && (
-        <p className="bg-muted/50 mt-3 rounded-md p-2.5 text-sm">{claim.note}</p>
+        <p className="bg-muted/50 mt-2 rounded-md px-2.5 py-1.5 text-sm">
+          <span className="text-muted-foreground">Note: </span>
+          {claim.note}
+        </p>
       )}
 
-      <div className="mt-4 flex justify-end gap-2">
-        <Button variant="ghost" onClick={onReject} disabled={rejecting}>
-          {rejecting ? <Spinner label="Dismissing…" /> : "Dismiss"}
-        </Button>
-        <FindEntryButton
-          claim={claim}
-          orgSlug={orgSlug}
-          eventId={eventId}
-          onResolved={onResolved}
-        />
-      </div>
+      <AlertDialog open={confirmDismiss} onOpenChange={setConfirmDismiss}>
+        <AlertDialogPopup>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Dismiss this request?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This request will be removed from the list.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogClose render={<Button variant="ghost" />}>
+              Cancel
+            </AlertDialogClose>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                setConfirmDismiss(false);
+                onReject();
+              }}
+              disabled={rejecting}
+            >
+              Dismiss request
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogPopup>
+      </AlertDialog>
     </li>
   );
 }
 
 /**
  * Approving runs through the same guarded reassignment an admin would perform
- * by hand — the request records *why*, it is not a second way to move a roster
- * entry. The confirmation still names whoever currently holds it.
+ * by hand. The request records why it happened, it is not a second way to move
+ * a roster entry. The confirmation still names whoever currently holds it.
  */
 function FindEntryButton({
   claim,
@@ -197,7 +243,7 @@ function FindEntryButton({
 
   if (!eventId) {
     return (
-      <Button disabled title="Select an event first">
+      <Button disabled size="sm" title="Select an event first">
         Find roster entry
       </Button>
     );
@@ -205,7 +251,9 @@ function FindEntryButton({
 
   return (
     <>
-      <Button onClick={() => setOpen(true)}>Find roster entry</Button>
+      <Button size="sm" onClick={() => setOpen(true)}>
+        Find roster entry
+      </Button>
       {open && (
         <ResolveClaimDialog
           open={open}

--- a/apps/frontend/src/routes/_org/o/$orgSlug/no-access.tsx
+++ b/apps/frontend/src/routes/_org/o/$orgSlug/no-access.tsx
@@ -9,6 +9,8 @@ import { useCreateRosterClaim } from "@/features/org/api/roster-claim-queries";
 import { CheckCircle2Icon, ShieldXIcon } from "lucide-react";
 import { useState } from "react";
 
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 export const Route = createFileRoute("/_org/o/$orgSlug/no-access")({
   component: NoAccessPage,
 });
@@ -25,7 +27,11 @@ function NoAccessPage() {
 
   const createClaim = useCreateRosterClaim();
 
-  const canSubmit = firstName.trim().length > 0 && lastName.trim().length > 0;
+  const trimmedEmail = claimedEmail.trim();
+  const emailInvalid =
+    trimmedEmail.length > 0 && !EMAIL_PATTERN.test(trimmedEmail);
+  const canSubmit =
+    firstName.trim().length > 0 && lastName.trim().length > 0 && !emailInvalid;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -47,7 +53,7 @@ function NoAccessPage() {
       setError(
         e2?.code === "ALREADY_ON_ROSTER"
           ? "This account is already on the roster. Try refreshing the page."
-          : (e2?.message ?? "Could not send your request. Please try again.")
+          : (e2?.message ?? "Could not send your request. Please try again."),
       );
     }
   };
@@ -90,10 +96,9 @@ function NoAccessPage() {
         <div className="space-y-1.5">
           <h2 className="text-lg font-semibold">No event access</h2>
           <p className="text-muted-foreground text-sm">
-            You are not currently on the roster for this event. If you were
-            registered by a parent or your studio, it may be under a different
-            email address &mdash; let the organizer know and they can connect it
-            to this account.
+            You are not on the roster for this event. If a parent or studio
+            registered you, it may be under a different email. Let the organizer
+            know and they can connect it to this account.
           </p>
         </div>
 
@@ -149,11 +154,18 @@ function NoAccessPage() {
                 type="email"
                 value={claimedEmail}
                 onChange={(e) => setClaimedEmail(e.target.value)}
-                placeholder="A parent's or studio's email, if you know it"
+                placeholder="Email"
+                aria-invalid={emailInvalid}
               />
-              <p className="text-muted-foreground text-xs">
-                Helps the organizer find you faster. Leave blank if unsure.
-              </p>
+              {emailInvalid ? (
+                <p className="text-destructive text-xs">
+                  Enter a valid email address.
+                </p>
+              ) : (
+                <p className="text-muted-foreground text-xs">
+                  Helps the organizer find you faster. Leave blank if unsure.
+                </p>
+              )}
             </div>
 
             <div className="space-y-1.5">


### PR DESCRIPTION
UI-only pass over the roster claim flow, from the screenshots.

## Dancer side (`no-access.tsx`)

- Shortened the "No event access" description and removed the em dash.
- The optional registration email field now uses a plain `Email` placeholder.
- Added client-side email validation: a malformed address sets `aria-invalid`, swaps the helper text for an error, and blocks submit. Empty is still allowed, the field is optional.

## Admin Roster Requests page

- Removed the verbose intro paragraph.
- The request list now runs full width.
- Rebuilt the request card: it was four stacked bands, it is now a single row (avatar + requester with email and time on one line, `Registered as` name · email in the middle, actions right-aligned). The `Registered as` label went from washed-out muted to `text-foreground`, and the note only wraps below when present.
- Dismiss now opens an AlertDialog confirmation instead of firing immediately.

## Reassign confirmation dialog

- Replaced the prose paragraph with a From → To block; each side shows both the name and the email.
- The red warning now has bottom spacing so it no longer touches the footer, and it describes the consequence (unregisters the account, drops its callbacks) rather than the parent scenario.

## Wording

Gender-neutral throughout the feature, in the UI copy and in the backend/query comments.

## Verification

`tsc --noEmit` passes. No new lint errors; the two `any` warnings in `admin-sidebar.tsx` are pre-existing. Prettier reformatted a few unrelated lines in `admin-sidebar.tsx` as a side effect.

Not verified in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)