### PR TITLE
fix(scouting): collapse a dancer's unclaimed past-event rows in the coach list

### DIFF
--- a/apps/backend/app/modules/orgs/scouting/dancers/list/service.spec.ts
+++ b/apps/backend/app/modules/orgs/scouting/dancers/list/service.spec.ts
@@ -349,4 +349,154 @@ test.group("ListDancersService", (group) => {
     assert.equal(all.length, 1);
     assert.equal(all[0]!.rosterId, activeRoster!.id);
   });
+
+  test("keeps distinct unclaimed dancers apart across events", async ({
+    assert,
+  }) => {
+    const [pastEvent] = await db
+      .insert(orgEvents)
+      .values({
+        orgId: summit.id,
+        name: "Summit 2025",
+        startDate: "2025-06-13",
+        endDate: "2025-06-14",
+        isActive: false,
+      })
+      .returning();
+
+    await db.insert(eventRosters).values([
+      {
+        eventId: pastEvent!.id,
+        type: "dancer",
+        email: "one@x.co",
+        firstName: "One",
+        lastName: "Dancer",
+        bibNumber: 12,
+      },
+      {
+        eventId: event.id,
+        type: "dancer",
+        email: "two@x.co",
+        firstName: "Two",
+        lastName: "Dancer",
+        bibNumber: 14,
+      },
+    ]);
+
+    const svc = new ListDancersService();
+    const all = await svc.execute(summit.id, event.id, null, {});
+    assert.equal(all.length, 2);
+  });
+
+  test("hides the bib of a dancer who is not on the active event", async ({
+    assert,
+  }) => {
+    const [pastEvent] = await db
+      .insert(orgEvents)
+      .values({
+        orgId: summit.id,
+        name: "Summit 2025",
+        startDate: "2025-06-13",
+        endDate: "2025-06-14",
+        isActive: false,
+      })
+      .returning();
+
+    await db.insert(eventRosters).values([
+      {
+        eventId: pastEvent!.id,
+        type: "dancer",
+        email: "gone@x.co",
+        firstName: "Gone",
+        lastName: "Dancer",
+        bibNumber: 12,
+      },
+      {
+        eventId: event.id,
+        type: "dancer",
+        email: "here@x.co",
+        firstName: "Here",
+        lastName: "Dancer",
+        bibNumber: 300,
+      },
+    ]);
+
+    const svc = new ListDancersService();
+    const all = await svc.execute(summit.id, event.id, null, {});
+    const gone = all.find((r) => r.lastName === "Dancer" && !r.bibNumber);
+    const here = all.find((r) => r.firstName === "Here");
+    assert.equal(here!.bibNumber, 300);
+    assert.isNotNull(gone);
+    assert.isNull(gone!.bibNumber);
+
+    // Browsing that past event directly still shows the bib it issued.
+    const pastOnly = await svc.execute(
+      summit.id,
+      event.id,
+      null,
+      {},
+      false,
+      undefined,
+      pastEvent!.id
+    );
+    assert.equal(pastOnly[0]!.bibNumber, 12);
+  });
+  test("dedupes an unclaimed past-event row against the dancer's claimed row", async ({
+    assert,
+  }) => {
+    const [abbey] = await db
+      .insert(users)
+      .values({
+        username: "abbey",
+        email: "abbey@x.co",
+        displayEmail: "abbey@x.co",
+        firstName: "Abbey",
+        lastName: "Nugent",
+        password: "x",
+        role: "user",
+        type: "dancer",
+        verified: true,
+      })
+      .returning();
+
+    const [pastEvent] = await db
+      .insert(orgEvents)
+      .values({
+        orgId: summit.id,
+        name: "Summit 2025",
+        startDate: "2025-06-13",
+        endDate: "2025-06-14",
+        isActive: false,
+      })
+      .returning();
+
+    // The past-event row was never claimed, so it holds no userId — only the
+    // email ties it back to the dancer's row on the active event.
+    await db.insert(eventRosters).values({
+      eventId: pastEvent!.id,
+      type: "dancer",
+      email: "Abbey@X.co",
+      firstName: "Abbey",
+      lastName: "Nugent",
+      bibNumber: 12,
+    });
+    const [activeRoster] = await db
+      .insert(eventRosters)
+      .values({
+        eventId: event.id,
+        type: "dancer",
+        email: "abbey@x.co",
+        firstName: "Abbey",
+        lastName: "Nugent",
+        bibNumber: 200,
+        userId: abbey!.id,
+      })
+      .returning();
+
+    const svc = new ListDancersService();
+    const all = await svc.execute(summit.id, event.id, null, {});
+    assert.equal(all.length, 1);
+    assert.equal(all[0]!.rosterId, activeRoster!.id);
+    assert.equal(all[0]!.bibNumber, 200);
+  });
 });

--- a/apps/backend/app/modules/orgs/scouting/dancers/list/service.ts
+++ b/apps/backend/app/modules/orgs/scouting/dancers/list/service.ts
@@ -143,6 +143,7 @@ export class ListDancersService {
           isCalledBack: isCalledBackSubquery,
           username: users.username,
           userId: eventRosters.userId,
+          email: eventRosters.email,
           eventId: eventRosters.eventId,
           createdAt: eventRosters.createdAt,
         })
