### PR TITLE
fix(roster-claims): tighten the roster request UI and sidebar borders

### DIFF
--- a/apps/frontend/src/features/org/components/admin-sidebar.tsx
+++ b/apps/frontend/src/features/org/components/admin-sidebar.tsx
@@ -269,8 +269,9 @@ export function AdminSidebar() {
                     className={`border-sidebar-border border-t ${section.items.length > 1 ? "grid grid-cols-2" : ""}`}
                   >
                     {section.items.map(
-                      ({ label, icon: Icon, to, fullWidth }) => {
+                      ({ label, icon: Icon, to, fullWidth }, index) => {
                         const isActive = isItemActive(to);
+                        const inFirstRow = index < 2;
                         return (
                           <Link
                             key={label}
@@ -283,7 +284,11 @@ export function AdminSidebar() {
                             } ${
                               isActive
                                 ? "border-t-primary text-primary bg-sidebar-accent/40"
-                                : "text-sidebar-foreground hover:bg-sidebar-accent/20 border-t-transparent"
+                                : `text-sidebar-foreground hover:bg-sidebar-accent/20 ${
+                                    inFirstRow
+                                      ? "border-t-transparent"
+                                      : "border-t-sidebar-border"
+                                  }`
                             }`}
                           >
                             <Icon


### PR DESCRIPTION
## Summary

Polish pass on the roster-claims feature plus a sidebar border fix.

- **No-access page**: trimmed copy, simplified the optional email field to a plain "Email" placeholder, and validate it client-side so a malformed address blocks submit instead of failing server-side.
- **Admin Roster Requests page**: dropped the intro paragraph, let the list run full width, and collapsed the request card from four stacked bands into a single row with legible labels. Dismiss now asks for confirmation.
- **Reassign confirmation**: shows the change as a From → To block, each side carrying name and email; the warning has bottom spacing so it no longer touches the footer.
- **Copy**: gender neutral wording across the feature, UI and backend comments.
- **Admin sidebar**: the nav grid draws its 1px rule on the container, so only the first row had a line above it — items carry `border-t-2 border-t-transparent` so the active state can swap it to primary. "Requests" wraps onto a second row and had nothing above it. Inactive items past the first row now use `border-t-sidebar-border`, so the second row gets its divider while the active indicator still wins.

## Test plan

- `pnpm exec tsc --noEmit` in `apps/frontend` passes.
- Visually check the admin sidebar: Requests now has a top border, and the active-item primary indicator is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)