### PR TITLE
docs: domain glossary and S2S Live billing ADRs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,76 @@
+# Studio 2 Stadium
+
+The collegiate dance recruiting platform. This repo is the public marketing site and schools
+directory; the product itself lives in the `app` repo. The glossary below is shared by both.
+
+## Language
+
+### Organisations and events
+
+**Org**:
+A tenant on the S2S Live platform — the party that hosts live recruiting events. Owns its own
+branding, members, and events, and reaches them at `/o/{slug}`.
+_Avoid_: Organisation, tenant, account, client, host
+
+**Org Event**:
+A single live, in-person recruiting occasion — an audition, tryout, showcase, or combine — owned by
+one Org and sold individually. An Org may own many, but only one is active at a time.
+_Avoid_: Event on its own, which is ambiguous — see Platform Event.
+
+**Platform Event**:
+A public, school-hosted or global event browsed in the main S2S app. A different concept from an Org
+Event and a different set of tables; the two are never mixed.
+
+**Tier**:
+The bundle of features and limits bought for one Org Event — Core, Regional, National, or
+Enterprise. What is sold and what is enforced are the same thing.
+_Avoid_: Plan, package, subscription — nothing here recurs.
+
+### People
+
+**Dancer**:
+A high-school-age person pursuing a place on a collegiate dance program. The persistent identity: a
+Dancer stays a Dancer whether or not they are attending an Org Event.
+_Avoid_: Athlete, talent, performer, participant
+
+**Coach**:
+A member of a college dance program's staff, verified by the Studio 2 Stadium team before being
+granted access to Dancer profiles. Attends Org Events to evaluate Dancers.
+_Avoid_: Recruiter, scout, evaluator
+
+**Organizer**:
+The person who runs an Org's events and buys S2S Live. Never appears on a Roster and never evaluates
+Dancers — the distinction from a Coach is that an Organizer runs the event rather than recruiting at
+it.
+_Avoid_: Host, promoter, event manager
+
+**Roster Entry**:
+One person's participation in one Org Event. Roster Entries exist for both Dancers and Coaches, and
+all event activity — notes, ratings, callbacks, school selections — is recorded against them rather
+than against the person.
+_Avoid_: Attendee, participant, registration
+
+### Things
+
+**Profile**:
+A Dancer's portfolio on the platform. There is one Profile per Dancer; an Org Event surfaces that
+same Profile rather than creating a second one.
+_Avoid_: Event profile, performer profile, recruiting profile
+
+**Claim**:
+The act of a Roster Entry being connected to a real user account, turning a name on an uploaded
+roster into a person with a Profile.
+_Avoid_: Activation, merge, linking
+
+**Reconciliation**:
+The admin process of resolving Roster Entries against user accounts — resending, revoking, and
+merging invites until every entry is either claimed or dismissed.
+
+**Verification**:
+The manual review by the Studio 2 Stadium team confirming a Coach's credentials, which unlocks
+access to Dancer profiles.
+_Avoid_: Approval, which refers to Schools appearing in the public directory — a different check.
+
+**Premium Grant**:
+Time-limited premium access given to a Dancer because of something they took part in, such as an Org
+Event. Expires; not a purchase the Dancer made.

--- a/docs/adr/0001-sell-org-events-not-subscriptions.md
+++ b/docs/adr/0001-sell-org-events-not-subscriptions.md
@@ -1,0 +1,15 @@
+# S2S Live sells Org Events, not Org subscriptions
+
+S2S Live is priced per event (Core $2,000, Regional $3,000, National $4,200, Enterprise custom), but
+the entity a purchase must create is an Org, which owns many events. We sell one Org Event per
+checkout: the first purchase also creates the Org and makes the buyer its admin, and later purchases
+add further Org Events to the Org that already exists.
+
+We rejected an Org-level subscription. It would have reused the dancer subscription machinery almost
+unchanged, but it contradicts every price on the marketing page and does not match how an event
+organizer budgets — they approve spend per event, not per year.
+
+## Consequences
+
+Nothing about an Org recurs, so an Org with no purchased events is a real and valid state. Anything
+that needs to know whether a customer is "paying" must ask about an Org Event, never about the Org.

--- a/docs/adr/0002-tier-entitlement-lives-on-the-event.md
+++ b/docs/adr/0002-tier-entitlement-lives-on-the-event.md
@@ -1,0 +1,18 @@
+# Tier entitlement lives on the Org Event
+
+Feature flags are org-level today: `organizations.features` is untyped `jsonb`, read through
+`useOrg()` and enforced in route `beforeLoad` guards. Because a Tier is bought per Org Event, we put
+the purchased Tier on `org_events` and resolve entitlement from the active event, leaving
+`organizations.features` for genuine org-wide configuration such as branding and free-tier settings.
+
+Keeping entitlement org-level was cheaper — no migration, no guard rewrite — but an Org buying Core
+for its spring showcase and National for its summer combine would silently get National features at
+both. Whatever we sell and whatever we enforce have to be the same thing, or we can never sell the
+same upgrade twice.
+
+## Consequences
+
+The route guards that currently read `features.callbacks`, `features.check_in`,
+`features.school_selections`, and `features.video_library` from `useOrg()` must move to the active
+Org Event. Every Org Event existing at migration time is grandfathered at Enterprise so that no
+current customer loses access.