@@ -161,16 +162,20 @@ export class ListDancersService {
     });
 
     // Across all of the org's events the same dancer can hold a roster row per
-    // event. Collapse to one row per dancer — keyed by their account when
-    // registered, otherwise left distinct — preferring the active event's row
-    // so the coach's favorites/ratings/callbacks stay wired to it.
+    // event. Collapse to one row per dancer — keyed by their account, falling
+    // back to email for rows no one has claimed — preferring the active event's
+    // row so the coach's favorites/ratings/callbacks stay wired to it.
     const deduped = selectedEventId
       ? rows
       : this.dedupeByDancer(rows, activeEventId);
 
     return deduped.map((row) => ({
       rosterId: row.rosterId,
-      bibNumber: row.bibNumber,
+      // A bib only identifies a dancer at the event that issued it. When the
+      // coach browses the org's history, a dancer who is not on the active
+      // event's roster is shown without one rather than under a stale number.
+      bibNumber:
+        selectedEventId || row.eventId === activeEventId ? row.bibNumber : null,
       firstName: row.firstName,
       lastName: row.lastName,
       isRegistered: row.isRegistered,
@@ -194,13 +199,24 @@ export class ListDancersService {
       rosterId: string;
       bibNumber: number | null;
       userId: string | null;
+      email: string | null;
       eventId: string;
       createdAt: Date | null;
     },
   >(rows: T[], activeEventId: string | null): T[] {
+    // An older event's row for the same person is often still unclaimed, so it
+    // carries no account to match on. Email is the only identity those rows
+    // share with the claimed row, and rosters are unique by email per event.
+    const accountByEmail = new Map<string, string>();
+    for (const row of rows) {
+      const email = this.normalizeEmail(row.email);
+      if (!email || !row.userId || accountByEmail.has(email)) continue;
+      accountByEmail.set(email, row.userId);
+    }
+
     const byDancer = new Map<string, T>();
     for (const row of rows) {
-      const key = row.userId ?? `roster:${row.rosterId}`;
+      const key = this.dancerKey(row, accountByEmail);
       const current = byDancer.get(key);
       if (!current || this.isBetterRow(row, current, activeEventId)) {
         byDancer.set(key, row);
@@ -209,6 +225,21 @@ export class ListDancersService {
     return [...byDancer.values()].sort(
       (a, b) => (a.bibNumber ?? Infinity) - (b.bibNumber ?? Infinity)
     );
+  }
+
+  private dancerKey(
+    row: { rosterId: string; userId: string | null; email: string | null },
+    accountByEmail: Map<string, string>
+  ) {
+    if (row.userId) return `user:${row.userId}`;
+    const email = this.normalizeEmail(row.email);
+    if (!email) return `roster:${row.rosterId}`;
+    const account = accountByEmail.get(email);
+    return account ? `user:${account}` : `email:${email}`;
+  }
+
+  private normalizeEmail(email: string | null) {
+    return email?.trim().toLowerCase() || null;
   }
 
   private isBetterRow(


### PR DESCRIPTION
## The bug

Dancers deleted from the admin roster kept showing up in the coach view (bibs #12 and #14 in the report).

They were never undeleted rows. The coach dancer list deliberately spans **every event the org has run** (`scouting/dancers/list/service.ts`), while the admin dancers page and the roster delete are both scoped to a single `eventId`. So #12/#14 were live rows on another event — visible in the coach's cross-event view, untouchable from the active event's admin page. The reporter's screenshot confirms it: those two rows render with no heart / Call / + controls, which the frontend only does when `dancer.eventId !== myRoster.eventId`.

The list already had a dedupe meant to collapse one dancer's rows across events, but it keyed only on `userId`. An older event's row is usually still unclaimed and carries no account, so it never merged — Abbey Nugent appeared three times, and a dancer removed from the active event still sat in the list under their old bib.

## The fix

- **Dedupe by email as well as account.** Unclaimed rows match to the dancer's claimed row by normalized email (rosters are already unique by email per event). The active event's row still wins, so the coach's favorites / ratings / callbacks stay wired to the right roster id.
- **Bibs are event-scoped.** In the cross-event view a row shows a bib only if it belongs to the active event; a dancer not on the active roster shows `—`. Selecting a specific past event from the dropdown still shows that event's bibs.

No frontend change needed — the table already types `bibNumber` as nullable and renders null as `—`.

Result for the reported org: 122, 125, 126, 200, 220, 230 (6 registered), with #12 folded into Abbey's row and #14 into Juna's.

## Verification

- Three new tests in `service.spec.ts`. The dedupe test fails on the old code (`expected 2 to equal 1`) and passes on the new code.
- `pnpm typecheck` and `eslint` clean.
- Full backend suite: 311 passed / 12 failed — **the same 12 failures as the untouched baseline** (failing test names diffed against a baseline run).

## Notes for the reviewer

- Those 12 baseline failures are pre-existing order-dependence in unrelated specs (`roster-claims` does `select users limit 1` without seeding a user, so it depends on leftovers from whichever spec ran before it). The new tests are ordered around that fragility rather than fixing it — out of scope here, but worth its own issue.
- A dancer who exists **only** in a past event still appears in the coach's "All events" view by design, now without a bib. Easy to hide entirely if that's preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
