### PR TITLE
docs: split Event Tier from Account Tier in the glossary

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -21,10 +21,16 @@ _Avoid_: Event on its own, which is ambiguous — see Platform Event.
 A public, school-hosted or global event browsed in the main S2S app. A different concept from an Org
 Event and a different set of tables; the two are never mixed.
 
-**Tier**:
+**Event Tier**:
 The bundle of features and limits bought for one Org Event — Core, Regional, National, or
 Enterprise. What is sold and what is enforced are the same thing.
-_Avoid_: Plan, package, subscription — nothing here recurs.
+_Avoid_: Plan, package, subscription — nothing here recurs. Never bare "tier", which is ambiguous
+with Account Tier.
+
+**Account Tier**:
+The level of platform access a Dancer's account holds — standard or limited. An Org Event grants one
+for a window the Org configures, after which it lapses unless the Dancer subscribes.
+_Avoid_: Bare "tier"; premium, which is the Dancer's own paid subscription rather than a grant.
 
 ### People
 
@@ -72,5 +78,5 @@ access to Dancer profiles.
 _Avoid_: Approval, which refers to Schools appearing in the public directory — a different check.
 
 **Premium Grant**:
-Time-limited premium access given to a Dancer because of something they took part in, such as an Org
-Event. Expires; not a purchase the Dancer made.
+The record of an Account Tier being given to a Dancer because of something they took part in, such
+as an Org Event. Expires; not a purchase the Dancer made.

--- a/docs/adr/0002-tier-entitlement-lives-on-the-event.md
+++ b/docs/adr/0002-tier-entitlement-lives-on-the-event.md
@@ -1,8 +1,8 @@
 # Tier entitlement lives on the Org Event
 
 Feature flags are org-level today: `organizations.features` is untyped `jsonb`, read through
-`useOrg()` and enforced in route `beforeLoad` guards. Because a Tier is bought per Org Event, we put
-the purchased Tier on `org_events` and resolve entitlement from the active event, leaving
+`useOrg()` and enforced in route `beforeLoad` guards. Because an Event Tier is bought per Org Event, we put
+the purchased Event Tier on `org_events` and resolve entitlement from the active event, leaving
 `organizations.features` for genuine org-wide configuration such as branding and free-tier settings.
 
 Keeping entitlement org-level was cheaper — no migration, no guard rewrite — but an Org buying Core

--- a/docs/adr/0006-existing-events-grandfathered-at-enterprise.md
+++ b/docs/adr/0006-existing-events-grandfathered-at-enterprise.md
@@ -1,15 +1,15 @@
 # Orgs that predate billing are grandfathered at Enterprise
 
 Moving tier entitlement onto `org_events` has to account for orgs created by hand, whose access
-comes from flag combinations on `organizations.features` that need not match any tier we sell. Every
-Org Event existing at migration time is stamped Enterprise.
+comes from flag combinations on `organizations.features` that need not match any Event Tier we sell. Every
+Org Event existing at migration time is stamped with the Enterprise Event Tier.
 
-Deriving each org's nearest tier would have kept the commercial door open, but these are our earliest
+Deriving each org's nearest Event Tier would have kept the commercial door open, but these are our earliest
 customers and hand-built accounts; a mapping bug would revoke access from someone mid-season. We took
 the migration we cannot get wrong.
 
 ## Consequences
 
-Pre-billing customers sit permanently at the top tier and cannot be sold an upgrade. Their events
-must be treated as a closed grandfathered set — moving them onto paid tiers later is a commercial
+Pre-billing customers sit permanently at the top Event Tier and cannot be sold an upgrade. Their events
+must be treated as a closed grandfathered set — moving them onto paid Event Tiers later is a commercial
 conversation, not a migration.


### PR DESCRIPTION
Docs only. This commit was pushed to `docs/s2s-live-billing-adrs` after #83 had already merged, so it was stranded on that branch.

**Merge this promptly** — issue #85 is in flight and tells its agent that "tier" is ambiguous and to consult `CONTEXT.md`, but `CONTEXT.md` on `main` still defines a bare **Tier**.

`grantOrgAccountTier` already uses "tier" for a Dancer's account access level, granted by attending an event and expiring after `tierExpiryMonths`. The glossary was using the same word for the Core/Regional/National purchase.

- **Event Tier** — what an Organizer buys for one Org Event
- **Account Tier** — what a Dancer receives, a name the code had already chosen in `grantOrgAccountTier` and `GrantedOrgTier`

Bare "tier" is now ambiguous and should not appear in new code or copy. ADRs 0002 and 0006 are updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)