--- a/docs/adr/0003-organizer-is-a-distinct-member-type.md
+++ b/docs/adr/0003-organizer-is-a-distinct-member-type.md
@@ -1,0 +1,15 @@
+# Organizer is a distinct org member type
+
+`org_member_type` is `["coach", "dancer"]`, and the same enum is used for both org memberships and
+event roster entries. The person who buys S2S Live runs the event: they never appear on a roster and
+never evaluate dancers. We add `organizer` to the enum rather than filing them as a coach with
+`role = "admin"`.
+
+Reusing `coach` needed no migration, but organizers would then appear wherever coaches are listed,
+and `coach` would stop meaning "college dance program staff" — a term both products and the public
+site depend on.
+
+## Consequences
+
+Every switch on `org_member_type` needs auditing, including roster code that reasonably assumes an
+entry is a coach or a dancer. Organizer memberships must never produce a Roster Entry.

--- a/docs/adr/0004-buyers-authenticate-before-paying.md
+++ b/docs/adr/0004-buyers-authenticate-before-paying.md
@@ -1,0 +1,14 @@
+# Buyers create an account before checkout
+
+`org_memberships` requires a `userId`, and `add-org-member` hard-fails when no user matches the
+given email. The pre-checkout form therefore ends in account creation, and the Checkout Session
+carries a real `userId` in its metadata.
+
+The alternative — creating the user from the Stripe billing email in the webhook — removes a step
+before a $2,000 purchase, but the billing email on a corporate card is frequently not the buyer's
+working address, which produces provisioned orgs that nobody can log into.
+
+## Consequences
+
+Provisioning never matches on email, so it cannot orphan an Org. The cost is a signup step in front
+of the purchase, which will show up in conversion on the `/s2s-live` funnel.

--- a/docs/adr/0005-refunds-deactivate-rather-than-revoke.md
+++ b/docs/adr/0005-refunds-deactivate-rather-than-revoke.md
@@ -1,0 +1,15 @@
+# A refunded Org Event is deactivated, not revoked
+
+Provisioning is automatic, so the reverse case needs an answer. By the time a refund or chargeback
+arrives, the Org may have uploaded a roster of real dancers and coaches may have recorded notes,
+ratings, and callbacks against them. A refund therefore sets the Org Event inactive and notifies the
+Studio 2 Stadium team; it does not delete the event, its roster, or any Premium Grants already given
+to dancers.
+
+Automatic teardown was rejected because a chargeback landing mid-event would break a live audition,
+and dancers would lose granted premium over a dispute they are not party to.
+
+## Consequences
+
+This is deliberately not full automation: a refund during a live event needs a human. Resolution
+happens in Stripe and the admin dashboard, as a conversation with the customer.

--- a/docs/adr/0006-existing-events-grandfathered-at-enterprise.md
+++ b/docs/adr/0006-existing-events-grandfathered-at-enterprise.md
@@ -1,0 +1,15 @@
+# Orgs that predate billing are grandfathered at Enterprise
+
+Moving tier entitlement onto `org_events` has to account for orgs created by hand, whose access
+comes from flag combinations on `organizations.features` that need not match any tier we sell. Every
+Org Event existing at migration time is stamped Enterprise.
+
+Deriving each org's nearest tier would have kept the commercial door open, but these are our earliest
+customers and hand-built accounts; a mapping bug would revoke access from someone mid-season. We took
+the migration we cannot get wrong.
+
+## Consequences
+
+Pre-billing customers sit permanently at the top tier and cannot be sold an upgrade. Their events
+must be treated as a closed grandfathered set — moving them onto paid tiers later is a commercial
+conversation, not a migration.


### PR DESCRIPTION
Docs only — no code, no migrations. Records the decisions from a grilling session on automating S2S Live org provisioning with Stripe, which today is a manual `admin/create-org` + `add-org-member` process.

## CONTEXT.md

One glossary, shared with the marketing repo. It settles two things the code and the marketing copy disagreed on:

- The site says *dancer* and *coach*; the S2S Live page says *performer* and *recruiter* while shipping a feature called "Coach Notes". **Dancer** and **Coach** are the persistent identities.
- **Roster Entry** is the participation concept — which is what `event_rosters` already models, since `coachRosterId` and `dancerRosterId` both point at it.

It also separates **Org Event** from **Platform Event**, the naming collision `ORG_EVENTS_REFERENCE.md` warns about.

## ADRs

| # | Decision |
|---|---|
| 0001 | Checkout sells one **Org Event**, not an org subscription. First purchase also creates the Org. Nothing recurs. |
| 0002 | Tier entitlement moves from `organizations.features` onto `org_events`; `organizations.features` keeps only org-wide config. |
| 0003 | `organizer` joins `org_member_type`, so buyers aren't filed as coaches. |
| 0004 | Buyers authenticate before checkout, so provisioning carries a real `userId` and never matches on a billing email. |
| 0005 | A refunded Org Event is deactivated and flagged for a human, not torn down. |
| 0006 | Orgs predating billing are grandfathered at Enterprise. |

## What these imply for later work

- **0002 is the largest.** The guards reading `features.callbacks`, `features.check_in`, `features.school_selections`, and `features.video_library` from `useOrg()` move to the active Org Event. 0006 is what makes that migration safe.
- **0003 needs an audit** of every switch on `org_member_type`, including roster code that assumes an entry is a coach or a dancer. Organizer memberships must never produce a Roster Entry.
- **0004 needs an invite or signup path** — `add-org-member` currently hard-fails when no user matches the email.

The two ADRs about the marketing site's side of this (backend owns Stripe; provisioning inputs collected before checkout) are in the marketing repo on `s2s-live`, along with a copy of `CONTEXT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)