### PR TITLE
feat(orgs): add organizer as a distinct org member type

### DIFF
--- a/ORG_EVENTS_REFERENCE.md
+++ b/ORG_EVENTS_REFERENCE.md
@@ -268,6 +268,23 @@ Backfill: `node ace backfill:staff-rosters` flags pre-existing admin-attended ro
 Two role systems: platform `role` (`admin`/`prodigy_admin`/`user`) on `users`; org `orgRole`
 (`admin`/`member`) on `org_memberships`.
 
+### Org member types vs roster types (`organizer`)
+`org_member_type` is `coach`|`dancer`|`organizer`, but only `coach`|`dancer` can appear on a
+Roster. `event_rosters.type` and `csv_uploads.type` are typed `RosterType` in TypeScript and carry
+a `... type in ('coach','dancer')` CHECK, so an Organizer can never become a Roster Entry
+(ADR 0003). Predicates are written positively rather than as `<> 'organizer'` — the DDL must not
+name a label added in the same migration, and a member type added later then stays out of rosters
+until someone decides otherwise.
+
+An Organizer administers the org by definition, whatever `org_memberships.role` says: use
+`grantsOrgAdmin()` (`#shared/org/membership`, mirrored in `@/lib/access`) rather than comparing
+`role === "admin"` by hand. Coach and dancer remain mutually exclusive per person per org
+(`org_memberships_user_id_org_id_index`, now partial), but an organizer membership sits alongside
+them — someone who runs an event may also coach at it. That means a user can hold **more than one**
+membership row per org: read them all and collapse with `resolveEffectiveMembership()`, and use
+`hasMemberType()` for "is this person a coach here?" checks. Participant upserts must pass
+`nonOrganizerMembershipConflict()` so Postgres infers the partial index.
+
 **View-as flow (how staff rosters get created):** admin picks "Coach/Dancer" in the
 `ViewSwitcher` → `POST :slug/events/view-as { type }` (`modules/orgs/events/view-as/`, admin-only)
 upserts their `is_staff` roster. `OrgEventMiddleware` resolves `ctx.orgRoster` using the

--- a/ORG_EVENTS_REFERENCE.md
+++ b/ORG_EVENTS_REFERENCE.md
@@ -292,6 +292,13 @@ membership row per org: read them all and collapse with `resolveEffectiveMembers
 `rosterTypeMembershipConflict()` so Postgres infers the partial index. Load memberships with
 `loadOrgMemberships()` rather than a hand-rolled `.limit(1)` lookup.
 
+Reclassifying pre-ADR-0003 data: `node ace backfill:organizers` (dry run by default,
+`--no-dry-run` to apply, `--org=slug` to scope). It only flips admin coach memberships whose owner
+holds **no** real Roster Entry. Someone with a roster row genuinely coached, and flipping them
+would leave that row — and so their place in every coach-facing list, which reads `event_rosters`
+and never `org_memberships` — while removing the coach membership that explains it. Those are
+reported for a human to give an organizer membership *alongside* the coach one.
+
 **View-as flow (how staff rosters get created):** admin picks "Coach/Dancer" in the
 `ViewSwitcher` → `POST :slug/events/view-as { type }` (`modules/orgs/events/view-as/`, admin-only)
 upserts their `is_staff` roster. `OrgEventMiddleware` resolves `ctx.orgRoster` using the

--- a/ORG_EVENTS_REFERENCE.md
+++ b/ORG_EVENTS_REFERENCE.md
@@ -271,10 +271,14 @@ Two role systems: platform `role` (`admin`/`prodigy_admin`/`user`) on `users`; o
 ### Org member types vs roster types (`organizer`)
 `org_member_type` is `coach`|`dancer`|`organizer`, but only `coach`|`dancer` can appear on a
 Roster. `event_rosters.type` and `csv_uploads.type` are typed `RosterType` in TypeScript and carry
-a `... type in ('coach','dancer')` CHECK, so an Organizer can never become a Roster Entry
-(ADR 0003). Predicates are written positively rather than as `<> 'organizer'` — the DDL must not
-name a label added in the same migration, and a member type added later then stays out of rosters
-until someone decides otherwise.
+the `event_rosters_roster_type` / `csv_uploads_roster_type` CHECKs, so an Organizer can never
+become a Roster Entry (ADR 0003). All of these predicates come from one fragment,
+`isRosterTypeSql()` in `schema/enums.ts` — the CHECKs, the membership partial index, and the
+ON CONFLICT `where` must stay identical or Postgres stops inferring the index. It is written
+positively (`type in ('coach','dancer')`) rather than as `<> 'organizer'`: DDL may not name a
+label added in the same migration, and a member type added later then stays out of rosters until
+someone decides otherwise. `org_memberships_organizer_per_user_per_org` is the one place the
+negative form (`isNotRosterTypeSql()`) is unavoidable.
 
 An Organizer administers the org by definition, whatever `org_memberships.role` says: use
 `grantsOrgAdmin()` (`#shared/org/membership`, mirrored in `@/lib/access`) rather than comparing
@@ -283,7 +287,8 @@ An Organizer administers the org by definition, whatever `org_memberships.role` 
 them — someone who runs an event may also coach at it. That means a user can hold **more than one**
 membership row per org: read them all and collapse with `resolveEffectiveMembership()`, and use
 `hasMemberType()` for "is this person a coach here?" checks. Participant upserts must pass
-`nonOrganizerMembershipConflict()` so Postgres infers the partial index.
+`rosterTypeMembershipConflict()` so Postgres infers the partial index. Load memberships with
+`loadOrgMemberships()` rather than a hand-rolled `.limit(1)` lookup.
 
 **View-as flow (how staff rosters get created):** admin picks "Coach/Dancer" in the
 `ViewSwitcher` → `POST :slug/events/view-as { type }` (`modules/orgs/events/view-as/`, admin-only)

--- a/ORG_EVENTS_REFERENCE.md
+++ b/ORG_EVENTS_REFERENCE.md
@@ -278,7 +278,9 @@ ON CONFLICT `where` must stay identical or Postgres stops inferring the index. I
 positively (`type in ('coach','dancer')`) rather than as `<> 'organizer'`: DDL may not name a
 label added in the same migration, and a member type added later then stays out of rosters until
 someone decides otherwise. `org_memberships_organizer_per_user_per_org` is the one place the
-negative form (`isNotRosterTypeSql()`) is unavoidable.
+negative form (`isNotRosterTypeSql()`) is unavoidable — which means a fourth member type added
+later would share the organizer's uniqueness slot. Adding one? Split that index first
+(`where type = 'organizer'` is safe in any migration after the label is committed).
 
 An Organizer administers the org by definition, whatever `org_memberships.role` says: use
 `grantsOrgAdmin()` (`#shared/org/membership`, mirrored in `@/lib/access`) rather than comparing

--- a/apps/backend/app/database/drizzle/20260824164210_same_darkhawk/migration.sql
+++ b/apps/backend/app/database/drizzle/20260824164210_same_darkhawk/migration.sql
@@ -1,0 +1,6 @@
+ALTER TYPE "org_member_type" ADD VALUE 'organizer';--> statement-breakpoint
+DROP INDEX "org_memberships_user_id_org_id_index";--> statement-breakpoint
+CREATE UNIQUE INDEX "org_memberships_user_id_org_id_index" ON "org_memberships" ("user_id","org_id") WHERE type in ('coach', 'dancer');--> statement-breakpoint
+CREATE UNIQUE INDEX "org_memberships_one_organizer_per_org" ON "org_memberships" ("user_id","org_id") WHERE type not in ('coach', 'dancer');--> statement-breakpoint
+ALTER TABLE "csv_uploads" ADD CONSTRAINT "csv_uploads_participant_type" CHECK (type in ('coach', 'dancer'));--> statement-breakpoint
+ALTER TABLE "event_rosters" ADD CONSTRAINT "event_rosters_participant_type" CHECK (type in ('coach', 'dancer'));

--- a/apps/backend/app/database/drizzle/20260824164210_same_darkhawk/migration.sql
+++ b/apps/backend/app/database/drizzle/20260824164210_same_darkhawk/migration.sql
@@ -1,6 +1,0 @@
-ALTER TYPE "org_member_type" ADD VALUE 'organizer';--> statement-breakpoint
-DROP INDEX "org_memberships_user_id_org_id_index";--> statement-breakpoint
-CREATE UNIQUE INDEX "org_memberships_user_id_org_id_index" ON "org_memberships" ("user_id","org_id") WHERE type in ('coach', 'dancer');--> statement-breakpoint
-CREATE UNIQUE INDEX "org_memberships_one_organizer_per_org" ON "org_memberships" ("user_id","org_id") WHERE type not in ('coach', 'dancer');--> statement-breakpoint
-ALTER TABLE "csv_uploads" ADD CONSTRAINT "csv_uploads_participant_type" CHECK (type in ('coach', 'dancer'));--> statement-breakpoint
-ALTER TABLE "event_rosters" ADD CONSTRAINT "event_rosters_participant_type" CHECK (type in ('coach', 'dancer'));

--- a/apps/backend/app/database/drizzle/20260824164210_same_darkhawk/snapshot.json
+++ b/apps/backend/app/database/drizzle/20260824164210_same_darkhawk/snapshot.json
@@ -1,0 +1,12021 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "fa0ab202-713c-47bf-8a56-5194cd0a462b",
+  "prevIds": [
+    "5bccd7e0-87f6-425b-9afd-d5e5466ea8f1"
+  ],
+  "ddl": [
+    {
+      "values": [
+        "dancer",
+        "school"
+      ],
+      "name": "account_type",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "upload",
+        "create",
+        "update",
+        "delete",
+        "activate",
+        "resend_invite"
+      ],
+      "name": "audit_action",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "roster",
+        "event",
+        "checklist",
+        "csv_upload",
+        "invite",
+        "video_category",
+        "video"
+      ],
+      "name": "audit_resource",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "uda",
+        "dtu",
+        "nda",
+        "usa",
+        "non-competitive",
+        "other"
+      ],
+      "name": "competitive_circuit_type",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "added",
+        "updated"
+      ],
+      "name": "csv_row_outcome",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "audition",
+        "rehearsal",
+        "recital",
+        "showcase",
+        "competition",
+        "class",
+        "intensive",
+        "workshop",
+        "fundraiser",
+        "combine",
+        "convention",
+        "clinic",
+        "deadline",
+        "recruitment",
+        "performance",
+        "camp",
+        "other"
+      ],
+      "name": "dance_event_type",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "image",
+        "video",
+        "profile",
+        "reference",
+        "achievement"
+      ],
+      "name": "feed_item_type",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "image",
+        "video"
+      ],
+      "name": "media_type",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "standard",
+        "limited"
+      ],
+      "name": "org_account_tier",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "coach",
+        "dancer",
+        "organizer"
+      ],
+      "name": "org_member_type",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "admin",
+        "member"
+      ],
+      "name": "org_role",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "core",
+        "prodigy"
+      ],
+      "name": "platform_name",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "org_event"
+      ],
+      "name": "premium_grant_source",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "pending",
+        "released",
+        "in_review",
+        "accepted"
+      ],
+      "name": "prospect_status",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "admin",
+        "prodigy_admin",
+        "user"
+      ],
+      "name": "role",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ],
+      "name": "roster_claim_status",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "pending",
+        "accepted",
+        "rejected"
+      ],
+      "name": "school_application_status",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "stripe",
+        "revenuecat"
+      ],
+      "name": "subscription_source",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "recruitment",
+        "audition",
+        "hybrid"
+      ],
+      "name": "team_selection_type",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "youtube",
+        "cloudflare"
+      ],
+      "name": "video_type",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "pending",
+        "processing",
+        "ready",
+        "failed"
+      ],
+      "name": "video_upload_status",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "cron_job_runs",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "crv_submissions",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "crv_videos",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "dancer_achievements",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "dancer_profiles",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "dancer_interests",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "dancer_references",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "dance_event_attendees",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "dance_event_schedules",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "dance_events",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "global_dance_event_attendees",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "global_dance_events",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "feed",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "video_library",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "posts",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "profile_images",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "video_uploads",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "profile_videos",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "global_notifications",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "notifications",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "outbox",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "processed_events",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "org_dancer_invites",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "org_memberships",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "organizations",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "premium_grants",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "school_favorites",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "dancer_follows",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "profile_views",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "school_applications",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "school_invites",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "school_profiles",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "suggested_claim_dismissals",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "dancer_skills",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "school_skills",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "skill_rarity",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "profile_skills",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "dancer_sports",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "school_sports",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "profile_sports",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "dancer_styles",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "school_styles",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "profile_styles",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "user_subscriptions",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "user_platforms",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "user_activities",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "users",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "csv_upload_rows",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "csv_uploads",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "event_audit_log",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "event_checklist",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "event_dancer_profiles",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "event_rosters",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "event_video_categories",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "event_videos",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "org_events",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "roster_claim_requests",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "event_callbacks",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "event_favorites",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "event_notes",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "event_ratings",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "event_school_selections",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "event_showcases",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "published_callbacks",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cron_job_runs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "job",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cron_job_runs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "run_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cron_job_runs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cron_job_runs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cron_job_runs"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crv_submissions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dancer_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crv_submissions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "school_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crv_submissions"
+    },
+    {
+      "type": "prospect_status",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'pending'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crv_submissions"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "watched",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crv_submissions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "watched_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crv_submissions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crv_submissions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crv_submissions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crv_videos"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dancer_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crv_videos"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "youtube_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crv_videos"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crv_videos"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crv_videos"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_achievements"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "profile_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_achievements"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_achievements"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_achievements"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_achievements"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_achievements"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "type": "date",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "birthday",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "location",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "biography",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "awards",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "instagram",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "tiktok",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "youtube",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "team_level",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "high_school",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "studio",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "type": "double precision",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "gpa",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "grad_year",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "training_hours",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dancer_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_interests"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "school_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_interests"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "1",
+      "generated": null,
+      "identity": null,
+      "name": "count",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_interests"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_interests"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_interests"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_references"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "profile_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_references"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_references"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_references"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_references"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_references"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_references"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_event_attendees"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_event_attendees"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_event_attendees"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_event_attendees"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_event_schedules"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_event_schedules"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "schedule",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_event_schedules"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_event_schedules"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_event_schedules"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "school_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "location",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "address",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "website",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 1,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "tags",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "type": "numeric",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "cost",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "type": "dance_event_type",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "start_datetime",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "end_datetime",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_dance_event_attendees"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_dance_event_attendees"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_dance_event_attendees"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_dance_event_attendees"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_dance_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_dance_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "thumbnail",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_dance_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_dance_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "location",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_dance_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "website",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_dance_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_dance_events"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "start_datetime",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_dance_events"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "end_datetime",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_dance_events"
+    },
+    {
+      "type": "dance_event_type",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_dance_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_dance_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_dance_events"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "feed"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "content_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "feed"
+    },
+    {
+      "type": "feed_item_type",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "content_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "feed"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "payload",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "feed"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "feed"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "feed"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "feed"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "video_library"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "video_library"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "category",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "video_library"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "video_library"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "video_library"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "video_library"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "content",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "thumbnail",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 1,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "tags",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "attachments",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_images"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_images"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "media_url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_images"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "caption",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_images"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_images"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_images"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "video_uploads"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "video_uploads"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "cloudflare_media_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "video_uploads"
+    },
+    {
+      "type": "video_upload_status",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'pending'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "video_uploads"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "thumbnail_url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "video_uploads"
+    },
+    {
+      "type": "real",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "duration",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "video_uploads"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "error_message",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "video_uploads"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "video_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "video_uploads"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "video_uploads"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "video_uploads"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_videos"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_videos"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "media_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_videos"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "caption",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_videos"
+    },
+    {
+      "type": "video_type",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'youtube'",
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_videos"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_videos"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_videos"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_notifications"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "content",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_notifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_notifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "global_notifications"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "notifications"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "notifications"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "content",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "notifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "seen_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "notifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "notifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "notifications"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "outbox"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "outbox"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "payload",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "outbox"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "published_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "outbox"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "outbox"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "processed_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "processed_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "processed_events"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_dancer_invites"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "org_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_dancer_invites"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_dancer_invites"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_dancer_invites"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_dancer_invites"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "consumed_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_dancer_invites"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_dancer_invites"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_dancer_invites"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_memberships"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_memberships"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "org_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_memberships"
+    },
+    {
+      "type": "org_role",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'member'",
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_memberships"
+    },
+    {
+      "type": "org_member_type",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_memberships"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_memberships"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_memberships"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "logo_url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "primary_color",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "accent_color",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "features",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "settings",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "premium_grants"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "premium_grants"
+    },
+    {
+      "type": "premium_grant_source",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "premium_grants"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "premium_grants"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "granted_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "premium_grants"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "premium_grants"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "revoked_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "premium_grants"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "premium_grants"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "premium_grants"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_favorites"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "school_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_favorites"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dancer_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_favorites"
+    },
+    {
+      "type": "platform_name",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "platform_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_favorites"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source_org_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_favorites"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "comment",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_favorites"
+    },
+    {
+      "type": "smallint",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "rating",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_favorites"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_contacted",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_favorites"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_notification",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_favorites"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_favorites"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_favorites"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_follows"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dancer_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_follows"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "school_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_follows"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_follows"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_follows"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_views"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dancer_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_views"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "school_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_views"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_views"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_views"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_applications"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "school_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_applications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "media_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_applications"
+    },
+    {
+      "type": "school_application_status",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'pending'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_applications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "notes",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_applications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_applications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_applications"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_invites"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_invites"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_invites"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_invites"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_invites"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_invites"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "consumed_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_invites"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_invites"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "location",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "city",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "common_recruiting",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "team_selection_type",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'recruitment'",
+      "generated": null,
+      "identity": null,
+      "name": "team_selection",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "competitive_circuit_type",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'non-competitive'",
+      "generated": null,
+      "identity": null,
+      "name": "competitive_circuit",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "division",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "benefits",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "about",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "website",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "time_commitment",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "head_coach",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "assistant_coach",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "mission_statement",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "what_we_do",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "double precision",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "gpa",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "size",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "tiktok",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "instagram",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "suggested_claim_dismissals"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "suggested_claim_dismissals"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "roster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "suggested_claim_dismissals"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "suggested_claim_dismissals"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dancer_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_skills"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "skill_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_skills"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_skills"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_skills"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "school_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_skills"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "skill_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_skills"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "1",
+      "generated": null,
+      "identity": null,
+      "name": "weight",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_skills"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_skills"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_skills"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "skill_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "skill_rarity"
+    },
+    {
+      "type": "real",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "rarity",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "skill_rarity"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "count",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "skill_rarity"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "skill_rarity"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "skill_rarity"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_skills"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_skills"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "category",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_skills"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dancer_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_sports"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "sport_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_sports"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_sports"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_sports"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "school_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_sports"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "sport_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_sports"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_sports"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_sports"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_sports"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_sports"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dancer_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_styles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "style_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_styles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_styles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "dancer_styles"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "school_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_styles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "style_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_styles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_styles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "school_styles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_styles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_styles"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_subscriptions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_subscriptions"
+    },
+    {
+      "type": "subscription_source",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'active'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "subscription_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "customer_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "price_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_subscriptions"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "cancel_at_period_end",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "current_period_end",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "canceled_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_subscriptions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_platforms"
+    },
+    {
+      "type": "platform_name",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "platform_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_platforms"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_platforms"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_activities"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_activities"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_activities"
+    },
+    {
+      "type": "platform_name",
+      "typeSchema": "public",
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "platform_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_activities"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_activities"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "citext",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "username",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "citext",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "role",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "account_type",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "display_email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "first_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "password",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "avatar",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "phone",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "verified",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "true",
+      "generated": null,
+      "identity": null,
+      "name": "notifications",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "org_account_tier",
+      "typeSchema": "public",
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "org_account_tier",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "org_account_tier_expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_upload_rows"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "csv_upload_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_upload_rows"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "row_number",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_upload_rows"
+    },
+    {
+      "type": "citext",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_upload_rows"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "first_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_upload_rows"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_upload_rows"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "bib_number",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_upload_rows"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "paid",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_upload_rows"
+    },
+    {
+      "type": "csv_row_outcome",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "outcome",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_upload_rows"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "roster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_upload_rows"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "matched_user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_upload_rows"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_upload_rows"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_upload_rows"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_uploads"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_uploads"
+    },
+    {
+      "type": "org_member_type",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_uploads"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "file_url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_uploads"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "uploaded_by",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_uploads"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "rows_added",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_uploads"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "rows_updated",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_uploads"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "rows_errored",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_uploads"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "error_details",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_uploads"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_uploads"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "csv_uploads"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_audit_log"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_audit_log"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "actor_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_audit_log"
+    },
+    {
+      "type": "audit_action",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "action",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_audit_log"
+    },
+    {
+      "type": "audit_resource",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "resource",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_audit_log"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "resource_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_audit_log"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_audit_log"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "parent_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_audit_log"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_audit_log"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_checklist"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_checklist"
+    },
+    {
+      "type": "varchar(160)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_checklist"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_checklist"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "completed",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_checklist"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "position",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_checklist"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_checklist"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_checklist"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_dancer_profiles"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "roster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_dancer_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "profile_photo_url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_dancer_profiles"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "grad_year",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_dancer_profiles"
+    },
+    {
+      "type": "double precision",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "gpa",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_dancer_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "studio",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_dancer_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "state",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_dancer_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "height",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_dancer_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 1,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dance_styles",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_dancer_profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "bio",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_dancer_profiles"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "extra",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_dancer_profiles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_dancer_profiles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_dancer_profiles"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "type": "org_member_type",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "bib_number",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "first_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "type": "date",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expiration_date",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "csv_upload_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "checked_in_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "paid",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "is_staff",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_video_categories"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_video_categories"
+    },
+    {
+      "type": "varchar(160)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_video_categories"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "sort_order",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_video_categories"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_video_categories"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_videos"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_videos"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "category_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_videos"
+    },
+    {
+      "type": "varchar(300)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_videos"
+    },
+    {
+      "type": "varchar(20)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "youtube_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_videos"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "sort_order",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_videos"
+    },
+    {
+      "type": "varchar(500)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "audio_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_videos"
+    },
+    {
+      "type": "varchar(300)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "audio_filename",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_videos"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_videos"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_videos"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_events"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "org_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_events"
+    },
+    {
+      "type": "varchar(160)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_events"
+    },
+    {
+      "type": "date",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "start_date",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_events"
+    },
+    {
+      "type": "date",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "end_date",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "venue_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "venue_address",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "contact_email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_events"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "is_active",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "schedule_pdf_url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "start_time",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "timezone",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "org_events"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "roster_claim_requests"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "org_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "roster_claim_requests"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "requester_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "roster_claim_requests"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "claimed_first_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "roster_claim_requests"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "claimed_last_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "roster_claim_requests"
+    },
+    {
+      "type": "citext",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "claimed_email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "roster_claim_requests"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "note",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "roster_claim_requests"
+    },
+    {
+      "type": "roster_claim_status",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'pending'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "roster_claim_requests"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "resolved_roster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "roster_claim_requests"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "resolved_by",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "roster_claim_requests"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "resolved_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "roster_claim_requests"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "roster_claim_requests"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "roster_claim_requests"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_callbacks"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_callbacks"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "showcase_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_callbacks"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "coach_roster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_callbacks"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dancer_roster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_callbacks"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_callbacks"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_callbacks"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_favorites"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_favorites"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "coach_roster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_favorites"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dancer_roster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_favorites"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_favorites"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_favorites"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_notes"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_notes"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "coach_roster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_notes"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dancer_roster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_notes"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "content",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_notes"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_notes"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_notes"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_ratings"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_ratings"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "coach_roster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_ratings"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dancer_roster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_ratings"
+    },
+    {
+      "type": "smallint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "rating",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_ratings"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_ratings"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_ratings"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_school_selections"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_school_selections"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dancer_roster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_school_selections"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "coach_roster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_school_selections"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_school_selections"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_showcases"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_showcases"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "number",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_showcases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'active'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_showcases"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "published_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_showcases"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "event_showcases"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "published_callbacks"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "showcase_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "published_callbacks"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "coach_roster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "published_callbacks"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dancer_roster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "published_callbacks"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "rank",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "published_callbacks"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "published_callbacks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "job",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "run_key",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cron_job_runs_job_run_key_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cron_job_runs"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "dancer_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "school_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "crv_submissions_dancer_id_school_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "crv_submissions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "school_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "crv_submissions_school_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "crv_submissions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "dancer_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "crv_videos_dancer_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "crv_videos"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "youtube_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "crv_videos_youtube_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "crv_videos"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "profile_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dancer_achievements_profile_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "dancer_achievements"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dancer_profiles_user_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "gpa",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dancer_profiles_gpa_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "location",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dancer_profiles_location_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "school_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dancer_interests_school_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "dancer_interests"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "profile_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dancer_references_profile_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "dancer_references"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dance_event_schedules_event_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "dance_event_schedules"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "school_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dance_events_school_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "start_datetime",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dance_events_start_datetime_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "tags",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "gin",
+      "concurrently": false,
+      "name": "dance_events_tags_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "start_datetime",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "global_dance_events_start_datetime_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "global_dance_events"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "feed_user_id_created_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "feed"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "feed_user_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "feed"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "feed_created_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "feed"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "video_library_created_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "video_library"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "category",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "video_library_category_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "video_library"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "slug",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "posts_slug_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "tags",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "gin",
+      "concurrently": false,
+      "name": "posts_tags_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "profile_images_user_id_created_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "profile_images"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "profile_images_user_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "profile_images"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "video_uploads_user_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "video_uploads"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "cloudflare_media_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "video_uploads_cloudflare_media_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "video_uploads"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "profile_videos_user_id_created_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "profile_videos"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "profile_videos_user_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "profile_videos"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "global_notifications_created_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "global_notifications"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "notifications_user_id_created_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "notifications"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "notifications_created_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "notifications"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "seen_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "(\"seen_at\" is null)",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "notifications_seen_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "notifications"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "outbox_type_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "outbox"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "published_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "(\"published_at\" is null)",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "outbox_published_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "outbox"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "org_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "email",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "org_dancer_invites_org_id_email_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "org_dancer_invites"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "token",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "org_dancer_invites_token_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "org_dancer_invites"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "org_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "type in ('coach', 'dancer')",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "org_memberships_user_id_org_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "org_memberships"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "org_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "type not in ('coach', 'dancer')",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "org_memberships_one_organizer_per_org",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "org_memberships"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "org_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "org_memberships_org_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "org_memberships"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "org_memberships_user_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "org_memberships"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "slug",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organizations_slug_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "expires_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "premium_grants_user_id_expires_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "premium_grants"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "expires_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "premium_grants_expires_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "premium_grants"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "school_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "dancer_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "school_favorites_school_id_dancer_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "school_favorites"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "dancer_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "school_favorites_dancer_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "school_favorites"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "school_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "school_favorites_school_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "school_favorites"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "dancer_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "school_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dancer_follows_dancer_id_school_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "dancer_follows"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "school_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dancer_follows_school_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "dancer_follows"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "dancer_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dancer_follows_dancer_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "dancer_follows"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "dancer_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "school_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "profile_views_dancer_id_school_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "profile_views"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "email",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "school_invites_event_email",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "school_invites"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "token",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "school_invites_token_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "school_invites"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "school_profiles_user_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "gpa",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "school_profiles_gpa_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "division",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "school_profiles_division_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "location",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "school_profiles_location_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "team_selection",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "school_profiles_team_selection_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "competitive_circuit",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "school_profiles_competitive_circuit_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "suggested_claim_dismissals_user_roster",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "suggested_claim_dismissals"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "dancer_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dancer_skills_dancer_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "dancer_skills"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "school_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "school_skills_school_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "school_skills"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "category",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "profile_skills_category_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "profile_skills"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "dancer_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dancer_sports_dancer_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "dancer_sports"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "school_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "school_sports_school_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "school_sports"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "dancer_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dancer_styles_dancer_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "dancer_styles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "school_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "school_styles_school_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "school_styles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "user_subscriptions_user_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "user_subscriptions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "current_period_end",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "user_subscriptions_current_period_end_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "user_subscriptions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "user_platforms_user_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "user_platforms"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "platform_name",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "user_platforms_platform_name_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "user_platforms"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "user_activities_user_id_created_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "user_activities"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "event_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "user_activities_created_at_event_type_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "user_activities"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "users_created_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "csv_upload_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "csv_upload_rows_csv_upload_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "csv_upload_rows"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "email",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "csv_upload_rows_email_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "csv_upload_rows"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "csv_upload_rows_roster_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "csv_upload_rows"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "csv_uploads_event_id_created_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "csv_uploads"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_audit_log_event_id_created_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_audit_log"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "parent_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_audit_log_parent_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_audit_log"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "actor_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_audit_log_actor_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_audit_log"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_checklist_event_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_checklist"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "email",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "is_staff = false",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_rosters_event_id_email_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "is_staff = true",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_rosters_staff_per_user",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "bib_number",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "bib_number IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_rosters_bib_per_event",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_rosters_event_id_type_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_rosters_user_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_video_categories_event_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_video_categories"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "name",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_video_categories_event_id_name_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_video_categories"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_videos_event_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_videos"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "category_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_videos_category_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_videos"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "org_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "org_events_org_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "org_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "org_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "is_active = true",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "org_events_one_active_per_org",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "org_events"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "org_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "status",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "roster_claim_requests_org_id_status_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "roster_claim_requests"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "requester_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "roster_claim_requests_requester_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "roster_claim_requests"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "org_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "requester_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "status = 'pending'",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "roster_claim_requests_one_open_per_requester",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "roster_claim_requests"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "showcase_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "coach_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "dancer_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_callbacks_showcase_id_coach_roster_id_dancer_roster_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_callbacks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "dancer_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_callbacks_event_id_dancer_roster_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_callbacks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "coach_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_callbacks_coach_roster_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_callbacks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "coach_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "dancer_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_favorites_event_id_coach_roster_id_dancer_roster_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_favorites"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "coach_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_favorites_coach_roster_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_favorites"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "coach_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "dancer_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_notes_event_id_coach_roster_id_dancer_roster_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_notes"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "coach_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_notes_coach_roster_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_notes"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "coach_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "dancer_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_ratings_event_id_coach_roster_id_dancer_roster_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_ratings"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "coach_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_ratings_coach_roster_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_ratings"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "dancer_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "coach_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_school_selections_event_id_dancer_roster_id_coach_roster_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_school_selections"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "dancer_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_school_selections_event_id_dancer_roster_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_school_selections"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "coach_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_school_selections_event_id_coach_roster_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_school_selections"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "status = 'active'",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_showcases_one_active_per_event",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_showcases"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "event_showcases_event_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "event_showcases"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "showcase_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "coach_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "dancer_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "published_callbacks_showcase_id_coach_roster_id_dancer_roster_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "published_callbacks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "showcase_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "dancer_roster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "published_callbacks_showcase_id_dancer_roster_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "published_callbacks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "dancer_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "dancer_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "crv_submissions_dancer_id_dancer_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "crv_submissions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "school_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "school_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "crv_submissions_school_id_school_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "crv_submissions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "dancer_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "dancer_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "crv_videos_dancer_id_dancer_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "crv_videos"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "profile_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "dancer_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "dancer_achievements_profile_id_dancer_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "dancer_achievements"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "dancer_profiles_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "dancer_profiles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "dancer_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "dancer_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "dancer_interests_dancer_id_dancer_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "dancer_interests"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "school_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "school_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "dancer_interests_school_id_school_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "dancer_interests"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "profile_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "dancer_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "dancer_references_profile_id_dancer_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "dancer_references"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "dance_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "dance_event_attendees_event_id_dance_events_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "dance_event_attendees"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "dance_event_attendees_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "dance_event_attendees"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "dance_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "dance_event_schedules_event_id_dance_events_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "dance_event_schedules"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "school_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "school_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "dance_events_school_id_school_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "dance_events"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "global_dance_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "global_dance_event_attendees_VAnWZ7akpnDz_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "global_dance_event_attendees"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "global_dance_event_attendees_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "global_dance_event_attendees"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "feed_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "feed"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "profile_images_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "profile_images"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "video_uploads_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "video_uploads"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "video_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "profile_videos",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "video_uploads_video_id_profile_videos_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "video_uploads"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "profile_videos_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "profile_videos"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "notifications_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "notifications"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "org_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "org_dancer_invites_org_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "org_dancer_invites"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "org_memberships_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "org_memberships"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "org_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "org_memberships_org_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "org_memberships"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "premium_grants_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "premium_grants"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "school_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "school_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "school_favorites_school_id_school_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "school_favorites"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "dancer_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "dancer_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "school_favorites_dancer_id_dancer_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "school_favorites"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "source_org_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "school_favorites_source_org_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "school_favorites"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "dancer_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "dancer_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "dancer_follows_dancer_id_dancer_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "dancer_follows"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "school_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "school_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "dancer_follows_school_id_school_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "dancer_follows"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "dancer_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "dancer_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "profile_views_dancer_id_dancer_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "profile_views"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "school_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "school_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "profile_views_school_id_school_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "profile_views"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "school_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "school_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "school_applications_school_id_school_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "school_applications"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "org_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "school_invites_event_id_org_events_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "school_invites"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "school_profiles_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "school_profiles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "suggested_claim_dismissals_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "suggested_claim_dismissals"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "roster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_rosters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "suggested_claim_dismissals_roster_id_event_rosters_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "suggested_claim_dismissals"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "dancer_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "dancer_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "dancers_to_skills_dancer_id_dancer_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "dancer_skills"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "skill_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "profile_skills",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "dancer_skills_skill_id_profile_skills_slug_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "dancer_skills"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "school_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "school_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "schools_to_skills_school_id_school_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "school_skills"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "skill_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "profile_skills",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "school_skills_skill_id_profile_skills_slug_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "school_skills"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "skill_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "profile_skills",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "skill_rarity_skill_id_profile_skills_slug_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "skill_rarity"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "dancer_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "dancer_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "dancer_sports_dancer_id_dancer_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "dancer_sports"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "sport_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "profile_sports",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "dancer_sports_sport_id_profile_sports_slug_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "dancer_sports"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "school_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "school_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "school_sports_school_id_school_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "school_sports"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "sport_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "profile_sports",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "school_sports_sport_id_profile_sports_slug_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "school_sports"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "dancer_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "dancer_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "dancers_to_styles_dancer_id_dancer_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "dancer_styles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "style_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "profile_styles",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "dancer_styles_style_id_profile_styles_slug_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "dancer_styles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "school_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "school_profiles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "schools_to_styles_school_id_school_profiles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "school_styles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "style_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "profile_styles",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "school_styles_style_id_profile_styles_slug_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "school_styles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_subscriptions_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_subscriptions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_platforms_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_platforms"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_activities_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_activities"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "csv_upload_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "csv_uploads",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "csv_upload_rows_csv_upload_id_csv_uploads_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "csv_upload_rows"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "roster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_rosters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "csv_upload_rows_roster_id_event_rosters_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "csv_upload_rows"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "matched_user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "csv_upload_rows_matched_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "csv_upload_rows"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "org_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "csv_uploads_event_id_org_events_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "csv_uploads"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "uploaded_by"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "RESTRICT",
+      "name": "csv_uploads_uploaded_by_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "csv_uploads"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "org_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_audit_log_event_id_org_events_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_audit_log"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "actor_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "RESTRICT",
+      "name": "event_audit_log_actor_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_audit_log"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "parent_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_audit_log",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_audit_log_parent_id_event_audit_log_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_audit_log"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "org_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_checklist_event_id_org_events_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_checklist"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "roster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_rosters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_dancer_profiles_roster_id_event_rosters_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_dancer_profiles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "org_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_rosters_event_id_org_events_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "event_rosters_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_rosters"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "org_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_video_categories_event_id_org_events_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_video_categories"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "org_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_videos_event_id_org_events_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_videos"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "category_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_video_categories",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "RESTRICT",
+      "name": "event_videos_category_id_event_video_categories_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_videos"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "org_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "org_events_org_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "org_events"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "org_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "roster_claim_requests_org_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "roster_claim_requests"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "requester_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "roster_claim_requests_requester_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "roster_claim_requests"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "resolved_roster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_rosters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "roster_claim_requests_resolved_roster_id_event_rosters_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "roster_claim_requests"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "resolved_by"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "roster_claim_requests_resolved_by_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "roster_claim_requests"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "org_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_callbacks_event_id_org_events_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_callbacks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "showcase_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_showcases",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_callbacks_showcase_id_event_showcases_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_callbacks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "coach_roster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_rosters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_callbacks_coach_roster_id_event_rosters_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_callbacks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "dancer_roster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_rosters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_callbacks_dancer_roster_id_event_rosters_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_callbacks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "org_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_favorites_event_id_org_events_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_favorites"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "coach_roster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_rosters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_favorites_coach_roster_id_event_rosters_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_favorites"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "dancer_roster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_rosters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_favorites_dancer_roster_id_event_rosters_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_favorites"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "org_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_notes_event_id_org_events_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_notes"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "coach_roster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_rosters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_notes_coach_roster_id_event_rosters_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_notes"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "dancer_roster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_rosters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_notes_dancer_roster_id_event_rosters_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_notes"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "org_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_ratings_event_id_org_events_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_ratings"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "coach_roster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_rosters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_ratings_coach_roster_id_event_rosters_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_ratings"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "dancer_roster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_rosters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_ratings_dancer_roster_id_event_rosters_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_ratings"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "org_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_school_selections_event_id_org_events_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_school_selections"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "dancer_roster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_rosters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_school_selections_dancer_roster_id_event_rosters_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_school_selections"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "coach_roster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_rosters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_school_selections_coach_roster_id_event_rosters_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_school_selections"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "org_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "event_showcases_event_id_org_events_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "event_showcases"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "showcase_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_showcases",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "published_callbacks_showcase_id_event_showcases_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "published_callbacks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "coach_roster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_rosters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "published_callbacks_coach_roster_id_event_rosters_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "published_callbacks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "dancer_roster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "event_rosters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "published_callbacks_dancer_roster_id_event_rosters_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "published_callbacks"
+    },
+    {
+      "columns": [
+        "dancer_id",
+        "school_id"
+      ],
+      "nameExplicit": false,
+      "name": "dancer_interests_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "dancer_interests"
+    },
+    {
+      "columns": [
+        "user_id",
+        "event_id"
+      ],
+      "nameExplicit": false,
+      "name": "dance_event_attendees_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "dance_event_attendees"
+    },
+    {
+      "columns": [
+        "user_id",
+        "event_id"
+      ],
+      "nameExplicit": false,
+      "name": "global_dance_event_attendees_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "global_dance_event_attendees"
+    },
+    {
+      "columns": [
+        "dancer_id",
+        "skill_id"
+      ],
+      "nameExplicit": false,
+      "name": "dancers_to_skills_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "dancer_skills"
+    },
+    {
+      "columns": [
+        "school_id",
+        "skill_id"
+      ],
+      "nameExplicit": false,
+      "name": "schools_to_skills_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "school_skills"
+    },
+    {
+      "columns": [
+        "dancer_id",
+        "sport_id"
+      ],
+      "nameExplicit": false,
+      "name": "dancer_sports_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "dancer_sports"
+    },
+    {
+      "columns": [
+        "school_id",
+        "sport_id"
+      ],
+      "nameExplicit": false,
+      "name": "school_sports_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "school_sports"
+    },
+    {
+      "columns": [
+        "dancer_id",
+        "style_id"
+      ],
+      "nameExplicit": false,
+      "name": "dancers_to_styles_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "dancer_styles"
+    },
+    {
+      "columns": [
+        "school_id",
+        "style_id"
+      ],
+      "nameExplicit": false,
+      "name": "schools_to_styles_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "school_styles"
+    },
+    {
+      "columns": [
+        "user_id",
+        "platform_name"
+      ],
+      "nameExplicit": false,
+      "name": "user_platforms_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "user_platforms"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "cron_job_runs_pkey",
+      "schema": "public",
+      "table": "cron_job_runs",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "crv_submissions_pkey",
+      "schema": "public",
+      "table": "crv_submissions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "crv_videos_pkey",
+      "schema": "public",
+      "table": "crv_videos",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "dancer_achievements_pkey",
+      "schema": "public",
+      "table": "dancer_achievements",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "dancer_profiles_pkey",
+      "schema": "public",
+      "table": "dancer_profiles",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "dancer_references_pkey",
+      "schema": "public",
+      "table": "dancer_references",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "dance_event_schedules_pkey",
+      "schema": "public",
+      "table": "dance_event_schedules",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "dance_events_pkey",
+      "schema": "public",
+      "table": "dance_events",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "global_dance_events_pkey",
+      "schema": "public",
+      "table": "global_dance_events",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "feed_pkey",
+      "schema": "public",
+      "table": "feed",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "video_library_pkey",
+      "schema": "public",
+      "table": "video_library",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "posts_pkey",
+      "schema": "public",
+      "table": "posts",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "profile_images_pkey",
+      "schema": "public",
+      "table": "profile_images",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "video_uploads_pkey",
+      "schema": "public",
+      "table": "video_uploads",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "profile_videos_pkey",
+      "schema": "public",
+      "table": "profile_videos",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "global_notifications_pkey",
+      "schema": "public",
+      "table": "global_notifications",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "notifications_pkey",
+      "schema": "public",
+      "table": "notifications",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "outbox_pkey",
+      "schema": "public",
+      "table": "outbox",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "event_id"
+      ],
+      "nameExplicit": false,
+      "name": "processed_events_pkey",
+      "schema": "public",
+      "table": "processed_events",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "org_dancer_invites_pkey",
+      "schema": "public",
+      "table": "org_dancer_invites",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "org_memberships_pkey",
+      "schema": "public",
+      "table": "org_memberships",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "organizations_pkey",
+      "schema": "public",
+      "table": "organizations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "premium_grants_pkey",
+      "schema": "public",
+      "table": "premium_grants",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "school_favorites_pkey",
+      "schema": "public",
+      "table": "school_favorites",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "dancer_follows_pkey",
+      "schema": "public",
+      "table": "dancer_follows",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "profile_views_pkey",
+      "schema": "public",
+      "table": "profile_views",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "school_applications_pkey",
+      "schema": "public",
+      "table": "school_applications",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "school_invites_pkey",
+      "schema": "public",
+      "table": "school_invites",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "school_profiles_pkey",
+      "schema": "public",
+      "table": "school_profiles",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "suggested_claim_dismissals_pkey",
+      "schema": "public",
+      "table": "suggested_claim_dismissals",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "skill_id"
+      ],
+      "nameExplicit": false,
+      "name": "skill_rarity_pkey",
+      "schema": "public",
+      "table": "skill_rarity",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "slug"
+      ],
+      "nameExplicit": false,
+      "name": "profile_skills_pkey",
+      "schema": "public",
+      "table": "profile_skills",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "slug"
+      ],
+      "nameExplicit": false,
+      "name": "profile_sports_pkey",
+      "schema": "public",
+      "table": "profile_sports",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "slug"
+      ],
+      "nameExplicit": false,
+      "name": "profile_styles_pkey",
+      "schema": "public",
+      "table": "profile_styles",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_subscriptions_pkey",
+      "schema": "public",
+      "table": "user_subscriptions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_activities_pkey",
+      "schema": "public",
+      "table": "user_activities",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "users_pkey",
+      "schema": "public",
+      "table": "users",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "csv_upload_rows_pkey",
+      "schema": "public",
+      "table": "csv_upload_rows",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "csv_uploads_pkey",
+      "schema": "public",
+      "table": "csv_uploads",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "event_audit_log_pkey",
+      "schema": "public",
+      "table": "event_audit_log",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "event_checklist_pkey",
+      "schema": "public",
+      "table": "event_checklist",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "event_dancer_profiles_pkey",
+      "schema": "public",
+      "table": "event_dancer_profiles",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "event_rosters_pkey",
+      "schema": "public",
+      "table": "event_rosters",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "event_video_categories_pkey",
+      "schema": "public",
+      "table": "event_video_categories",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "event_videos_pkey",
+      "schema": "public",
+      "table": "event_videos",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "org_events_pkey",
+      "schema": "public",
+      "table": "org_events",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "roster_claim_requests_pkey",
+      "schema": "public",
+      "table": "roster_claim_requests",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "event_callbacks_pkey",
+      "schema": "public",
+      "table": "event_callbacks",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "event_favorites_pkey",
+      "schema": "public",
+      "table": "event_favorites",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "event_notes_pkey",
+      "schema": "public",
+      "table": "event_notes",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "event_ratings_pkey",
+      "schema": "public",
+      "table": "event_ratings",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "event_school_selections_pkey",
+      "schema": "public",
+      "table": "event_school_selections",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "event_showcases_pkey",
+      "schema": "public",
+      "table": "event_showcases",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "published_callbacks_pkey",
+      "schema": "public",
+      "table": "published_callbacks",
+      "entityType": "pks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "dancer_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "crv_videos_dancer_id_key",
+      "schema": "public",
+      "table": "crv_videos",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "dancer_profiles_user_id_key",
+      "schema": "public",
+      "table": "dancer_profiles",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "url"
+      ],
+      "nullsNotDistinct": false,
+      "name": "video_library_url_key",
+      "schema": "public",
+      "table": "video_library",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "nullsNotDistinct": false,
+      "name": "posts_slug_key",
+      "schema": "public",
+      "table": "posts",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "media_url"
+      ],
+      "nullsNotDistinct": false,
+      "name": "profile_images_media_url_key",
+      "schema": "public",
+      "table": "profile_images",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "cloudflare_media_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "video_uploads_cloudflare_media_id_key",
+      "schema": "public",
+      "table": "video_uploads",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "media_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "profile_videos_media_id_key",
+      "schema": "public",
+      "table": "profile_videos",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "token"
+      ],
+      "nullsNotDistinct": false,
+      "name": "org_dancer_invites_token_key",
+      "schema": "public",
+      "table": "org_dancer_invites",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "nullsNotDistinct": false,
+      "name": "organizations_slug_key",
+      "schema": "public",
+      "table": "organizations",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "school_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "school_applications_school_id_key",
+      "schema": "public",
+      "table": "school_applications",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "token"
+      ],
+      "nullsNotDistinct": false,
+      "name": "school_invites_token_key",
+      "schema": "public",
+      "table": "school_invites",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "school_profiles_user_id_key",
+      "schema": "public",
+      "table": "school_profiles",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "name"
+      ],
+      "nullsNotDistinct": false,
+      "name": "school_profiles_name_key",
+      "schema": "public",
+      "table": "school_profiles",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "name"
+      ],
+      "nullsNotDistinct": false,
+      "name": "profile_skills_name_key",
+      "schema": "public",
+      "table": "profile_skills",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "name"
+      ],
+      "nullsNotDistinct": false,
+      "name": "profile_sports_name_key",
+      "schema": "public",
+      "table": "profile_sports",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "name"
+      ],
+      "nullsNotDistinct": false,
+      "name": "profile_styles_name_key",
+      "schema": "public",
+      "table": "profile_styles",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "user_subscriptions_user_id_key",
+      "schema": "public",
+      "table": "user_subscriptions",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "subscription_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "user_subscriptions_subscription_id_key",
+      "schema": "public",
+      "table": "user_subscriptions",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "username"
+      ],
+      "nullsNotDistinct": false,
+      "name": "users_username_key",
+      "schema": "public",
+      "table": "users",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "email"
+      ],
+      "nullsNotDistinct": false,
+      "name": "users_email_key",
+      "schema": "public",
+      "table": "users",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "roster_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "event_dancer_profiles_roster_id_key",
+      "schema": "public",
+      "table": "event_dancer_profiles",
+      "entityType": "uniques"
+    },
+    {
+      "value": "\"count\" <= 3",
+      "name": "count <= 3",
+      "entityType": "checks",
+      "schema": "public",
+      "table": "dancer_interests"
+    },
+    {
+      "value": "type in ('coach', 'dancer')",
+      "name": "csv_uploads_participant_type",
+      "entityType": "checks",
+      "schema": "public",
+      "table": "csv_uploads"
+    },
+    {
+      "value": "type in ('coach', 'dancer')",
+      "name": "event_rosters_participant_type",
+      "entityType": "checks",
+      "schema": "public",
+      "table": "event_rosters"
+    }
+  ],
+  "renames": []
+}

--- a/apps/backend/app/database/drizzle/20260824170307_sour_goliath/migration.sql
+++ b/apps/backend/app/database/drizzle/20260824170307_sour_goliath/migration.sql
@@ -1,0 +1,6 @@
+ALTER TYPE "org_member_type" ADD VALUE 'organizer';--> statement-breakpoint
+DROP INDEX "org_memberships_user_id_org_id_index";--> statement-breakpoint
+CREATE UNIQUE INDEX "org_memberships_user_id_org_id_index" ON "org_memberships" ("user_id","org_id") WHERE type in ('coach', 'dancer');--> statement-breakpoint
+CREATE UNIQUE INDEX "org_memberships_organizer_per_user_per_org" ON "org_memberships" ("user_id","org_id") WHERE type not in ('coach', 'dancer');--> statement-breakpoint
+ALTER TABLE "csv_uploads" ADD CONSTRAINT "csv_uploads_roster_type" CHECK (type in ('coach', 'dancer'));--> statement-breakpoint
+ALTER TABLE "event_rosters" ADD CONSTRAINT "event_rosters_roster_type" CHECK (type in ('coach', 'dancer'));

--- a/apps/backend/app/database/drizzle/20260824170307_sour_goliath/snapshot.json
+++ b/apps/backend/app/database/drizzle/20260824170307_sour_goliath/snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "8",
   "dialect": "postgres",
-  "id": "fa0ab202-713c-47bf-8a56-5194cd0a462b",
+  "id": "5445b437-b7de-468a-a1af-da8c8d97310d",
   "prevIds": [
     "5bccd7e0-87f6-425b-9afd-d5e5466ea8f1"
   ],
@@ -7774,7 +7774,7 @@
       "with": "",
       "method": "btree",
       "concurrently": false,
-      "name": "org_memberships_one_organizer_per_org",
+      "name": "org_memberships_organizer_per_user_per_org",
       "entityType": "indexes",
       "schema": "public",
       "table": "org_memberships"
@@ -12004,14 +12004,14 @@
     },
     {
       "value": "type in ('coach', 'dancer')",
-      "name": "csv_uploads_participant_type",
+      "name": "csv_uploads_roster_type",
       "entityType": "checks",
       "schema": "public",
       "table": "csv_uploads"
     },
     {
       "value": "type in ('coach', 'dancer')",
-      "name": "event_rosters_participant_type",
+      "name": "event_rosters_roster_type",
       "entityType": "checks",
       "schema": "public",
       "table": "event_rosters"

--- a/apps/backend/app/database/schema/enums.ts
+++ b/apps/backend/app/database/schema/enums.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import { pgEnum } from "drizzle-orm/pg-core";
 
 export const prospectStatus = pgEnum("prospect_status", [
@@ -106,6 +107,29 @@ export type RosterType = (typeof ROSTER_TYPES)[number];
 
 export const isRosterType = (value: string): value is RosterType =>
   (ROSTER_TYPES as readonly string[]).includes(value);
+
+/**
+ * SQL predicate for "this row's `type` is a Roster type". Shared by the roster
+ * CHECK constraints, the membership partial indexes, and the ON CONFLICT clause
+ * that has to infer one of those indexes — Postgres only infers a partial index
+ * when the statement's predicate implies the index's, so these must not drift.
+ *
+ * Written as a positive list rather than `<> 'organizer'` for two reasons: DDL
+ * may not name an enum label added in the same transaction, and a member type
+ * added later then stays out of rosters until someone decides otherwise.
+ */
+export const isRosterTypeSql = () =>
+  sql`type in (${sql.join(
+    ROSTER_TYPES.map((t) => sql`${t}`),
+    sql`, `
+  )})`;
+
+/** The complement of `isRosterTypeSql`, for indexes over the non-Roster types. */
+export const isNotRosterTypeSql = () =>
+  sql`type not in (${sql.join(
+    ROSTER_TYPES.map((t) => sql`${t}`),
+    sql`, `
+  )})`;
 export const premiumGrantSource = pgEnum("premium_grant_source", ["org_event"]);
 export const orgAccountTier = pgEnum("org_account_tier", [
   "standard",

--- a/apps/backend/app/database/schema/enums.ts
+++ b/apps/backend/app/database/schema/enums.ts
@@ -79,7 +79,33 @@ export const videoUploadStatus = pgEnum("video_upload_status", [
 ]);
 
 export const orgRole = pgEnum("org_role", ["admin", "member"]);
-export const orgMemberType = pgEnum("org_member_type", ["coach", "dancer"]);
+/**
+ * What a person is inside an Org. Shared by `org_memberships` and, in the
+ * narrowed `RosterType` form below, by `event_rosters` and `csv_uploads`.
+ *
+ * `organizer` is the person who runs the Org's events and buys S2S Live. They
+ * administer the Org but never evaluate dancers and never appear on a Roster —
+ * see docs/adr/0003-organizer-is-a-distinct-member-type.md.
+ */
+export const orgMemberType = pgEnum("org_member_type", [
+  "coach",
+  "dancer",
+  "organizer",
+]);
+
+export type OrgMemberType = (typeof orgMemberType.enumValues)[number];
+
+/**
+ * The subset of `org_member_type` a Roster Entry may hold. An Organizer runs
+ * the event rather than taking part in it, so an organizer membership must
+ * never produce a Roster Entry — `event_rosters.type` and `csv_uploads.type`
+ * are typed to this and carry a matching CHECK constraint.
+ */
+export const ROSTER_TYPES = ["coach", "dancer"] as const;
+export type RosterType = (typeof ROSTER_TYPES)[number];
+
+export const isRosterType = (value: string): value is RosterType =>
+  (ROSTER_TYPES as readonly string[]).includes(value);
 export const premiumGrantSource = pgEnum("premium_grant_source", ["org_event"]);
 export const orgAccountTier = pgEnum("org_account_tier", [
   "standard",

--- a/apps/backend/app/database/schema/org-events.ts
+++ b/apps/backend/app/database/schema/org-events.ts
@@ -7,6 +7,7 @@ import {
   csvRowOutcome,
   orgMemberType,
   rosterClaimStatus,
+  isRosterTypeSql,
   type RosterType,
 } from "./enums.ts";
 import { citext, timestamps } from "./helpers/columns.ts";
@@ -95,10 +96,7 @@ export const eventRosters = pg.pgTable(
     pg.index().on(table.eventId, table.type),
     pg.index().on(table.userId),
     // A Roster Entry is a Coach or a Dancer, never an Organizer (ADR 0003).
-    pg.check(
-      "event_rosters_participant_type",
-      sql`type in ('coach', 'dancer')`
-    ),
+    pg.check("event_rosters_roster_type", isRosterTypeSql()),
   ]
 );
 
@@ -144,7 +142,7 @@ export const csvUploads = pg.pgTable(
   },
   (table) => [
     pg.index().on(table.eventId, table.createdAt),
-    pg.check("csv_uploads_participant_type", sql`type in ('coach', 'dancer')`),
+    pg.check("csv_uploads_roster_type", isRosterTypeSql()),
   ]
 );
 

--- a/apps/backend/app/database/schema/org-events.ts
+++ b/apps/backend/app/database/schema/org-events.ts
@@ -7,6 +7,7 @@ import {
   csvRowOutcome,
   orgMemberType,
   rosterClaimStatus,
+  type RosterType,
 } from "./enums.ts";
 import { citext, timestamps } from "./helpers/columns.ts";
 import { organizations } from "./organizations.ts";
@@ -50,7 +51,10 @@ export const eventRosters = pg.pgTable(
       .notNull()
       .references(() => orgEvents.id, { onDelete: "cascade" }),
     userId: pg.uuid().references(() => users.id, { onDelete: "set null" }),
-    type: orgMemberType().notNull(),
+    // A Roster Entry is a Coach or a Dancer. Organizers run the event rather
+    // than taking part in it (ADR 0003), so `organizer` is excluded here at the
+    // type level and by the `event_rosters_type_not_organizer` CHECK below.
+    type: orgMemberType().$type<RosterType>().notNull(),
     bibNumber: pg.integer(),
     email: pg.text().notNull(),
     firstName: pg.text().notNull(),
@@ -90,6 +94,11 @@ export const eventRosters = pg.pgTable(
       .where(sql`bib_number IS NOT NULL`),
     pg.index().on(table.eventId, table.type),
     pg.index().on(table.userId),
+    // A Roster Entry is a Coach or a Dancer, never an Organizer (ADR 0003).
+    pg.check(
+      "event_rosters_participant_type",
+      sql`type in ('coach', 'dancer')`
+    ),
   ]
 );
 
@@ -120,7 +129,8 @@ export const csvUploads = pg.pgTable(
       .uuid()
       .notNull()
       .references(() => orgEvents.id, { onDelete: "cascade" }),
-    type: orgMemberType().notNull(),
+    // Rosters are uploaded as Coaches or Dancers; there is no organizer CSV.
+    type: orgMemberType().$type<RosterType>().notNull(),
     fileUrl: pg.text().notNull(),
     uploadedBy: pg
       .uuid()
@@ -132,7 +142,10 @@ export const csvUploads = pg.pgTable(
     errorDetails: pg.jsonb(),
     ...timestamps,
   },
-  (table) => [pg.index().on(table.eventId, table.createdAt)]
+  (table) => [
+    pg.index().on(table.eventId, table.createdAt),
+    pg.check("csv_uploads_participant_type", sql`type in ('coach', 'dancer')`),
+  ]
 );
 
 /**

--- a/apps/backend/app/database/schema/organizations.ts
+++ b/apps/backend/app/database/schema/organizations.ts
@@ -1,6 +1,11 @@
-import { sql } from "drizzle-orm";
 import * as pg from "drizzle-orm/pg-core";
-import { orgMemberType, orgRole, premiumGrantSource } from "./enums.ts";
+import {
+  isNotRosterTypeSql,
+  isRosterTypeSql,
+  orgMemberType,
+  orgRole,
+  premiumGrantSource,
+} from "./enums.ts";
 import { timestamps } from "./helpers/columns.ts";
 import { users } from "./users.ts";
 
@@ -42,19 +47,15 @@ export const orgMemberships = pg.pgTable(
     // Coach and dancer stay mutually exclusive, exactly as before organizer
     // existed — the original index is kept, narrowed to those two rows.
     // Left unnamed to keep the original auto-generated index name.
-    //
-    // The predicates name the participant types rather than excluding
-    // `organizer` so the DDL never mentions a label added in the same
-    // migration, which Postgres rejects. It also fails safe: a member type
-    // added later is excluded from this index until someone decides otherwise.
+    pg.uniqueIndex().on(table.userId, table.orgId).where(isRosterTypeSql()),
+    // The complement: one organizer membership per person per Org. It caps the
+    // person, not the Org — an Org may have several Organizers, each with their
+    // own row. Necessarily phrased as "not a Roster type", the one place the
+    // positive form of the predicate cannot be used.
     pg
-      .uniqueIndex()
+      .uniqueIndex("org_memberships_organizer_per_user_per_org")
       .on(table.userId, table.orgId)
-      .where(sql`type in ('coach', 'dancer')`),
-    pg
-      .uniqueIndex("org_memberships_one_organizer_per_org")
-      .on(table.userId, table.orgId)
-      .where(sql`type not in ('coach', 'dancer')`),
+      .where(isNotRosterTypeSql()),
     pg.index().on(table.orgId),
     pg.index().on(table.userId),
   ]

--- a/apps/backend/app/database/schema/organizations.ts
+++ b/apps/backend/app/database/schema/organizations.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import * as pg from "drizzle-orm/pg-core";
 import { orgMemberType, orgRole, premiumGrantSource } from "./enums.ts";
 import { timestamps } from "./helpers/columns.ts";
@@ -36,7 +37,24 @@ export const orgMemberships = pg.pgTable(
     ...timestamps,
   },
   (table) => [
-    pg.uniqueIndex().on(table.userId, table.orgId),
+    // An Organizer runs the Org's events; a Coach recruits at them. The two are
+    // orthogonal, so the same person may hold both memberships (ADR 0003).
+    // Coach and dancer stay mutually exclusive, exactly as before organizer
+    // existed — the original index is kept, narrowed to those two rows.
+    // Left unnamed to keep the original auto-generated index name.
+    //
+    // The predicates name the participant types rather than excluding
+    // `organizer` so the DDL never mentions a label added in the same
+    // migration, which Postgres rejects. It also fails safe: a member type
+    // added later is excluded from this index until someone decides otherwise.
+    pg
+      .uniqueIndex()
+      .on(table.userId, table.orgId)
+      .where(sql`type in ('coach', 'dancer')`),
+    pg
+      .uniqueIndex("org_memberships_one_organizer_per_org")
+      .on(table.userId, table.orgId)
+      .where(sql`type not in ('coach', 'dancer')`),
     pg.index().on(table.orgId),
     pg.index().on(table.userId),
   ]

--- a/apps/backend/app/database/schema/organizations.ts
+++ b/apps/backend/app/database/schema/organizations.ts
@@ -50,8 +50,15 @@ export const orgMemberships = pg.pgTable(
     pg.uniqueIndex().on(table.userId, table.orgId).where(isRosterTypeSql()),
     // The complement: one organizer membership per person per Org. It caps the
     // person, not the Org — an Org may have several Organizers, each with their
-    // own row. Necessarily phrased as "not a Roster type", the one place the
-    // positive form of the predicate cannot be used.
+    // own row.
+    //
+    // This is the one predicate that cannot be phrased positively: `organizer`
+    // is added by the same migration, and Postgres refuses DDL naming an enum
+    // label added in its own transaction. The cost is that it reads as "not a
+    // Roster type" rather than "is an organizer", so a fourth member type added
+    // later would silently share this uniqueness slot and could not coexist
+    // with an organizer membership. Whoever adds one should split this index —
+    // `where type = 'organizer'` is safe in any later migration.
     pg
       .uniqueIndex("org_memberships_organizer_per_user_per_org")
       .on(table.userId, table.orgId)

--- a/apps/backend/app/middleware/routes/org-admin.ts
+++ b/apps/backend/app/middleware/routes/org-admin.ts
@@ -1,8 +1,10 @@
+import { grantsOrgAdmin } from "#shared/org/membership";
 import type { HttpContext } from "@adonisjs/core/http";
 import type { NextFn } from "@adonisjs/core/types/http";
 
 /**
- * Requires the authenticated user's org membership to have role=admin.
+ * Requires the authenticated user to administer the org — either role=admin, or
+ * a membership of type organizer, which administers by definition (ADR 0003).
  * Must be composed after `orgMember` so `ctx.orgMembership` is populated.
  */
 export default class OrgAdminMiddleware {
@@ -13,7 +15,7 @@ export default class OrgAdminMiddleware {
         message: "Membership not resolved.",
       });
     }
-    if (membership.role !== "admin") {
+    if (!grantsOrgAdmin(membership)) {
       return ctx.response.forbidden({ message: "Admin access required." });
     }
     return next();

--- a/apps/backend/app/middleware/routes/org-coach.ts
+++ b/apps/backend/app/middleware/routes/org-coach.ts
@@ -13,10 +13,10 @@ import type { NextFn } from "@adonisjs/core/types/http";
 export default class OrgCoachMiddleware {
   async handle(ctx: HttpContext, next: NextFn) {
     const membership = ctx.orgMembership;
-    if (!membership) {
+    const memberships = ctx.orgMemberships;
+    if (!membership || !memberships) {
       return ctx.response.forbidden({ message: "Membership not resolved." });
     }
-    const memberships = ctx.orgMemberships ?? [membership];
     if (!hasMemberType(memberships, "coach") && !grantsOrgAdmin(membership)) {
       return ctx.response.forbidden({ message: "Coach access required." });
     }

--- a/apps/backend/app/middleware/routes/org-coach.ts
+++ b/apps/backend/app/middleware/routes/org-coach.ts
@@ -1,11 +1,14 @@
+import { grantsOrgAdmin, hasMemberType } from "#shared/org/membership";
 import type { HttpContext } from "@adonisjs/core/http";
 import type { NextFn } from "@adonisjs/core/types/http";
 
 /**
- * Allows users whose membership is either type=coach or role=admin.
- * Org admins can reach coach routes even if they aren't themselves a
- * coach — this matches the spec's "admin implies coach access for
- * coach-scoped routes" rule.
+ * Allows users who hold a coach membership, or who administer the org.
+ * Org admins — including Organizers, who administer by definition — can reach
+ * coach routes even if they aren't themselves a coach; this matches the spec's
+ * "admin implies coach access for coach-scoped routes" rule. Reaching a coach
+ * route this way never makes an Organizer a Coach: it grants no Roster Entry
+ * and no place in any coach-facing list.
  */
 export default class OrgCoachMiddleware {
   async handle(ctx: HttpContext, next: NextFn) {
@@ -13,7 +16,8 @@ export default class OrgCoachMiddleware {
     if (!membership) {
       return ctx.response.forbidden({ message: "Membership not resolved." });
     }
-    if (membership.type !== "coach" && membership.role !== "admin") {
+    const memberships = ctx.orgMemberships ?? [membership];
+    if (!hasMemberType(memberships, "coach") && !grantsOrgAdmin(membership)) {
       return ctx.response.forbidden({ message: "Coach access required." });
     }
     return next();

--- a/apps/backend/app/middleware/routes/org-dancer.ts
+++ b/apps/backend/app/middleware/routes/org-dancer.ts
@@ -1,10 +1,12 @@
+import { grantsOrgAdmin, hasMemberType } from "#shared/org/membership";
 import type { HttpContext } from "@adonisjs/core/http";
 import type { NextFn } from "@adonisjs/core/types/http";
 
 /**
- * Allows users whose membership is type=dancer or role=admin.
- * Org admins can reach dancer routes so they can test the dancer
- * experience (mirrors how orgCoach grants admin access to coach routes).
+ * Allows users who hold a dancer membership, or who administer the org.
+ * Org admins — including Organizers, who administer by definition — can reach
+ * dancer routes so they can test the dancer experience (mirrors how orgCoach
+ * grants admin access to coach routes).
  */
 export default class OrgDancerMiddleware {
   async handle(ctx: HttpContext, next: NextFn) {
@@ -12,7 +14,8 @@ export default class OrgDancerMiddleware {
     if (!membership) {
       return ctx.response.forbidden({ message: "Membership not resolved." });
     }
-    if (membership.type !== "dancer" && membership.role !== "admin") {
+    const memberships = ctx.orgMemberships ?? [membership];
+    if (!hasMemberType(memberships, "dancer") && !grantsOrgAdmin(membership)) {
       return ctx.response.forbidden({ message: "Dancer access required." });
     }
     return next();

--- a/apps/backend/app/middleware/routes/org-dancer.ts
+++ b/apps/backend/app/middleware/routes/org-dancer.ts
@@ -11,10 +11,10 @@ import type { NextFn } from "@adonisjs/core/types/http";
 export default class OrgDancerMiddleware {
   async handle(ctx: HttpContext, next: NextFn) {
     const membership = ctx.orgMembership;
-    if (!membership) {
+    const memberships = ctx.orgMemberships;
+    if (!membership || !memberships) {
       return ctx.response.forbidden({ message: "Membership not resolved." });
     }
-    const memberships = ctx.orgMemberships ?? [membership];
     if (!hasMemberType(memberships, "dancer") && !grantsOrgAdmin(membership)) {
       return ctx.response.forbidden({ message: "Dancer access required." });
     }

--- a/apps/backend/app/middleware/routes/org-event.ts
+++ b/apps/backend/app/middleware/routes/org-event.ts
@@ -1,11 +1,11 @@
 import { db } from "#database/connection";
 import { orgEvents, eventRosters } from "#database/schema/org-events";
-import { orgMemberships } from "#database/schema/organizations";
 import type { HttpContext } from "@adonisjs/core/http";
 import type { NextFn } from "@adonisjs/core/types/http";
 import {
   grantsOrgAdmin,
   hasMemberType,
+  loadOrgMemberships,
   resolveEffectiveMembership,
 } from "#shared/org/membership";
 import { isRosterType } from "#database/schema/enums";
@@ -39,17 +39,7 @@ export default class OrgEventMiddleware {
       const user = await ctx.auth.getUserOrFail();
 
       if (mode === "dancerSelfRead" && user.role !== "admin") {
-        // A person can hold more than one membership in an org (ADR 0003), so
-        // read them all rather than an arbitrary first row.
-        const memberships = await db
-          .select({ role: orgMemberships.role, type: orgMemberships.type })
-          .from(orgMemberships)
-          .where(
-            and(
-              eq(orgMemberships.userId, user.id),
-              eq(orgMemberships.orgId, ctx.org.id)
-            )
-          );
+        const memberships = await loadOrgMemberships(db, user.id, ctx.org.id);
 
         if (hasMemberType(memberships, "dancer")) {
           const requestedEventId =
@@ -134,15 +124,7 @@ export default class OrgEventMiddleware {
 
       // Non-admin members must have a roster entry for the active event
       if (!roster && user.role !== "admin") {
-        const memberships = await db
-          .select({ role: orgMemberships.role, type: orgMemberships.type })
-          .from(orgMemberships)
-          .where(
-            and(
-              eq(orgMemberships.userId, user.id),
-              eq(orgMemberships.orgId, ctx.org.id)
-            )
-          );
+        const memberships = await loadOrgMemberships(db, user.id, ctx.org.id);
         const membership = resolveEffectiveMembership(memberships);
         const browseRosters =
           mode === "coachDancerRead" && hasMemberType(memberships, "coach")

--- a/apps/backend/app/middleware/routes/org-event.ts
+++ b/apps/backend/app/middleware/routes/org-event.ts
@@ -3,6 +3,12 @@ import { orgEvents, eventRosters } from "#database/schema/org-events";
 import { orgMemberships } from "#database/schema/organizations";
 import type { HttpContext } from "@adonisjs/core/http";
 import type { NextFn } from "@adonisjs/core/types/http";
+import {
+  grantsOrgAdmin,
+  hasMemberType,
+  resolveEffectiveMembership,
+} from "#shared/org/membership";
+import { isRosterType } from "#database/schema/enums";
 import { and, desc, eq, sql } from "drizzle-orm";
 
 declare module "@adonisjs/core/http" {
@@ -33,7 +39,9 @@ export default class OrgEventMiddleware {
       const user = await ctx.auth.getUserOrFail();
 
       if (mode === "dancerSelfRead" && user.role !== "admin") {
-        const [membership] = await db
+        // A person can hold more than one membership in an org (ADR 0003), so
+        // read them all rather than an arbitrary first row.
+        const memberships = await db
           .select({ role: orgMemberships.role, type: orgMemberships.type })
           .from(orgMemberships)
           .where(
@@ -41,10 +49,9 @@ export default class OrgEventMiddleware {
               eq(orgMemberships.userId, user.id),
               eq(orgMemberships.orgId, ctx.org.id)
             )
-          )
-          .limit(1);
+          );
 
-        if (membership?.type === "dancer") {
+        if (hasMemberType(memberships, "dancer")) {
           const requestedEventId =
             (ctx.params.id as string | undefined) ??
             (ctx.request.input("eventId") as string | undefined);
@@ -102,9 +109,10 @@ export default class OrgEventMiddleware {
       // the LIMIT 1 lookup would be ambiguous. The frontend sends the acting
       // type via `x-act-as-type` while in preview mode; honour it. Real
       // participants only ever have one row, so this is a no-op for them.
+      // Only a Roster type can be acted as — an organizer never has a roster.
       const actAs = ctx.request.header("x-act-as-type");
       const actAsType =
-        actAs === "coach" || actAs === "dancer" ? actAs : undefined;
+        typeof actAs === "string" && isRosterType(actAs) ? actAs : undefined;
 
       const [roster] = ev
         ? await db
@@ -126,7 +134,7 @@ export default class OrgEventMiddleware {
 
       // Non-admin members must have a roster entry for the active event
       if (!roster && user.role !== "admin") {
-        const [membership] = await db
+        const memberships = await db
           .select({ role: orgMemberships.role, type: orgMemberships.type })
           .from(orgMemberships)
           .where(
@@ -134,10 +142,10 @@ export default class OrgEventMiddleware {
               eq(orgMemberships.userId, user.id),
               eq(orgMemberships.orgId, ctx.org.id)
             )
-          )
-          .limit(1);
+          );
+        const membership = resolveEffectiveMembership(memberships);
         const browseRosters =
-          mode === "coachDancerRead" && membership?.type === "coach"
+          mode === "coachDancerRead" && hasMemberType(memberships, "coach")
             ? await db
                 .select({ exists: sql<boolean>`true` })
                 .from(eventRosters)
@@ -152,7 +160,7 @@ export default class OrgEventMiddleware {
                 .limit(1)
             : [];
         const canBrowseDancers = browseRosters.length > 0;
-        if ((!membership || membership.role !== "admin") && !canBrowseDancers) {
+        if (!grantsOrgAdmin(membership) && !canBrowseDancers) {
           return ctx.response.forbidden({
             message: "Not on event roster.",
           });

--- a/apps/backend/app/middleware/routes/org-member.ts
+++ b/apps/backend/app/middleware/routes/org-member.ts
@@ -2,11 +2,19 @@ import { db } from "#database/connection";
 import { orgMemberships } from "#database/schema/organizations";
 import type { HttpContext } from "@adonisjs/core/http";
 import type { NextFn } from "@adonisjs/core/types/http";
+import { resolveEffectiveMembership } from "#shared/org/membership";
 import { and, eq } from "drizzle-orm";
 
 declare module "@adonisjs/core/http" {
   interface HttpContext {
+    /**
+     * The user's highest-privilege membership in this org. A person may hold
+     * both an organizer and a coach membership (ADR 0003), so checks that care
+     * about one specific type must read `orgMemberships` instead.
+     */
     orgMembership?: typeof orgMemberships.$inferSelect;
+    /** Every membership the user holds in this org. */
+    orgMemberships?: (typeof orgMemberships.$inferSelect)[];
   }
 }
 
@@ -25,7 +33,7 @@ export default class OrgMemberMiddleware {
 
     // System admins can access any org without membership
     if (user.role === "admin") {
-      ctx.orgMembership = {
+      const synthetic = {
         id: "system-admin",
         userId: user.id,
         orgId: ctx.org.id,
@@ -34,10 +42,12 @@ export default class OrgMemberMiddleware {
         createdAt: new Date(),
         updatedAt: new Date(),
       } as typeof orgMemberships.$inferSelect;
+      ctx.orgMembership = synthetic;
+      ctx.orgMemberships = [synthetic];
       return next();
     }
 
-    const [membership] = await db
+    const memberships = await db
       .select()
       .from(orgMemberships)
       .where(
@@ -45,8 +55,8 @@ export default class OrgMemberMiddleware {
           eq(orgMemberships.userId, user.id),
           eq(orgMemberships.orgId, ctx.org.id)
         )
-      )
-      .limit(1);
+      );
+    const membership = resolveEffectiveMembership(memberships);
 
     if (!membership) {
       return ctx.response.forbidden({
@@ -54,6 +64,7 @@ export default class OrgMemberMiddleware {
       });
     }
 
+    ctx.orgMemberships = memberships;
     ctx.orgMembership = membership;
     return next();
   }

--- a/apps/backend/app/middleware/routes/org-member.ts
+++ b/apps/backend/app/middleware/routes/org-member.ts
@@ -1,9 +1,11 @@
 import { db } from "#database/connection";
-import { orgMemberships } from "#database/schema/organizations";
+import { type orgMemberships } from "#database/schema/organizations";
 import type { HttpContext } from "@adonisjs/core/http";
 import type { NextFn } from "@adonisjs/core/types/http";
-import { resolveEffectiveMembership } from "#shared/org/membership";
-import { and, eq } from "drizzle-orm";
+import {
+  loadOrgMemberships,
+  resolveEffectiveMembership,
+} from "#shared/org/membership";
 
 declare module "@adonisjs/core/http" {
   interface HttpContext {
@@ -47,15 +49,7 @@ export default class OrgMemberMiddleware {
       return next();
     }
 
-    const memberships = await db
-      .select()
-      .from(orgMemberships)
-      .where(
-        and(
-          eq(orgMemberships.userId, user.id),
-          eq(orgMemberships.orgId, ctx.org.id)
-        )
-      );
+    const memberships = await loadOrgMemberships(db, user.id, ctx.org.id);
     const membership = resolveEffectiveMembership(memberships);
 
     if (!membership) {

--- a/apps/backend/app/middleware/routes/org-roles.spec.ts
+++ b/apps/backend/app/middleware/routes/org-roles.spec.ts
@@ -15,10 +15,16 @@ type CtxState = {
   notFoundBody: { message: string } | null;
 };
 
+/**
+ * Mirrors what OrgMemberMiddleware attaches: `orgMemberships` is the full set
+ * and `orgMembership` the effective one. Tests that pass a single membership
+ * get a one-row set, which is what a person with one membership really has.
+ */
 function mockCtx(opts: {
   user: { id: string } | null;
   org?: { id: string; slug: string } | null;
   membership?: { role: string; type: string } | null;
+  memberships?: Array<{ role: string; type: string }>;
 }) {
   const state: CtxState = {
     nextCalled: false,
@@ -43,6 +49,8 @@ function mockCtx(opts: {
     },
     org: opts.org ?? undefined,
     orgMembership: opts.membership ?? undefined,
+    orgMemberships:
+      opts.memberships ?? (opts.membership ? [opts.membership] : undefined),
   };
   const next = async () => {
     state.nextCalled = true;
@@ -148,6 +156,18 @@ test.group("org role middlewares", (group) => {
     assert.isNotNull(state.forbiddenBody);
   });
 
+  test("orgAdmin allows an organizer even at role=member", async ({
+    assert,
+  }) => {
+    const { ctx, state, next } = mockCtx({
+      user: { id: "u2b" },
+      membership: { role: "member", type: "organizer" },
+    });
+    await new OrgAdminMiddleware().handle(ctx, next);
+    assert.isTrue(state.nextCalled);
+    assert.isNull(state.forbiddenBody);
+  });
+
   // ----- orgCoach ------
   test("orgCoach allows type=coach", async ({ assert }) => {
     const { ctx, state, next } = mockCtx({
@@ -174,6 +194,41 @@ test.group("org role middlewares", (group) => {
     });
     await new OrgCoachMiddleware().handle(ctx, next);
     assert.isFalse(state.nextCalled);
+  });
+
+  test("orgCoach lets an organizer through, as an org admin", async ({
+    assert,
+  }) => {
+    const { ctx, state, next } = mockCtx({
+      user: { id: "u5b" },
+      membership: { role: "member", type: "organizer" },
+    });
+    await new OrgCoachMiddleware().handle(ctx, next);
+    assert.isTrue(state.nextCalled);
+  });
+
+  test("orgMember picks the organizer when a user holds two memberships", async ({
+    assert,
+  }) => {
+    const user = await createUser("m4");
+    const [summit] = await db
+      .select()
+      .from(organizations)
+      .where(eq(organizations.slug, "summit"));
+    await db.insert(orgMemberships).values([
+      { userId: user.id, orgId: summit!.id, role: "member", type: "coach" },
+      { userId: user.id, orgId: summit!.id, role: "member", type: "organizer" },
+    ]);
+
+    const { ctx, state, next } = mockCtx({
+      user: { id: user.id },
+      org: summit as any,
+    });
+    await new OrgMemberMiddleware().handle(ctx, next);
+
+    assert.isTrue(state.nextCalled);
+    assert.equal(ctx.orgMembership?.type, "organizer");
+    assert.lengthOf(ctx.orgMemberships ?? [], 2);
   });
 
   // ----- orgDancer ------

--- a/apps/backend/app/modules/admin/add-org-member/validator.ts
+++ b/apps/backend/app/modules/admin/add-org-member/validator.ts
@@ -8,7 +8,7 @@ export const schema = vine.create(
     }),
     email: vine.string().email(),
     role: vine.enum(["admin", "member"]),
-    type: vine.enum(["coach", "dancer"]),
+    type: vine.enum(["coach", "dancer", "organizer"]),
   })
 );
 

--- a/apps/backend/app/modules/admin/update-org-member/service.ts
+++ b/apps/backend/app/modules/admin/update-org-member/service.ts
@@ -1,4 +1,5 @@
 import { orgMemberships } from "#database/schema/organizations";
+import type { OrgMemberType } from "#database/schema/enums";
 import { DatabaseService } from "#database/service";
 import { inject } from "@adonisjs/core";
 import { eq } from "drizzle-orm";
@@ -9,7 +10,8 @@ export class Service {
   constructor(private db: DatabaseService) {}
 
   async execute({ params, role, type }: Validator) {
-    const updates: Partial<{ role: "admin" | "member"; type: "coach" | "dancer" }> = {};
+    const updates: Partial<{ role: "admin" | "member"; type: OrgMemberType }> =
+      {};
     if (role) updates.role = role;
     if (type) updates.type = type;
 

--- a/apps/backend/app/modules/admin/update-org-member/validator.ts
+++ b/apps/backend/app/modules/admin/update-org-member/validator.ts
@@ -8,7 +8,7 @@ export const schema = vine.create(
       memberId: vine.string().uuid(),
     }),
     role: vine.enum(["admin", "member"]).optional(),
-    type: vine.enum(["coach", "dancer"]).optional(),
+    type: vine.enum(["coach", "dancer", "organizer"]).optional(),
   })
 );
 

--- a/apps/backend/app/modules/auth/signup/service.ts
+++ b/apps/backend/app/modules/auth/signup/service.ts
@@ -9,6 +9,7 @@ import hash from "@adonisjs/core/services/hash";
 import { and, eq, isNull } from "drizzle-orm";
 import { SignupEvent } from "./event.ts";
 import type { Validator } from "./validator.ts";
+import { nonOrganizerMembershipConflict } from "#shared/org/membership";
 
 @inject()
 export class Service {
@@ -112,9 +113,7 @@ export class Service {
         await tx
           .insert(orgMemberships)
           .values({ userId, orgId: event.orgId, type: "coach", role: "member" })
-          .onConflictDoNothing({
-            target: [orgMemberships.userId, orgMemberships.orgId],
-          });
+          .onConflictDoNothing(nonOrganizerMembershipConflict());
       }
     }
 

--- a/apps/backend/app/modules/auth/signup/service.ts
+++ b/apps/backend/app/modules/auth/signup/service.ts
@@ -9,7 +9,7 @@ import hash from "@adonisjs/core/services/hash";
 import { and, eq, isNull } from "drizzle-orm";
 import { SignupEvent } from "./event.ts";
 import type { Validator } from "./validator.ts";
-import { nonOrganizerMembershipConflict } from "#shared/org/membership";
+import { rosterTypeMembershipConflict } from "#shared/org/membership";
 
 @inject()
 export class Service {
@@ -113,7 +113,7 @@ export class Service {
         await tx
           .insert(orgMemberships)
           .values({ userId, orgId: event.orgId, type: "coach", role: "member" })
-          .onConflictDoNothing(nonOrganizerMembershipConflict());
+          .onConflictDoNothing(rosterTypeMembershipConflict());
       }
     }
 

--- a/apps/backend/app/modules/dancers/profile/create-dancer/event.ts
+++ b/apps/backend/app/modules/dancers/profile/create-dancer/event.ts
@@ -35,6 +35,8 @@ export class DancerCreatedHandler {
     // Org-provisioned dancers are freemium and must not receive the S2S
     // welcome email. If they later pay for full S2S access, the Stripe
     // SubscriptionCreatedEvent sends the premium welcome email instead.
+    // Any membership counts, organizer included: someone who already belongs to
+    // an org reached the platform through it, whichever hat they wear there.
     const [orgMembership] = await db
       .select({ userId: orgMemberships.userId })
       .from(orgMemberships)

--- a/apps/backend/app/modules/organizations/backfill-organizers.spec.ts
+++ b/apps/backend/app/modules/organizations/backfill-organizers.spec.ts
@@ -1,0 +1,177 @@
+import { db } from "#database/connection";
+import { eventRosters, orgEvents } from "#database/schema/org-events";
+import { organizations, orgMemberships } from "#database/schema/organizations";
+import { users } from "#database/schema/users";
+import { seedOrganizations } from "#commands/backfill-organizations";
+import { backfillOrganizers } from "#commands/backfill-organizers";
+import { test } from "@japa/runner";
+import { and, eq } from "drizzle-orm";
+
+test.group("backfill organizers", (group) => {
+  let orgId: string;
+  let eventId: string;
+  let seq = 0;
+
+  group.each.setup(async () => {
+    await db.delete(organizations).execute();
+    await seedOrganizations();
+    const [org] = await db
+      .select()
+      .from(organizations)
+      .where(eq(organizations.slug, "summit"));
+    orgId = org!.id;
+
+    const [event] = await db
+      .insert(orgEvents)
+      .values({
+        orgId,
+        name: "Backfill Event",
+        startDate: "2030-01-01",
+        endDate: "2030-01-02",
+      })
+      .returning();
+    eventId = event!.id;
+  });
+
+  async function makeUser() {
+    seq += 1;
+    const stamp = `${Date.now()}_${seq}`;
+    const [user] = await db
+      .insert(users)
+      .values({
+        username: `bf_${stamp}`,
+        email: `bf_${stamp}@example.com`,
+        displayEmail: `bf_${stamp}@example.com`,
+        firstName: "Back",
+        lastName: "Fill",
+        password: "hashed",
+        role: "user",
+        type: "school",
+      })
+      .returning();
+    return user!;
+  }
+
+  const typeOf = async (userId: string) => {
+    const rows = await db
+      .select({ type: orgMemberships.type })
+      .from(orgMemberships)
+      .where(
+        and(eq(orgMemberships.userId, userId), eq(orgMemberships.orgId, orgId))
+      );
+    return rows.map((r) => r.type).sort();
+  };
+
+  test("reclassifies an admin coach who is on no roster", async ({
+    assert,
+  }) => {
+    const user = await makeUser();
+    await db
+      .insert(orgMemberships)
+      .values({ userId: user.id, orgId, type: "coach", role: "admin" });
+
+    const dry = await backfillOrganizers({ orgSlug: "summit" });
+    assert.equal(dry.reclassified, 0);
+    assert.deepEqual(
+      await typeOf(user.id),
+      ["coach"],
+      "dry run must not write"
+    );
+    assert.equal(dry.candidates[0]?.verdict, "reclassify");
+
+    const applied = await backfillOrganizers({
+      apply: true,
+      orgSlug: "summit",
+    });
+    assert.equal(applied.reclassified, 1);
+    assert.deepEqual(await typeOf(user.id), ["organizer"]);
+  });
+
+  test("leaves an admin coach who holds a real roster entry", async ({
+    assert,
+  }) => {
+    const user = await makeUser();
+    await db
+      .insert(orgMemberships)
+      .values({ userId: user.id, orgId, type: "coach", role: "admin" });
+    await db.insert(eventRosters).values({
+      eventId,
+      userId: user.id,
+      type: "coach",
+      email: user.email,
+      firstName: "Back",
+      lastName: "Fill",
+    });
+
+    const result = await backfillOrganizers({ apply: true, orgSlug: "summit" });
+
+    assert.equal(result.reclassified, 0);
+    assert.equal(result.candidates[0]?.verdict, "coaches-too");
+    assert.deepEqual(await typeOf(user.id), ["coach"]);
+  });
+
+  test("a view-as preview roster is not evidence of coaching", async ({
+    assert,
+  }) => {
+    const user = await makeUser();
+    await db
+      .insert(orgMemberships)
+      .values({ userId: user.id, orgId, type: "coach", role: "admin" });
+    await db.insert(eventRosters).values({
+      eventId,
+      userId: user.id,
+      type: "coach",
+      email: user.email,
+      firstName: "Back",
+      lastName: "Fill",
+      isStaff: true,
+    });
+
+    const result = await backfillOrganizers({ apply: true, orgSlug: "summit" });
+
+    assert.equal(result.reclassified, 1);
+    assert.equal(result.candidates[0]?.previewRosters, 1);
+    assert.deepEqual(await typeOf(user.id), ["organizer"]);
+  });
+
+  test("never touches a plain coach member", async ({ assert }) => {
+    const user = await makeUser();
+    await db
+      .insert(orgMemberships)
+      .values({ userId: user.id, orgId, type: "coach", role: "member" });
+
+    const result = await backfillOrganizers({ apply: true, orgSlug: "summit" });
+
+    assert.lengthOf(result.candidates, 0);
+    assert.deepEqual(await typeOf(user.id), ["coach"]);
+  });
+
+  test("skips someone who already holds an organizer membership", async ({
+    assert,
+  }) => {
+    const user = await makeUser();
+    await db.insert(orgMemberships).values([
+      { userId: user.id, orgId, type: "coach", role: "admin" },
+      { userId: user.id, orgId, type: "organizer", role: "member" },
+    ]);
+
+    const result = await backfillOrganizers({ apply: true, orgSlug: "summit" });
+
+    assert.equal(result.reclassified, 0);
+    assert.equal(result.candidates[0]?.verdict, "already-organizer");
+    assert.deepEqual(await typeOf(user.id), ["coach", "organizer"]);
+  });
+
+  test("is idempotent", async ({ assert }) => {
+    const user = await makeUser();
+    await db
+      .insert(orgMemberships)
+      .values({ userId: user.id, orgId, type: "coach", role: "admin" });
+
+    await backfillOrganizers({ apply: true, orgSlug: "summit" });
+    const second = await backfillOrganizers({ apply: true, orgSlug: "summit" });
+
+    assert.lengthOf(second.candidates, 0);
+    assert.deepEqual(await typeOf(user.id), ["organizer"]);
+  });
+});

--- a/apps/backend/app/modules/orgs/events/reconciliation/service.ts
+++ b/apps/backend/app/modules/orgs/events/reconciliation/service.ts
@@ -6,7 +6,7 @@ import { users } from "#database/schema/users";
 import { inject } from "@adonisjs/core";
 import { and, eq, isNull, notInArray, sql } from "drizzle-orm";
 import { sendSchoolAccountInviteEmail } from "#shared/org/school-account-invite-email";
-import { nonOrganizerMembershipConflict } from "#shared/org/membership";
+import { rosterTypeMembershipConflict } from "#shared/org/membership";
 
 @inject()
 export class ReconciliationService {
@@ -162,7 +162,7 @@ export class ReconciliationService {
             type: "coach",
             role: "member",
           })
-          .onConflictDoNothing(nonOrganizerMembershipConflict());
+          .onConflictDoNothing(rosterTypeMembershipConflict());
       }
 
       // Mark matching unconsumed invite consumed

--- a/apps/backend/app/modules/orgs/events/reconciliation/service.ts
+++ b/apps/backend/app/modules/orgs/events/reconciliation/service.ts
@@ -6,6 +6,7 @@ import { users } from "#database/schema/users";
 import { inject } from "@adonisjs/core";
 import { and, eq, isNull, notInArray, sql } from "drizzle-orm";
 import { sendSchoolAccountInviteEmail } from "#shared/org/school-account-invite-email";
+import { nonOrganizerMembershipConflict } from "#shared/org/membership";
 
 @inject()
 export class ReconciliationService {
@@ -161,9 +162,7 @@ export class ReconciliationService {
             type: "coach",
             role: "member",
           })
-          .onConflictDoNothing({
-            target: [orgMemberships.userId, orgMemberships.orgId],
-          });
+          .onConflictDoNothing(nonOrganizerMembershipConflict());
       }
 
       // Mark matching unconsumed invite consumed

--- a/apps/backend/app/modules/orgs/events/rosters/attach/service.ts
+++ b/apps/backend/app/modules/orgs/events/rosters/attach/service.ts
@@ -14,7 +14,7 @@ import {
 } from "#shared/org/grant-account-tier";
 import { inject } from "@adonisjs/core";
 import { and, eq, isNull, ne, sql } from "drizzle-orm";
-import { nonOrganizerMembershipConflict } from "#shared/org/membership";
+import { rosterTypeMembershipConflict } from "#shared/org/membership";
 
 export class RosterNotFoundError extends Error {
   code = "ROSTER_NOT_FOUND" as const;
@@ -124,7 +124,8 @@ export class AttachAccountService {
       const oldFirstName = roster.firstName;
       const oldLastName = roster.lastName;
       const previousUserId = roster.userId;
-      const isRelink = previousUserId !== null && previousUserId !== targetUserId;
+      const isRelink =
+        previousUserId !== null && previousUserId !== targetUserId;
 
       // Reassigning a claimed entry unregisters its current holder, so it takes
       // a deliberate confirmation. Re-running an attach for the account that
@@ -219,7 +220,7 @@ export class AttachAccountService {
             type: "dancer",
             role: "member",
           })
-          .onConflictDoNothing(nonOrganizerMembershipConflict());
+          .onConflictDoNothing(rosterTypeMembershipConflict());
 
         // Bring the account's advisory window up to what this roster entitles
         // it to: granted outright if it had no tier, extended if this event runs

--- a/apps/backend/app/modules/orgs/events/rosters/attach/service.ts
+++ b/apps/backend/app/modules/orgs/events/rosters/attach/service.ts
@@ -14,6 +14,7 @@ import {
 } from "#shared/org/grant-account-tier";
 import { inject } from "@adonisjs/core";
 import { and, eq, isNull, ne, sql } from "drizzle-orm";
+import { nonOrganizerMembershipConflict } from "#shared/org/membership";
 
 export class RosterNotFoundError extends Error {
   code = "ROSTER_NOT_FOUND" as const;
@@ -218,9 +219,7 @@ export class AttachAccountService {
             type: "dancer",
             role: "member",
           })
-          .onConflictDoNothing({
-            target: [orgMemberships.userId, orgMemberships.orgId],
-          });
+          .onConflictDoNothing(nonOrganizerMembershipConflict());
 
         // Bring the account's advisory window up to what this roster entitles
         // it to: granted outright if it had no tier, extended if this event runs

--- a/apps/backend/app/modules/orgs/events/rosters/delete/service.ts
+++ b/apps/backend/app/modules/orgs/events/rosters/delete/service.ts
@@ -1,6 +1,7 @@
 import { DatabaseService } from "#database/service";
 import { inject } from "@adonisjs/core";
 import { eventRosters, orgEvents } from "#database/schema/org-events";
+import { ROSTER_TYPES } from "#database/schema/enums";
 import { orgMemberships } from "#database/schema/organizations";
 import { and, eq, inArray } from "drizzle-orm";
 import type { Validator } from "./validator.ts";
@@ -56,7 +57,10 @@ export class DeleteRosterService {
         });
       }
 
-      // Rescind org access for users with no remaining roster entries
+      // Rescind participant org access for users with no remaining roster
+      // entries. An Organizer's membership is never a consequence of a Roster
+      // Entry, so it is left alone — removing someone from a roster must not
+      // strip the org from the person who runs it (ADR 0003).
       const affectedUserIds = [
         ...new Set(
           before
@@ -86,7 +90,8 @@ export class DeleteRosterService {
               and(
                 eq(orgMemberships.userId, userId),
                 eq(orgMemberships.orgId, orgId),
-                eq(orgMemberships.role, "member")
+                eq(orgMemberships.role, "member"),
+                inArray(orgMemberships.type, [...ROSTER_TYPES])
               )
             );
         }

--- a/apps/backend/app/modules/orgs/events/upload-coaches/service.ts
+++ b/apps/backend/app/modules/orgs/events/upload-coaches/service.ts
@@ -21,6 +21,7 @@ import { verifyPreviewToken } from "#shared/org/preview-token";
 import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import { randomBytes } from "node:crypto";
 import logger from "@adonisjs/core/services/logger";
+import { nonOrganizerMembershipConflict } from "#shared/org/membership";
 
 @inject()
 export class UploadCoachesService {
@@ -184,9 +185,7 @@ export class UploadCoachesService {
                   type: "coach",
                   role: "member",
                 })
-                .onConflictDoNothing({
-                  target: [orgMemberships.userId, orgMemberships.orgId],
-                });
+                .onConflictDoNothing(nonOrganizerMembershipConflict());
             } else {
               // Mint a school invite for unmatched rows. On re-upload keep the
               // token STABLE per (eventId, email): preserve the existing row's

--- a/apps/backend/app/modules/orgs/events/upload-coaches/service.ts
+++ b/apps/backend/app/modules/orgs/events/upload-coaches/service.ts
@@ -21,7 +21,7 @@ import { verifyPreviewToken } from "#shared/org/preview-token";
 import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import { randomBytes } from "node:crypto";
 import logger from "@adonisjs/core/services/logger";
-import { nonOrganizerMembershipConflict } from "#shared/org/membership";
+import { rosterTypeMembershipConflict } from "#shared/org/membership";
 
 @inject()
 export class UploadCoachesService {
@@ -185,7 +185,7 @@ export class UploadCoachesService {
                   type: "coach",
                   role: "member",
                 })
-                .onConflictDoNothing(nonOrganizerMembershipConflict());
+                .onConflictDoNothing(rosterTypeMembershipConflict());
             } else {
               // Mint a school invite for unmatched rows. On re-upload keep the
               // token STABLE per (eventId, email): preserve the existing row's

--- a/apps/backend/app/modules/orgs/events/upload-dancers/service.ts
+++ b/apps/backend/app/modules/orgs/events/upload-dancers/service.ts
@@ -27,6 +27,7 @@ import { grantOrgAccountTier } from "#shared/org/grant-account-tier";
 import { verifyPreviewToken } from "#shared/org/preview-token";
 import { and, eq, inArray } from "drizzle-orm";
 import logger from "@adonisjs/core/services/logger";
+import { nonOrganizerMembershipConflict } from "#shared/org/membership";
 
 function randomToken(): string {
   return randomBytes(32).toString("base64url");
@@ -314,9 +315,7 @@ export class UploadDancersService {
                   type: "dancer",
                   role: "member",
                 })
-                .onConflictDoNothing({
-                  target: [orgMemberships.userId, orgMemberships.orgId],
-                });
+                .onConflictDoNothing(nonOrganizerMembershipConflict());
 
               // Matched dancers already had an account, so they never got a tier
               // from the invite flow. Grant what their roster entitles them to —

--- a/apps/backend/app/modules/orgs/events/upload-dancers/service.ts
+++ b/apps/backend/app/modules/orgs/events/upload-dancers/service.ts
@@ -27,7 +27,7 @@ import { grantOrgAccountTier } from "#shared/org/grant-account-tier";
 import { verifyPreviewToken } from "#shared/org/preview-token";
 import { and, eq, inArray } from "drizzle-orm";
 import logger from "@adonisjs/core/services/logger";
-import { nonOrganizerMembershipConflict } from "#shared/org/membership";
+import { rosterTypeMembershipConflict } from "#shared/org/membership";
 
 function randomToken(): string {
   return randomBytes(32).toString("base64url");
@@ -315,7 +315,7 @@ export class UploadDancersService {
                   type: "dancer",
                   role: "member",
                 })
-                .onConflictDoNothing(nonOrganizerMembershipConflict());
+                .onConflictDoNothing(rosterTypeMembershipConflict());
 
               // Matched dancers already had an account, so they never got a tier
               // from the invite flow. Grant what their roster entitles them to —

--- a/apps/backend/app/modules/orgs/events/view-as/service.ts
+++ b/apps/backend/app/modules/orgs/events/view-as/service.ts
@@ -1,10 +1,12 @@
+import type { RosterType } from "#database/schema/enums";
 import { DatabaseService } from "#database/service";
 import { eventRosters } from "#database/schema/org-events";
 import { inject } from "@adonisjs/core";
 import type { SessionUser } from "#auth/provider";
 import { and, eq } from "drizzle-orm";
 
-type ViewAsType = "coach" | "dancer";
+/** Admins preview the event as a Coach or a Dancer; there is no organizer view. */
+type ViewAsType = RosterType;
 
 /**
  * Provisions an admin's staff "preview" roster for the active event so they can

--- a/apps/backend/app/modules/orgs/get-org/service.ts
+++ b/apps/backend/app/modules/orgs/get-org/service.ts
@@ -1,3 +1,5 @@
+import type { OrgMemberType, RosterType } from "#database/schema/enums";
+import { resolveEffectiveMembership } from "#shared/org/membership";
 import { DatabaseService } from "#database/service";
 import { organizations, orgMemberships } from "#database/schema/organizations";
 import { eventRosters, orgEvents } from "#database/schema/org-events";
@@ -8,7 +10,7 @@ import { and, asc, desc, eq, sql } from "drizzle-orm";
 export interface OrgRosterSummary {
   id: string;
   eventId: string;
-  type: "coach" | "dancer";
+  type: RosterType;
   eventName: string;
   eventStartDate: string;
   eventEndDate: string;
@@ -18,9 +20,13 @@ export interface OrgRosterSummary {
 
 export interface GetOrgResult {
   org: typeof organizations.$inferSelect;
+  /**
+   * The user's highest-privilege membership. A person may hold both an
+   * organizer and a coach membership in the same Org (ADR 0003).
+   */
   membership: {
     role: "admin" | "member";
-    type: "coach" | "dancer";
+    type: OrgMemberType;
   } | null;
   myRoster: OrgRosterSummary | null;
   myRosters: OrgRosterSummary[];
@@ -46,7 +52,7 @@ export class GetOrgService {
       let myRoster: GetOrgResult["myRoster"] = null;
       let myRosters: GetOrgResult["myRosters"] = [];
       if (userId) {
-        const [row] = await db
+        const membershipRows = await db
           .select({
             role: orgMemberships.role,
             type: orgMemberships.type,
@@ -57,14 +63,8 @@ export class GetOrgService {
               eq(orgMemberships.orgId, org.id),
               eq(orgMemberships.userId, userId)
             )
-          )
-          .limit(1);
-        if (row) {
-          membership = {
-            role: row.role as "admin" | "member",
-            type: row.type as "coach" | "dancer",
-          };
-        }
+          );
+        membership = resolveEffectiveMembership(membershipRows);
 
         const today = new Date().toISOString().slice(0, 10);
         const rosterRows = await db
@@ -100,7 +100,7 @@ export class GetOrgService {
         myRosters = rosterRows.map((roster) => ({
           id: roster.id,
           eventId: roster.eventId,
-          type: roster.type as "coach" | "dancer",
+          type: roster.type,
           eventName: roster.eventName,
           eventStartDate: roster.eventStartDate,
           eventEndDate: roster.eventEndDate,

--- a/apps/backend/app/modules/orgs/organizer-membership.spec.ts
+++ b/apps/backend/app/modules/orgs/organizer-membership.spec.ts
@@ -1,0 +1,157 @@
+import { db } from "#database/connection";
+import { eventRosters, orgEvents } from "#database/schema/org-events";
+import { organizations, orgMemberships } from "#database/schema/organizations";
+import { users } from "#database/schema/users";
+import { seedOrganizations } from "#commands/backfill-organizations";
+import { nonOrganizerMembershipConflict } from "#shared/org/membership";
+import { test } from "@japa/runner";
+import { and, eq, sql } from "drizzle-orm";
+
+/**
+ * The invariants ADR 0003 puts on `organizer`. The enum value is cheap; these
+ * are the things that would quietly break if a later change treated an org
+ * member type as "coach or dancer".
+ */
+test.group("organizer membership", (group) => {
+  let orgId: string;
+  let userId: string;
+
+  group.each.setup(async () => {
+    await db.delete(organizations).execute();
+    await seedOrganizations();
+    const [org] = await db
+      .select()
+      .from(organizations)
+      .where(eq(organizations.slug, "summit"));
+    orgId = org!.id;
+
+    const stamp = `${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+    const [user] = await db
+      .insert(users)
+      .values({
+        username: `organizer_${stamp}`,
+        email: `organizer_${stamp}@example.com`,
+        firstName: "Ora",
+        lastName: "Ganiser",
+        displayEmail: `organizer_${stamp}@example.com`,
+        password: "hashed",
+        role: "user",
+        type: "school",
+      })
+      .returning();
+    userId = user!.id;
+  });
+
+  test("an organizer membership can be created", async ({ assert }) => {
+    const [membership] = await db
+      .insert(orgMemberships)
+      .values({ userId, orgId, type: "organizer", role: "member" })
+      .returning();
+
+    assert.equal(membership!.type, "organizer");
+  });
+
+  test("the same person can hold both an organizer and a coach membership", async ({
+    assert,
+  }) => {
+    await db
+      .insert(orgMemberships)
+      .values({ userId, orgId, type: "organizer", role: "member" });
+    await db
+      .insert(orgMemberships)
+      .values({ userId, orgId, type: "coach", role: "member" });
+
+    const held = await db
+      .select({ type: orgMemberships.type })
+      .from(orgMemberships)
+      .where(
+        and(eq(orgMemberships.userId, userId), eq(orgMemberships.orgId, orgId))
+      );
+
+    assert.sameMembers(
+      held.map((m) => m.type),
+      ["organizer", "coach"]
+    );
+  });
+
+  test("coach and dancer stay mutually exclusive, as before organizer existed", async ({
+    assert,
+  }) => {
+    await db
+      .insert(orgMemberships)
+      .values({ userId, orgId, type: "coach", role: "member" });
+
+    await assert.rejects(() =>
+      db
+        .insert(orgMemberships)
+        .values({ userId, orgId, type: "dancer", role: "member" })
+        .then(() => undefined)
+    );
+  });
+
+  test("a second organizer membership is rejected", async ({ assert }) => {
+    await db
+      .insert(orgMemberships)
+      .values({ userId, orgId, type: "organizer", role: "member" });
+
+    await assert.rejects(() =>
+      db
+        .insert(orgMemberships)
+        .values({ userId, orgId, type: "organizer", role: "admin" })
+        .then(() => undefined)
+    );
+  });
+
+  test("upserting a coach membership leaves an existing organizer one alone", async ({
+    assert,
+  }) => {
+    await db
+      .insert(orgMemberships)
+      .values({ userId, orgId, type: "organizer", role: "member" });
+
+    // The shape every roster/invite flow uses to grant participant membership.
+    await db
+      .insert(orgMemberships)
+      .values({ userId, orgId, type: "coach", role: "member" })
+      .onConflictDoNothing(nonOrganizerMembershipConflict());
+    await db
+      .insert(orgMemberships)
+      .values({ userId, orgId, type: "coach", role: "member" })
+      .onConflictDoNothing(nonOrganizerMembershipConflict());
+
+    const held = await db
+      .select({ type: orgMemberships.type })
+      .from(orgMemberships)
+      .where(
+        and(eq(orgMemberships.userId, userId), eq(orgMemberships.orgId, orgId))
+      );
+
+    assert.sameMembers(
+      held.map((m) => m.type),
+      ["organizer", "coach"]
+    );
+  });
+
+  test("an organizer can never become a roster entry", async ({ assert }) => {
+    const [event] = await db
+      .insert(orgEvents)
+      .values({
+        orgId,
+        name: "Organizer Invariant Event",
+        startDate: "2030-01-01",
+        endDate: "2030-01-02",
+      })
+      .returning();
+
+    // Bypasses the TypeScript narrowing on `event_rosters.type` on purpose:
+    // the database must refuse this even if application code ever slips.
+    await assert.rejects(() =>
+      db
+        .execute(
+          sql`insert into ${eventRosters} (event_id, type, email, first_name, last_name)
+              values (${event!.id}, 'organizer', 'ora@example.com', 'Ora', 'Ganiser')`
+        )
+        .then(() => undefined)
+    );
+  });
+});

--- a/apps/backend/app/modules/orgs/organizer-membership.spec.ts
+++ b/apps/backend/app/modules/orgs/organizer-membership.spec.ts
@@ -3,7 +3,7 @@ import { eventRosters, orgEvents } from "#database/schema/org-events";
 import { organizations, orgMemberships } from "#database/schema/organizations";
 import { users } from "#database/schema/users";
 import { seedOrganizations } from "#commands/backfill-organizations";
-import { nonOrganizerMembershipConflict } from "#shared/org/membership";
+import { rosterTypeMembershipConflict } from "#shared/org/membership";
 import { test } from "@japa/runner";
 import { and, eq, sql } from "drizzle-orm";
 
@@ -113,11 +113,11 @@ test.group("organizer membership", (group) => {
     await db
       .insert(orgMemberships)
       .values({ userId, orgId, type: "coach", role: "member" })
-      .onConflictDoNothing(nonOrganizerMembershipConflict());
+      .onConflictDoNothing(rosterTypeMembershipConflict());
     await db
       .insert(orgMemberships)
       .values({ userId, orgId, type: "coach", role: "member" })
-      .onConflictDoNothing(nonOrganizerMembershipConflict());
+      .onConflictDoNothing(rosterTypeMembershipConflict());
 
     const held = await db
       .select({ type: orgMemberships.type })

--- a/apps/backend/app/modules/orgs/register-school/service.spec.ts
+++ b/apps/backend/app/modules/orgs/register-school/service.spec.ts
@@ -7,7 +7,7 @@ import { eventRosters, orgEvents } from "#database/schema/org-events";
 import { schoolInvites, schoolProfiles } from "#database/schema/schools";
 import { seedOrganizations } from "#commands/backfill-organizations";
 import { randomBytes } from "node:crypto";
-import { nonOrganizerMembershipConflict } from "#shared/org/membership";
+import { rosterTypeMembershipConflict } from "#shared/org/membership";
 
 function token() {
   return randomBytes(32).toString("hex");
@@ -538,7 +538,7 @@ test.group("School invite + activation paths", (group) => {
         type: "coach",
         role: "member",
       })
-      .onConflictDoNothing(nonOrganizerMembershipConflict());
+      .onConflictDoNothing(rosterTypeMembershipConflict());
 
     const [linked] = await db
       .select()

--- a/apps/backend/app/modules/orgs/register-school/service.spec.ts
+++ b/apps/backend/app/modules/orgs/register-school/service.spec.ts
@@ -7,6 +7,7 @@ import { eventRosters, orgEvents } from "#database/schema/org-events";
 import { schoolInvites, schoolProfiles } from "#database/schema/schools";
 import { seedOrganizations } from "#commands/backfill-organizations";
 import { randomBytes } from "node:crypto";
+import { nonOrganizerMembershipConflict } from "#shared/org/membership";
 
 function token() {
   return randomBytes(32).toString("hex");
@@ -537,9 +538,7 @@ test.group("School invite + activation paths", (group) => {
         type: "coach",
         role: "member",
       })
-      .onConflictDoNothing({
-        target: [orgMemberships.userId, orgMemberships.orgId],
-      });
+      .onConflictDoNothing(nonOrganizerMembershipConflict());
 
     const [linked] = await db
       .select()

--- a/apps/backend/app/modules/orgs/register-school/service.ts
+++ b/apps/backend/app/modules/orgs/register-school/service.ts
@@ -7,6 +7,7 @@ import { inject } from "@adonisjs/core";
 import hash from "@adonisjs/core/services/hash";
 import { and, eq, isNull } from "drizzle-orm";
 import type { Validator } from "./validator.ts";
+import { nonOrganizerMembershipConflict } from "#shared/org/membership";
 
 export class InviteInvalidError extends Error {
   constructor(message = "Invite is invalid or has expired.") {
@@ -103,9 +104,7 @@ export class RegisterSchoolService {
             type: "coach",
             role: "member",
           })
-          .onConflictDoNothing({
-            target: [orgMemberships.userId, orgMemberships.orgId],
-          });
+          .onConflictDoNothing(nonOrganizerMembershipConflict());
       }
 
       await tx

--- a/apps/backend/app/modules/orgs/register-school/service.ts
+++ b/apps/backend/app/modules/orgs/register-school/service.ts
@@ -7,7 +7,7 @@ import { inject } from "@adonisjs/core";
 import hash from "@adonisjs/core/services/hash";
 import { and, eq, isNull } from "drizzle-orm";
 import type { Validator } from "./validator.ts";
-import { nonOrganizerMembershipConflict } from "#shared/org/membership";
+import { rosterTypeMembershipConflict } from "#shared/org/membership";
 
 export class InviteInvalidError extends Error {
   constructor(message = "Invite is invalid or has expired.") {
@@ -104,7 +104,7 @@ export class RegisterSchoolService {
             type: "coach",
             role: "member",
           })
-          .onConflictDoNothing(nonOrganizerMembershipConflict());
+          .onConflictDoNothing(rosterTypeMembershipConflict());
       }
 
       await tx

--- a/apps/backend/app/modules/orgs/scouting/schools/list/service.ts
+++ b/apps/backend/app/modules/orgs/scouting/schools/list/service.ts
@@ -54,12 +54,14 @@ export class ListSchoolsService {
             // Exclude rosters owned by an admin — admins are never real
             // participating schools, even if they hold a non-staff roster
             // created before the is_staff flag existed. Covers both org-level
-            // admins (org_memberships.role) and platform admins (users.role).
+            // admins (org_memberships.role, plus Organizers, who administer by
+            // definition) and platform admins (users.role).
             sql`NOT EXISTS (
               SELECT 1 FROM ${orgMemberships}
               WHERE ${orgMemberships.userId} = ${eventRosters.userId}
                 AND ${orgMemberships.orgId} = ${orgId}
-                AND ${orgMemberships.role} = 'admin'
+                AND (${orgMemberships.role} = 'admin'
+                     OR ${orgMemberships.type} = 'organizer')
             )`,
             sql`${users.role} IS DISTINCT FROM 'admin'`
           )

--- a/apps/backend/app/modules/schools/pending-claims/service.ts
+++ b/apps/backend/app/modules/schools/pending-claims/service.ts
@@ -8,6 +8,7 @@ import { eventRosters, orgEvents } from "#database/schema/org-events";
 import { orgMemberships } from "#database/schema/organizations";
 import { inject } from "@adonisjs/core";
 import { and, eq, isNull, notInArray, sql } from "drizzle-orm";
+import { nonOrganizerMembershipConflict } from "#shared/org/membership";
 
 @inject()
 export class PendingClaimsService {
@@ -86,9 +87,7 @@ export class PendingClaimsService {
         await tx
           .insert(orgMemberships)
           .values({ userId, orgId: event.orgId, type: "coach", role: "member" })
-          .onConflictDoNothing({
-            target: [orgMemberships.userId, orgMemberships.orgId],
-          });
+          .onConflictDoNothing(nonOrganizerMembershipConflict());
       }
 
       await tx

--- a/apps/backend/app/modules/schools/pending-claims/service.ts
+++ b/apps/backend/app/modules/schools/pending-claims/service.ts
@@ -8,7 +8,7 @@ import { eventRosters, orgEvents } from "#database/schema/org-events";
 import { orgMemberships } from "#database/schema/organizations";
 import { inject } from "@adonisjs/core";
 import { and, eq, isNull, notInArray, sql } from "drizzle-orm";
-import { nonOrganizerMembershipConflict } from "#shared/org/membership";
+import { rosterTypeMembershipConflict } from "#shared/org/membership";
 
 @inject()
 export class PendingClaimsService {
@@ -87,7 +87,7 @@ export class PendingClaimsService {
         await tx
           .insert(orgMemberships)
           .values({ userId, orgId: event.orgId, type: "coach", role: "member" })
-          .onConflictDoNothing(nonOrganizerMembershipConflict());
+          .onConflictDoNothing(rosterTypeMembershipConflict());
       }
 
       await tx

--- a/apps/backend/app/modules/users/get-my-orgs/service.ts
+++ b/apps/backend/app/modules/users/get-my-orgs/service.ts
@@ -1,3 +1,5 @@
+import type { OrgMemberType } from "#database/schema/enums";
+import { resolveEffectiveMembership } from "#shared/org/membership";
 import { DatabaseService } from "#database/service";
 import { organizations, orgMemberships } from "#database/schema/organizations";
 import { eventRosters, orgEvents } from "#database/schema/org-events";
@@ -12,7 +14,11 @@ export interface MyOrgEntry {
   logoUrl: string | null;
   primaryColor: string | null;
   role: "admin" | "member" | null;
-  type: "coach" | "dancer";
+  /**
+   * The user's standing in this org. An Organizer runs it; the roster type is
+   * only a fallback for someone rostered without a membership row.
+   */
+  type: OrgMemberType;
 }
 
 @inject()
@@ -80,15 +86,26 @@ export class GetMyOrgsService {
 
       const orgsById = new Map<string, MyOrgEntry>();
 
+      // A person can hold more than one membership in an org (ADR 0003), so
+      // collapse them to the highest-privilege one rather than letting the last
+      // row read win.
+      const membershipsByOrg = new Map<string, typeof membershipRows>();
       for (const r of membershipRows) {
-        orgsById.set(r.id, {
-          id: r.id,
-          slug: r.slug,
-          name: r.name,
-          logoUrl: r.logoUrl,
-          primaryColor: r.primaryColor,
-          role: r.role,
-          type: r.type,
+        const bucket = membershipsByOrg.get(r.id);
+        if (bucket) bucket.push(r);
+        else membershipsByOrg.set(r.id, [r]);
+      }
+
+      for (const [orgId, rows] of membershipsByOrg) {
+        const effective = resolveEffectiveMembership(rows)!;
+        orgsById.set(orgId, {
+          id: effective.id,
+          slug: effective.slug,
+          name: effective.name,
+          logoUrl: effective.logoUrl,
+          primaryColor: effective.primaryColor,
+          role: effective.role,
+          type: effective.type,
         });
       }
 
@@ -104,9 +121,7 @@ export class GetMyOrgsService {
             existing?.role ??
             (r.membershipRole as "admin" | "member" | null) ??
             null,
-          type:
-            existing?.type ??
-            ((r.membershipType ?? r.rosterType) as "coach" | "dancer"),
+          type: existing?.type ?? r.membershipType ?? r.rosterType,
         });
       }
 

--- a/apps/backend/app/shared/org/invite-email.ts
+++ b/apps/backend/app/shared/org/invite-email.ts
@@ -4,6 +4,7 @@ import mail from "@adonisjs/mail/services/main";
 import { OrgInviteEmail, renderEmail, renderEmailText } from "@stos/emails";
 import type { organizations } from "#database/schema/organizations";
 import type { orgEvents } from "#database/schema/org-events";
+import type { RosterType } from "#database/schema/enums";
 
 interface OrgInviteMailData {
   email: string;
@@ -82,7 +83,7 @@ export async function sendOrgInviteEmail(opts: {
   event?: typeof orgEvents.$inferSelect | null;
   email: string;
   firstName: string;
-  type: "coach" | "dancer";
+  type: RosterType;
   token?: string;
 }): Promise<void> {
   const { org, event, email, firstName, type, token } = opts;
@@ -122,7 +123,7 @@ export async function sendOrgInviteEmailOrThrow(opts: {
   event?: typeof orgEvents.$inferSelect | null;
   email: string;
   firstName: string;
-  type: "coach" | "dancer";
+  type: RosterType;
   token?: string;
 }): Promise<void> {
   const { org, event, email, firstName, type, token } = opts;

--- a/apps/backend/app/shared/org/membership.spec.ts
+++ b/apps/backend/app/shared/org/membership.spec.ts
@@ -1,0 +1,85 @@
+import { test } from "@japa/runner";
+import {
+  grantsOrgAdmin,
+  hasMemberType,
+  resolveEffectiveMembership,
+  type OrgMembershipLike,
+} from "./membership.ts";
+
+const m = (
+  type: OrgMembershipLike["type"],
+  role: OrgMembershipLike["role"] = "member"
+): OrgMembershipLike => ({ role, type });
+
+test.group("grantsOrgAdmin", () => {
+  test("an organizer administers the org whatever its role column says", ({
+    assert,
+  }) => {
+    assert.isTrue(grantsOrgAdmin(m("organizer")));
+    assert.isTrue(grantsOrgAdmin(m("organizer", "admin")));
+  });
+
+  test("role=admin still grants admin for coaches and dancers", ({
+    assert,
+  }) => {
+    assert.isTrue(grantsOrgAdmin(m("coach", "admin")));
+    assert.isTrue(grantsOrgAdmin(m("dancer", "admin")));
+  });
+
+  test("a plain coach or dancer member is not an admin", ({ assert }) => {
+    assert.isFalse(grantsOrgAdmin(m("coach")));
+    assert.isFalse(grantsOrgAdmin(m("dancer")));
+    assert.isFalse(grantsOrgAdmin(null));
+  });
+});
+
+test.group("hasMemberType", () => {
+  test("finds a type across every membership the user holds", ({ assert }) => {
+    const rows = [m("organizer"), m("coach")];
+    assert.isTrue(hasMemberType(rows, "coach"));
+    assert.isTrue(hasMemberType(rows, "organizer"));
+    assert.isFalse(hasMemberType(rows, "dancer"));
+  });
+
+  test("an organizer alone is not a coach", ({ assert }) => {
+    assert.isFalse(hasMemberType([m("organizer")], "coach"));
+  });
+});
+
+test.group("resolveEffectiveMembership", () => {
+  test("returns null when the user holds no membership", ({ assert }) => {
+    assert.isNull(resolveEffectiveMembership([]));
+  });
+
+  test("prefers the organizer membership over a coach one", ({ assert }) => {
+    assert.equal(
+      resolveEffectiveMembership([m("coach"), m("organizer")])?.type,
+      "organizer"
+    );
+  });
+
+  test("keeps the organizer when they also coach as an org admin", ({
+    assert,
+  }) => {
+    const resolved = resolveEffectiveMembership([
+      m("coach", "admin"),
+      m("organizer"),
+    ]);
+    assert.equal(resolved?.type, "organizer");
+  });
+
+  test("prefers a role=admin coach over a plain dancer membership", ({
+    assert,
+  }) => {
+    const resolved = resolveEffectiveMembership([
+      m("dancer"),
+      m("coach", "admin"),
+    ]);
+    assert.equal(resolved?.type, "coach");
+    assert.equal(resolved?.role, "admin");
+  });
+
+  test("is unchanged for a user holding a single membership", ({ assert }) => {
+    assert.deepEqual(resolveEffectiveMembership([m("dancer")]), m("dancer"));
+  });
+});

--- a/apps/backend/app/shared/org/membership.ts
+++ b/apps/backend/app/shared/org/membership.ts
@@ -1,0 +1,73 @@
+import type { OrgMemberType } from "#database/schema/enums";
+import { orgMemberships } from "#database/schema/organizations";
+import { sql } from "drizzle-orm";
+
+/**
+ * The part of an `org_memberships` row that access decisions read. Kept
+ * structural so callers can pass a full row or a two-column projection.
+ */
+export interface OrgMembershipLike {
+  role: "admin" | "member";
+  type: OrgMemberType;
+}
+
+/**
+ * Highest privilege first. An Organizer runs the Org, so their membership
+ * outranks the coach or dancer membership the same person may also hold.
+ */
+const TYPE_PRECEDENCE: readonly OrgMemberType[] = [
+  "organizer",
+  "coach",
+  "dancer",
+];
+
+/**
+ * Whether a membership administers the Org. An Organizer buys S2S Live and runs
+ * its events, so the type alone grants admin access — the `role` column stays
+ * meaningful for coaches and dancers promoted to admin (ADR 0003).
+ */
+export function grantsOrgAdmin(
+  membership: OrgMembershipLike | null | undefined
+): boolean {
+  if (!membership) return false;
+  return membership.role === "admin" || membership.type === "organizer";
+}
+
+/** Whether any of the user's memberships in this org has the given type. */
+export function hasMemberType(
+  memberships: readonly OrgMembershipLike[],
+  type: OrgMemberType
+): boolean {
+  return memberships.some((m) => m.type === type);
+}
+
+/**
+ * The single membership downstream code should treat as "the" membership when
+ * a person holds more than one in the same Org — an Organizer who also coaches
+ * at their own event. Admin rows win, then organizer over coach over dancer, so
+ * the choice is deterministic rather than whichever row the database returned
+ * first. Checks that care about a specific type should use `hasMemberType`.
+ */
+export function resolveEffectiveMembership<T extends OrgMembershipLike>(
+  memberships: readonly T[]
+): T | null {
+  if (memberships.length === 0) return null;
+
+  return [...memberships].sort((a, b) => {
+    const adminDiff = Number(grantsOrgAdmin(b)) - Number(grantsOrgAdmin(a));
+    if (adminDiff !== 0) return adminDiff;
+    return TYPE_PRECEDENCE.indexOf(a.type) - TYPE_PRECEDENCE.indexOf(b.type);
+  })[0]!;
+}
+
+/**
+ * Conflict target for "give this person a coach or dancer membership unless
+ * they already have one". Coach and dancer remain mutually exclusive per Org;
+ * an organizer membership sits alongside them and is deliberately outside this
+ * index, so upserting one never disturbs the other (ADR 0003).
+ */
+export const nonOrganizerMembershipConflict = () => ({
+  target: [orgMemberships.userId, orgMemberships.orgId],
+  // Must match the index predicate for Postgres to infer the partial index.
+  where: sql`type in ('coach', 'dancer')`,
+});

--- a/apps/backend/app/shared/org/membership.ts
+++ b/apps/backend/app/shared/org/membership.ts
@@ -1,6 +1,9 @@
-import type { OrgMemberType } from "#database/schema/enums";
+import type { db } from "#database/connection";
+import { isRosterTypeSql, type OrgMemberType } from "#database/schema/enums";
 import { orgMemberships } from "#database/schema/organizations";
-import { sql } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
+
+type AnyDb = typeof db | Parameters<Parameters<typeof db.transaction>[0]>[0];
 
 /**
  * The part of an `org_memberships` row that access decisions read. Kept
@@ -66,8 +69,27 @@ export function resolveEffectiveMembership<T extends OrgMembershipLike>(
  * an organizer membership sits alongside them and is deliberately outside this
  * index, so upserting one never disturbs the other (ADR 0003).
  */
-export const nonOrganizerMembershipConflict = () => ({
+export const rosterTypeMembershipConflict = () => ({
   target: [orgMemberships.userId, orgMemberships.orgId],
-  // Must match the index predicate for Postgres to infer the partial index.
-  where: sql`type in ('coach', 'dancer')`,
+  // Same fragment the index is declared with, so Postgres can infer it.
+  where: isRosterTypeSql(),
 });
+
+/**
+ * Every membership a person holds in one Org. Always read the full set: since
+ * an Organizer may also coach at their own event (ADR 0003), a single-row
+ * lookup would return an arbitrary one of the two. Collapse with
+ * `resolveEffectiveMembership`, or ask `hasMemberType` about a specific type.
+ */
+export async function loadOrgMemberships(
+  conn: AnyDb,
+  userId: string,
+  orgId: string
+) {
+  return conn
+    .select()
+    .from(orgMemberships)
+    .where(
+      and(eq(orgMemberships.userId, userId), eq(orgMemberships.orgId, orgId))
+    );
+}

--- a/apps/backend/app/shared/org/roster-added-email.ts
+++ b/apps/backend/app/shared/org/roster-added-email.ts
@@ -8,6 +8,7 @@ import {
 } from "@stos/emails";
 import type { organizations } from "#database/schema/organizations";
 import type { orgEvents } from "#database/schema/org-events";
+import type { RosterType } from "#database/schema/enums";
 
 interface OrgRosterAddedMailData {
   email: string;
@@ -79,7 +80,7 @@ export async function sendOrgRosterAddedEmailOrThrow(opts: {
   event?: typeof orgEvents.$inferSelect | null;
   email: string;
   firstName: string;
-  type: "coach" | "dancer";
+  type: RosterType;
 }): Promise<void> {
   const { org, event, email, firstName, type } = opts;
 
@@ -113,7 +114,7 @@ export async function sendOrgRosterAddedEmail(opts: {
   event?: typeof orgEvents.$inferSelect | null;
   email: string;
   firstName: string;
-  type: "coach" | "dancer";
+  type: RosterType;
 }): Promise<void> {
   try {
     await sendOrgRosterAddedEmailOrThrow(opts);

--- a/apps/backend/commands/backfill-org-memberships.ts
+++ b/apps/backend/commands/backfill-org-memberships.ts
@@ -4,7 +4,7 @@ import { eq } from "drizzle-orm";
 import { db } from "#database/connection";
 import { platforms, users } from "#database/schema/users";
 import { organizations, orgMemberships } from "#database/schema/organizations";
-import { nonOrganizerMembershipConflict } from "#shared/org/membership";
+import { rosterTypeMembershipConflict } from "#shared/org/membership";
 
 /**
  * One-shot data migration: map every `user_platforms` row into an equivalent
@@ -53,7 +53,7 @@ export async function backfillOrgMemberships(): Promise<number> {
         type: memberType,
         role: membershipRole,
       })
-      .onConflictDoNothing(nonOrganizerMembershipConflict());
+      .onConflictDoNothing(rosterTypeMembershipConflict());
     inserted += 1;
   }
 

--- a/apps/backend/commands/backfill-org-memberships.ts
+++ b/apps/backend/commands/backfill-org-memberships.ts
@@ -4,6 +4,7 @@ import { eq } from "drizzle-orm";
 import { db } from "#database/connection";
 import { platforms, users } from "#database/schema/users";
 import { organizations, orgMemberships } from "#database/schema/organizations";
+import { nonOrganizerMembershipConflict } from "#shared/org/membership";
 
 /**
  * One-shot data migration: map every `user_platforms` row into an equivalent
@@ -52,9 +53,7 @@ export async function backfillOrgMemberships(): Promise<number> {
         type: memberType,
         role: membershipRole,
       })
-      .onConflictDoNothing({
-        target: [orgMemberships.userId, orgMemberships.orgId],
-      });
+      .onConflictDoNothing(nonOrganizerMembershipConflict());
     inserted += 1;
   }
 

--- a/apps/backend/commands/backfill-organizers.ts
+++ b/apps/backend/commands/backfill-organizers.ts
@@ -1,0 +1,212 @@
+import { BaseCommand, flags } from "@adonisjs/core/ace";
+import type { CommandOptions } from "@adonisjs/core/types/ace";
+import { and, eq, sql } from "drizzle-orm";
+import { db } from "#database/connection";
+import { eventRosters, orgEvents } from "#database/schema/org-events";
+import { organizations, orgMemberships } from "#database/schema/organizations";
+import { users } from "#database/schema/users";
+
+/**
+ * Before ADR 0003 the only way to file an Organizer was as a coach with
+ * `role = "admin"`. This reclassifies the ones that really are Organizers.
+ *
+ * Only one bucket is safe to automate. A coach membership is *evidence of a
+ * person's standing in the Org*; their appearance in coach lists, roster
+ * queries and scouting surfaces comes from `event_rosters`, which this command
+ * never touches. So:
+ *
+ * - No real Roster Entry → they never coached at an event. Flipping the type
+ *   to `organizer` is the whole change, and it takes them out of the
+ *   coach-membership checks with no other consequence.
+ * - Has a real Roster Entry → they genuinely coached. Flipping would leave the
+ *   roster row (and so their place in every coach-facing list) while removing
+ *   the coach membership that explains it. These are reported, never changed:
+ *   whether such a person is *also* an Organizer is a human judgement, and the
+ *   fix is to add an organizer membership alongside the coach one, which the
+ *   partial indexes now allow.
+ *
+ * Staff "view-as" rosters (`is_staff = true`) are preview sandboxes already
+ * excluded from every participant-facing query, so they don't count as
+ * evidence of coaching.
+ *
+ * Idempotent: reclassified rows no longer match `type = "coach"`.
+ */
+
+export interface OrganizerCandidate {
+  membershipId: string;
+  orgSlug: string;
+  email: string;
+  name: string;
+  realCoachRosters: number;
+  previewRosters: number;
+  /** Why this row is or isn't safe to reclassify automatically. */
+  verdict: "reclassify" | "coaches-too" | "already-organizer";
+}
+
+export interface BackfillOrganizersResult {
+  candidates: OrganizerCandidate[];
+  reclassified: number;
+}
+
+/**
+ * @param apply  false (the default) reports without writing anything.
+ * @param orgSlug  limit to a single org.
+ */
+export async function backfillOrganizers({
+  apply = false,
+  orgSlug,
+}: {
+  apply?: boolean;
+  orgSlug?: string;
+} = {}): Promise<BackfillOrganizersResult> {
+  const rows = await db
+    .select({
+      membershipId: orgMemberships.id,
+      userId: orgMemberships.userId,
+      orgId: orgMemberships.orgId,
+      orgSlug: organizations.slug,
+      email: users.email,
+      firstName: users.firstName,
+      lastName: users.lastName,
+      realCoachRosters: sql<number>`(
+        select count(*)::int from ${eventRosters} r
+        join ${orgEvents} e on e.id = r.event_id
+        where r.user_id = ${orgMemberships.userId}
+          and e.org_id  = ${orgMemberships.orgId}
+          and r.type    = 'coach'
+          and r.is_staff = false
+      )`,
+      previewRosters: sql<number>`(
+        select count(*)::int from ${eventRosters} r
+        join ${orgEvents} e on e.id = r.event_id
+        where r.user_id = ${orgMemberships.userId}
+          and e.org_id  = ${orgMemberships.orgId}
+          and r.is_staff = true
+      )`,
+      // Reclassifying would collide with an organizer membership they hold.
+      hasOrganizer: sql<boolean>`exists (
+        select 1 from ${orgMemberships} existing
+        where existing.user_id = ${orgMemberships.userId}
+          and existing.org_id  = ${orgMemberships.orgId}
+          and existing.type    = 'organizer'
+      )`,
+    })
+    .from(orgMemberships)
+    .innerJoin(users, eq(users.id, orgMemberships.userId))
+    .innerJoin(organizations, eq(organizations.id, orgMemberships.orgId))
+    .where(
+      and(
+        eq(orgMemberships.type, "coach"),
+        // The only shape an Organizer could have had before ADR 0003.
+        eq(orgMemberships.role, "admin"),
+        ...(orgSlug ? [eq(organizations.slug, orgSlug)] : [])
+      )
+    )
+    .orderBy(organizations.slug, users.email);
+
+  const candidates: OrganizerCandidate[] = rows.map((r) => ({
+    membershipId: r.membershipId,
+    orgSlug: r.orgSlug,
+    email: r.email,
+    name: `${r.firstName} ${r.lastName}`,
+    realCoachRosters: r.realCoachRosters,
+    previewRosters: r.previewRosters,
+    verdict: r.hasOrganizer
+      ? "already-organizer"
+      : r.realCoachRosters > 0
+        ? "coaches-too"
+        : "reclassify",
+  }));
+
+  if (!apply) return { candidates, reclassified: 0 };
+
+  let reclassified = 0;
+  for (const c of candidates) {
+    if (c.verdict !== "reclassify") continue;
+    await db
+      .update(orgMemberships)
+      .set({ type: "organizer" })
+      .where(eq(orgMemberships.id, c.membershipId));
+    reclassified += 1;
+  }
+
+  return { candidates, reclassified };
+}
+
+export default class BackfillOrganizers extends BaseCommand {
+  static commandName = "backfill:organizers";
+  static description =
+    "Reclassify admin coach memberships that are really Organizers (ADR 0003)";
+
+  static options: CommandOptions = {
+    startApp: true,
+  };
+
+  @flags.boolean({
+    default: true,
+    description: "Report without writing. Pass --no-dry-run to apply.",
+  })
+  declare dryRun: boolean;
+
+  @flags.string({ description: "Limit to a single org slug" })
+  declare org?: string;
+
+  async run() {
+    const { candidates, reclassified } = await backfillOrganizers({
+      apply: !this.dryRun,
+      orgSlug: this.org,
+    });
+
+    if (candidates.length === 0) {
+      this.logger.info("No admin coach memberships found. Nothing to do.");
+      return;
+    }
+
+    const toReclassify = candidates.filter((c) => c.verdict === "reclassify");
+    const coachesToo = candidates.filter((c) => c.verdict === "coaches-too");
+    const already = candidates.filter((c) => c.verdict === "already-organizer");
+
+    if (toReclassify.length > 0) {
+      this.logger.info(
+        this.dryRun
+          ? `Would reclassify ${toReclassify.length} membership(s) as organizer:`
+          : `Reclassified ${reclassified} membership(s) as organizer:`
+      );
+      for (const c of toReclassify) {
+        this.logger.log(
+          `  ${c.orgSlug}  ${c.email}  (${c.name})` +
+            (c.previewRosters > 0
+              ? `  [${c.previewRosters} preview roster(s), ignored]`
+              : "")
+        );
+      }
+    }
+
+    if (coachesToo.length > 0) {
+      this.logger.warning(
+        `${coachesToo.length} membership(s) left alone — these people hold a real ` +
+          `Roster Entry, so they genuinely coached at an event:`
+      );
+      for (const c of coachesToo) {
+        this.logger.log(
+          `  ${c.orgSlug}  ${c.email}  (${c.name})  ${c.realCoachRosters} roster entr(y|ies)`
+        );
+      }
+      this.logger.log(
+        "  If any of these also run the Org, add an organizer membership " +
+          "alongside their coach one rather than converting it — reclassifying " +
+          "would leave them in coach-facing lists via the roster row."
+      );
+    }
+
+    if (already.length > 0) {
+      this.logger.info(
+        `${already.length} skipped — already hold an organizer membership.`
+      );
+    }
+
+    if (this.dryRun && toReclassify.length > 0) {
+      this.logger.info("Dry run. Re-run with --no-dry-run to apply.");
+    }
+  }
+}

--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -11620,7 +11620,12 @@
               ]
             },
             "type": {
-              "$ref": "#/components/schemas/UploadKind"
+              "type": "string",
+              "enum": [
+                "dancer",
+                "coach",
+                "organizer"
+              ]
             }
           },
           "required": [
@@ -11646,7 +11651,12 @@
             ]
           },
           "type": {
-            "$ref": "#/components/schemas/UploadKind"
+            "type": "string",
+            "enum": [
+              "dancer",
+              "coach",
+              "organizer"
+            ]
           }
         },
         "required": [
@@ -11675,7 +11685,12 @@
           "type": {
             "oneOf": [
               {
-                "$ref": "#/components/schemas/UploadKind"
+                "type": "string",
+                "enum": [
+                  "dancer",
+                  "coach",
+                  "organizer"
+                ]
               },
               {
                 "type": "null"
@@ -11704,7 +11719,12 @@
             ]
           },
           "type": {
-            "$ref": "#/components/schemas/UploadKind"
+            "type": "string",
+            "enum": [
+              "dancer",
+              "coach",
+              "organizer"
+            ]
           },
           "userId": {
             "type": "string"
@@ -12014,7 +12034,12 @@
                       ]
                     },
                     "type": {
-                      "$ref": "#/components/schemas/UploadKind"
+                      "type": "string",
+                      "enum": [
+                        "dancer",
+                        "coach",
+                        "organizer"
+                      ]
                     }
                   },
                   "required": [
@@ -12158,7 +12183,12 @@
                   ]
                 },
                 "type": {
-                  "$ref": "#/components/schemas/UploadKind"
+                  "type": "string",
+                  "enum": [
+                    "dancer",
+                    "coach",
+                    "organizer"
+                  ]
                 }
               },
               "required": [
@@ -12840,7 +12870,12 @@
                     ]
                   },
                   "type": {
-                    "$ref": "#/components/schemas/UploadKind"
+                    "type": "string",
+                    "enum": [
+                      "dancer",
+                      "coach",
+                      "organizer"
+                    ]
                   }
                 },
                 "required": [
@@ -19152,12 +19187,6 @@
                 "title": {
                   "type": "string"
                 },
-                "startDatetime": {
-                  "type": "string"
-                },
-                "endDatetime": {
-                  "type": "string"
-                },
                 "organizer": {
                   "oneOf": [
                     {
@@ -19175,6 +19204,12 @@
                       "type": "null"
                     }
                   ]
+                },
+                "startDatetime": {
+                  "type": "string"
+                },
+                "endDatetime": {
+                  "type": "string"
                 }
               },
               "required": [
@@ -19182,9 +19217,9 @@
                 "type",
                 "location",
                 "title",
+                "organizer",
                 "startDatetime",
-                "endDatetime",
-                "organizer"
+                "endDatetime"
               ]
             }
           },
@@ -19974,6 +20009,36 @@
           "description": {
             "type": "string"
           },
+          "organizer": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "username": {
+                "type": "string"
+              },
+              "avatar": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "events": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "name",
+              "username",
+              "avatar",
+              "events"
+            ]
+          },
           "address": {
             "oneOf": [
               {
@@ -20037,36 +20102,6 @@
           "startTime": {
             "type": "string"
           },
-          "organizer": {
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string"
-              },
-              "username": {
-                "type": "string"
-              },
-              "avatar": {
-                "oneOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "events": {
-                "type": "number"
-              }
-            },
-            "required": [
-              "name",
-              "username",
-              "avatar",
-              "events"
-            ]
-          },
           "attendees": {
             "type": "number"
           },
@@ -20090,13 +20125,13 @@
           "schoolId",
           "title",
           "description",
+          "organizer",
           "address",
           "tags",
           "cost",
           "startDate",
           "endDate",
           "startTime",
-          "organizer",
           "attendees",
           "saved",
           "eventAttendees",
@@ -22142,7 +22177,12 @@
               ]
             },
             "type": {
-              "$ref": "#/components/schemas/UploadKind"
+              "type": "string",
+              "enum": [
+                "dancer",
+                "coach",
+                "organizer"
+              ]
             },
             "slug": {
               "type": "string"

--- a/apps/backend/start/transmit.ts
+++ b/apps/backend/start/transmit.ts
@@ -1,12 +1,13 @@
 import transmit from "@adonisjs/transmit/services/main";
 import router from "@adonisjs/core/services/router";
 import { db } from "#database/connection";
-import { organizations, orgMemberships } from "#database/schema/organizations";
+import { organizations } from "#database/schema/organizations";
 import {
   grantsOrgAdmin,
+  loadOrgMemberships,
   resolveEffectiveMembership,
 } from "#shared/org/membership";
-import { and, eq } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 
 // Register transmit routes inline to work around a @poppinss/utils
 // version mismatch that breaks the built-in controllers.
@@ -59,17 +60,7 @@ transmit.authorize<{ slug: string }>(
       .limit(1);
     if (!org) return false;
 
-    // A person can hold several memberships in one org (ADR 0003), so read
-    // them all rather than whichever row came back first.
-    const memberships = await db
-      .select()
-      .from(orgMemberships)
-      .where(
-        and(
-          eq(orgMemberships.userId, user.id),
-          eq(orgMemberships.orgId, org.id)
-        )
-      );
+    const memberships = await loadOrgMemberships(db, user.id, org.id);
 
     return grantsOrgAdmin(resolveEffectiveMembership(memberships));
   }

--- a/apps/backend/start/transmit.ts
+++ b/apps/backend/start/transmit.ts
@@ -2,6 +2,10 @@ import transmit from "@adonisjs/transmit/services/main";
 import router from "@adonisjs/core/services/router";
 import { db } from "#database/connection";
 import { organizations, orgMemberships } from "#database/schema/organizations";
+import {
+  grantsOrgAdmin,
+  resolveEffectiveMembership,
+} from "#shared/org/membership";
 import { and, eq } from "drizzle-orm";
 
 // Register transmit routes inline to work around a @poppinss/utils
@@ -55,7 +59,9 @@ transmit.authorize<{ slug: string }>(
       .limit(1);
     if (!org) return false;
 
-    const [membership] = await db
+    // A person can hold several memberships in one org (ADR 0003), so read
+    // them all rather than whichever row came back first.
+    const memberships = await db
       .select()
       .from(orgMemberships)
       .where(
@@ -63,9 +69,8 @@ transmit.authorize<{ slug: string }>(
           eq(orgMemberships.userId, user.id),
           eq(orgMemberships.orgId, org.id)
         )
-      )
-      .limit(1);
+      );
 
-    return membership?.role === "admin";
+    return grantsOrgAdmin(resolveEffectiveMembership(memberships));
   }
 );

--- a/apps/frontend/src/components/shared/org-dashboard-link.spec.ts
+++ b/apps/frontend/src/components/shared/org-dashboard-link.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { dashboardLink, type MyOrg } from "./org-dashboard-link";
+
+const org = (
+  role: MyOrg["role"],
+  type: MyOrg["type"],
+): MyOrg => ({ role, type }) as MyOrg;
+
+describe("dashboardLink", () => {
+  it("sends an organizer to the admin dashboard, whatever their role", () => {
+    expect(dashboardLink(org("member", "organizer"))).toEqual({
+      to: "/o/$orgSlug/admin",
+      label: "Admin",
+    });
+    expect(dashboardLink(org("admin", "organizer")).label).toBe("Admin");
+  });
+
+  it("keeps admins, coaches and dancers where they were", () => {
+    expect(dashboardLink(org("admin", "coach")).label).toBe("Admin");
+    expect(dashboardLink(org("member", "coach"))).toEqual({
+      to: "/o/$orgSlug/coach",
+      label: "Coach",
+    });
+    expect(dashboardLink(org("member", "dancer"))).toEqual({
+      to: "/o/$orgSlug/dancer",
+      label: "Dancer",
+    });
+  });
+});

--- a/apps/frontend/src/components/shared/org-dashboard-link.ts
+++ b/apps/frontend/src/components/shared/org-dashboard-link.ts
@@ -1,9 +1,16 @@
 import type { ApiSchemas } from "@/lib/api/client";
+import { grantsOrgAdmin } from "@/lib/access";
 
 export type MyOrg = ApiSchemas["UsersMeOrgsResponse"][number];
 
+/**
+ * Where this org's tile links to, and what it calls the person. An Organizer
+ * administers the org whatever their `role` says (ADR 0003), so they get the
+ * admin dashboard rather than falling through to the dancer default — and are
+ * never labelled Coach or Dancer, terms that mean something specific here.
+ */
 export function dashboardLink(org: MyOrg) {
-  if (org.role === "admin") {
+  if (grantsOrgAdmin({ role: org.role ?? "member", type: org.type })) {
     return { to: "/o/$orgSlug/admin" as const, label: "Admin" };
   }
   if (org.type === "coach") {

--- a/apps/frontend/src/features/admin/orgs/components/members-dialog.tsx
+++ b/apps/frontend/src/features/admin/orgs/components/members-dialog.tsx
@@ -35,16 +35,16 @@ import { adminQueries } from "@/features/admin/api/queries";
 import { useQuery } from "@tanstack/react-query";
 import { Search, Trash2, UserPlus } from "lucide-react";
 import { useMemo, useState } from "react";
+import { ORG_MEMBER_TYPE_LABELS, type OrgMemberType } from "@/lib/access";
 
 const ROLE_ITEMS = [
   { value: "admin", label: "Admin" },
   { value: "member", label: "Member" },
 ];
 
-const TYPE_ITEMS = [
-  { value: "coach", label: "Coach" },
-  { value: "dancer", label: "Dancer" },
-];
+const TYPE_ITEMS = (
+  Object.keys(ORG_MEMBER_TYPE_LABELS) as OrgMemberType[]
+).map((value) => ({ value, label: ORG_MEMBER_TYPE_LABELS[value] }));
 
 interface Org {
   id: string;
@@ -59,7 +59,7 @@ interface MembersDialogProps {
 export function MembersDialog({ org, onOpenChange }: MembersDialogProps) {
   const [email, setEmail] = useState("");
   const [role, setRole] = useState<"admin" | "member" | null>("member");
-  const [type, setType] = useState<"coach" | "dancer" | null>("coach");
+  const [type, setType] = useState<OrgMemberType | null>("coach");
   const [search, setSearch] = useState("");
 
   const { data: members, isLoading } = useQuery({
@@ -187,7 +187,7 @@ export function MembersDialog({ org, onOpenChange }: MembersDialogProps) {
                   <FieldLabel>Type</FieldLabel>
                   <Select
                     value={type}
-                    onValueChange={(v) => setType(v as "coach" | "dancer")}
+                    onValueChange={(v) => setType(v as OrgMemberType)}
                     items={TYPE_ITEMS}
                   >
                     <SelectTrigger size="sm">
@@ -295,7 +295,7 @@ export function MembersDialog({ org, onOpenChange }: MembersDialogProps) {
                               if (!org) return;
                               updateMember({
                                 params: { path: { id: org.id, memberId: member.id } },
-                                body: { type: v as "coach" | "dancer" },
+                                body: { type: v as OrgMemberType },
                               });
                             }}
                             items={TYPE_ITEMS}

--- a/apps/frontend/src/features/org/components/admin-sidebar.tsx
+++ b/apps/frontend/src/features/org/components/admin-sidebar.tsx
@@ -51,6 +51,7 @@ import {
 import { useMemo } from "react";
 import { useOrgTheme } from "@/features/org/hooks/use-org-theme";
 import { type TernaryDarkMode } from "usehooks-ts";
+import { grantsOrgAdmin } from "@/lib/access";
 
 const dashboardItem = {
   label: "Dashboard",
@@ -175,7 +176,7 @@ export function AdminSidebar() {
       ? "Coach"
       : "Dancer";
   const canSwitchView =
-    membership?.role === "admin" || session.role === "admin";
+    grantsOrgAdmin(membership) || session.role === "admin";
 
   function handleSelectView(view: "Admin" | "Coach" | "Dancer") {
     if (view === "Admin") {

--- a/apps/frontend/src/features/org/components/coach-sidebar.tsx
+++ b/apps/frontend/src/features/org/components/coach-sidebar.tsx
@@ -39,6 +39,7 @@ import {
 } from "lucide-react";
 import { useOrgTheme } from "@/features/org/hooks/use-org-theme";
 import { type TernaryDarkMode } from "usehooks-ts";
+import { grantsOrgAdmin } from "@/lib/access";
 
 const dashboardItem = {
   label: "Event Info",
@@ -77,7 +78,7 @@ export function CoachSidebar() {
     : location.pathname.includes("/coach")
       ? "Coach"
       : "Dancer";
-  const canSwitchView = membership?.role === "admin" || session.role === "admin";
+  const canSwitchView = grantsOrgAdmin(membership) || session.role === "admin";
 
   function handleSelectView(view: "Admin" | "Coach" | "Dancer") {
     if (view === "Admin") {

--- a/apps/frontend/src/features/org/components/dancer-sidebar.tsx
+++ b/apps/frontend/src/features/org/components/dancer-sidebar.tsx
@@ -44,6 +44,7 @@ import {
 } from "lucide-react";
 import { useOrgTheme } from "@/features/org/hooks/use-org-theme";
 import { type TernaryDarkMode } from "usehooks-ts";
+import { grantsOrgAdmin } from "@/lib/access";
 
 const dashboardItem = {
   label: "Event Info",
@@ -124,7 +125,7 @@ export function DancerSidebar() {
     : location.pathname.includes("/coach")
       ? "Coach"
       : "Dancer";
-  const canSwitchView = membership?.role === "admin" || session.role === "admin";
+  const canSwitchView = grantsOrgAdmin(membership) || session.role === "admin";
 
   function handleSelectView(view: "Admin" | "Coach" | "Dancer") {
     if (view === "Admin") {

--- a/apps/frontend/src/features/org/context/org-context.ts
+++ b/apps/frontend/src/features/org/context/org-context.ts
@@ -1,14 +1,20 @@
 import { createContext } from "react";
 
+import type { OrgMemberType, RosterType } from "@/lib/access";
+
 export interface OrgMembership {
   role: "admin" | "member";
-  type: "coach" | "dancer";
+  /**
+   * The user's highest-privilege membership type. A person may hold both an
+   * organizer and a coach membership in the same Org (ADR 0003).
+   */
+  type: OrgMemberType;
 }
 
 export interface MyRoster {
   id: string;
   eventId: string;
-  type: "coach" | "dancer";
+  type: RosterType;
   eventName: string;
   eventStartDate: string;
   eventEndDate: string;

--- a/apps/frontend/src/features/org/context/org-provider.tsx
+++ b/apps/frontend/src/features/org/context/org-provider.tsx
@@ -8,6 +8,7 @@ import {
   type OrgMembership,
   type MyRoster,
 } from "./org-context";
+import { grantsOrgAdmin } from "@/lib/access";
 
 const EMPTY_ROSTERS: MyRoster[] = [];
 
@@ -43,7 +44,7 @@ export function OrgProvider({
       membership,
       myRoster,
       myRosters,
-      isAdmin: membership?.role === "admin" || session?.role === "admin",
+      isAdmin: grantsOrgAdmin(membership) || session?.role === "admin",
       hasFeature: (key) => Boolean(features[key]),
     }),
     [data, features, membership, myRoster, myRosters, session?.role],

--- a/apps/frontend/src/features/org/lib/org-destination.spec.ts
+++ b/apps/frontend/src/features/org/lib/org-destination.spec.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import { resolveOrgArea, resolveOrgDestination } from "./org-destination";
 
-const dancerRoster = { id: "r1", type: "dancer" };
-const coachRoster = { id: "r2", type: "coach" };
+const dancerRoster = { id: "r1", type: "dancer" } as const;
+const coachRoster = { id: "r2", type: "coach" } as const;
 
 describe("resolveOrgArea", () => {
   it("sends org admins to the admin area", () => {

--- a/apps/frontend/src/features/org/lib/org-destination.spec.ts
+++ b/apps/frontend/src/features/org/lib/org-destination.spec.ts
@@ -12,6 +12,24 @@ describe("resolveOrgArea", () => {
     ).toBe("admin");
   });
 
+  it("sends organizers to the admin area, roster or not", () => {
+    expect(
+      resolveOrgArea({ membership: { role: "member", type: "organizer" } }),
+    ).toBe("admin");
+    expect(
+      resolveOrgArea({ membership: { role: "admin", type: "organizer" } }),
+    ).toBe("admin");
+  });
+
+  it("still sends an organizer who also coaches to the admin area", () => {
+    expect(
+      resolveOrgArea({
+        membership: { role: "member", type: "organizer" },
+        myRosters: [coachRoster],
+      }),
+    ).toBe("admin");
+  });
+
   it("sends coaches to the coach area", () => {
     expect(
       resolveOrgArea({

--- a/apps/frontend/src/features/org/lib/org-destination.ts
+++ b/apps/frontend/src/features/org/lib/org-destination.ts
@@ -1,14 +1,18 @@
-import { grantsOrgAdmin } from "@/lib/access";
+import {
+  grantsOrgAdmin,
+  type OrgMemberType,
+  type RosterType,
+} from "@/lib/access";
 
 export interface OrgAccess {
-  membership?: { role: string; type: string } | null;
+  membership?: { role: "admin" | "member"; type: OrgMemberType } | null;
   myRoster?: { id: string } | null;
-  myRosters?: Array<{ id: string; type: string }>;
+  myRosters?: Array<{ id: string; type: RosterType }>;
 }
 
 export type OrgArea = "admin" | "coach" | "dancer" | "no-access";
 
-const hasRoster = (access: OrgAccess | null | undefined, type: string) =>
+const hasRoster = (access: OrgAccess | null | undefined, type: RosterType) =>
   access?.myRosters?.some((roster) => roster.type === type) ?? false;
 
 /**

--- a/apps/frontend/src/features/org/lib/org-destination.ts
+++ b/apps/frontend/src/features/org/lib/org-destination.ts
@@ -1,3 +1,5 @@
+import { grantsOrgAdmin } from "@/lib/access";
+
 export interface OrgAccess {
   membership?: { role: string; type: string } | null;
   myRoster?: { id: string } | null;
@@ -13,12 +15,18 @@ const hasRoster = (access: OrgAccess | null | undefined, type: string) =>
  * Where a member of this org belongs once they are signed in. Membership is the
  * source of truth when it exists, but users can be put on an event roster
  * without a membership row, so rosters act as the fallback signal.
+ *
+ * A member type with no area of its own falls through to the roster signal
+ * rather than guessing, so adding one can never route someone somewhere they
+ * do not belong.
  */
 export function resolveOrgArea(access: OrgAccess | null | undefined): OrgArea {
-  const role = access?.membership?.role;
   const type = access?.membership?.type;
 
-  if (role === "admin") return "admin";
+  // An Organizer runs the Org's events and administers it by definition, with
+  // no Roster Entry of their own (ADR 0003). Checked before the roster
+  // fallbacks so an organizer who also coaches still lands in the admin area.
+  if (grantsOrgAdmin(access?.membership)) return "admin";
   if (type === "coach") {
     return hasRoster(access, "coach") || access?.myRoster
       ? "coach"

--- a/apps/frontend/src/lib/access/index.ts
+++ b/apps/frontend/src/lib/access/index.ts
@@ -1,1 +1,10 @@
-export type { AccountType, Domain, Platform, Role } from "./types";
+export type {
+  AccountType,
+  Domain,
+  OrgMemberType,
+  Platform,
+  Role,
+  RosterType,
+} from "./types";
+export { ORG_MEMBER_TYPE_LABELS } from "./types";
+export { grantsOrgAdmin } from "./org-admin";

--- a/apps/frontend/src/lib/access/org-admin.spec.ts
+++ b/apps/frontend/src/lib/access/org-admin.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { grantsOrgAdmin } from "./org-admin";
+
+describe("grantsOrgAdmin", () => {
+  it("treats an organizer as an org admin whatever their role", () => {
+    expect(grantsOrgAdmin({ role: "member", type: "organizer" })).toBe(true);
+    expect(grantsOrgAdmin({ role: "admin", type: "organizer" })).toBe(true);
+  });
+
+  it("keeps role=admin working for coaches and dancers", () => {
+    expect(grantsOrgAdmin({ role: "admin", type: "coach" })).toBe(true);
+    expect(grantsOrgAdmin({ role: "admin", type: "dancer" })).toBe(true);
+  });
+
+  it("does not promote plain coach or dancer members", () => {
+    expect(grantsOrgAdmin({ role: "member", type: "coach" })).toBe(false);
+    expect(grantsOrgAdmin({ role: "member", type: "dancer" })).toBe(false);
+    expect(grantsOrgAdmin(null)).toBe(false);
+    expect(grantsOrgAdmin(undefined)).toBe(false);
+  });
+});

--- a/apps/frontend/src/lib/access/org-admin.ts
+++ b/apps/frontend/src/lib/access/org-admin.ts
@@ -7,7 +7,10 @@ import type { OrgMemberType } from "./types";
  * `grantsOrgAdmin` in the backend's `#shared/org/membership`.
  */
 export function grantsOrgAdmin(
-  membership: { role: string; type: OrgMemberType | string } | null | undefined,
+  membership:
+    | { role: "admin" | "member"; type: OrgMemberType }
+    | null
+    | undefined,
 ): boolean {
   if (!membership) return false;
   return membership.role === "admin" || membership.type === "organizer";

--- a/apps/frontend/src/lib/access/org-admin.ts
+++ b/apps/frontend/src/lib/access/org-admin.ts
@@ -1,0 +1,14 @@
+import type { OrgMemberType } from "./types";
+
+/**
+ * Whether an org membership administers the Org. An Organizer buys S2S Live and
+ * runs its events, so the type alone grants admin access; `role` stays
+ * meaningful for coaches and dancers promoted to admin. Mirrors
+ * `grantsOrgAdmin` in the backend's `#shared/org/membership`.
+ */
+export function grantsOrgAdmin(
+  membership: { role: string; type: OrgMemberType | string } | null | undefined,
+): boolean {
+  if (!membership) return false;
+  return membership.role === "admin" || membership.type === "organizer";
+}

--- a/apps/frontend/src/lib/access/types.ts
+++ b/apps/frontend/src/lib/access/types.ts
@@ -18,7 +18,7 @@ export type OrgMemberType = ApiSchemas["AdminOrgsIdMembersRequest"]["type"];
  * a roster row, a CSV upload, an admin previewing the event — is one of these,
  * never an Organizer.
  */
-export type RosterType = ApiSchemas["UploadKind"];
+export type RosterType = Exclude<OrgMemberType, "organizer">;
 
 export const ORG_MEMBER_TYPE_LABELS: Record<OrgMemberType, string> = {
   coach: "Coach",

--- a/apps/frontend/src/lib/access/types.ts
+++ b/apps/frontend/src/lib/access/types.ts
@@ -5,3 +5,23 @@ export type Platform = ApiSchemas["AuthSessionResponse"]["platforms"][number];
 export type AccountType = ApiSchemas["AuthSessionResponse"]["type"];
 
 export type Domain = `${Platform}:${AccountType}`;
+
+/**
+ * What a person is inside an Org. `organizer` runs the Org's events and buys
+ * S2S Live; they administer the Org but never evaluate Dancers and never appear
+ * on a Roster — see docs/adr/0003-organizer-is-a-distinct-member-type.md.
+ */
+export type OrgMemberType = ApiSchemas["AdminOrgsIdMembersRequest"]["type"];
+
+/**
+ * The subset of member types a Roster Entry may hold. Anything roster-shaped —
+ * a roster row, a CSV upload, an admin previewing the event — is one of these,
+ * never an Organizer.
+ */
+export type RosterType = ApiSchemas["UploadKind"];
+
+export const ORG_MEMBER_TYPE_LABELS: Record<OrgMemberType, string> = {
+  coach: "Coach",
+  dancer: "Dancer",
+  organizer: "Organizer",
+};

--- a/apps/frontend/src/lib/api/types.d.ts
+++ b/apps/frontend/src/lib/api/types.d.ts
@@ -10664,17 +10664,19 @@ export interface components {
             createdAt: string;
             /** @enum {string} */
             role: "admin" | "member";
-            type: components["schemas"]["UploadKind"];
+            /** @enum {string} */
+            type: "dancer" | "coach" | "organizer";
         }[];
         AdminOrgsIdMembersRequest: {
             email: string;
             /** @enum {string} */
             role: "admin" | "member";
-            type: components["schemas"]["UploadKind"];
+            /** @enum {string} */
+            type: "dancer" | "coach" | "organizer";
         };
         AdminOrgsIdMembersIdRequest: {
             role?: ("admin" | "member") | null;
-            type?: components["schemas"]["UploadKind"] | null;
+            type?: ("dancer" | "coach" | "organizer") | null;
         };
         AdminOrgsIdMembersIdResponse: {
             id: string;
@@ -10682,7 +10684,8 @@ export interface components {
             updatedAt: string;
             /** @enum {string} */
             role: "admin" | "member";
-            type: components["schemas"]["UploadKind"];
+            /** @enum {string} */
+            type: "dancer" | "coach" | "organizer";
             userId: string;
             orgId: string;
         };
@@ -10750,7 +10753,8 @@ export interface components {
                     orgSlug: string;
                     /** @enum {string} */
                     role: "admin" | "member";
-                    type: components["schemas"]["UploadKind"];
+                    /** @enum {string} */
+                    type: "dancer" | "coach" | "organizer";
                 }[];
                 platforms: ("core" | "prodigy")[];
             };
@@ -10779,7 +10783,8 @@ export interface components {
                 orgSlug: string;
                 /** @enum {string} */
                 role: "admin" | "member";
-                type: components["schemas"]["UploadKind"];
+                /** @enum {string} */
+                type: "dancer" | "coach" | "organizer";
             }[];
             platforms: ("core" | "prodigy")[];
         };
@@ -10915,7 +10920,8 @@ export interface components {
             membership: {
                 /** @enum {string} */
                 role: "admin" | "member";
-                type: components["schemas"]["UploadKind"];
+                /** @enum {string} */
+                type: "dancer" | "coach" | "organizer";
             } | null;
             myRoster: {
                 id: string;
@@ -12026,11 +12032,11 @@ export interface components {
                 type: "recruitment" | "audition" | "other" | "rehearsal" | "recital" | "showcase" | "competition" | "class" | "intensive" | "workshop" | "fundraiser" | "combine" | "convention" | "clinic" | "deadline" | "performance" | "camp";
                 location: string;
                 title: string;
-                startDatetime: string;
-                endDatetime: string;
                 organizer: {
                     name: string;
                 } | null;
+                startDatetime: string;
+                endDatetime: string;
             }[];
             globalEvents: {
                 id: string;
@@ -12171,6 +12177,12 @@ export interface components {
             schoolId: string;
             title: string;
             description: string;
+            organizer: {
+                name: string;
+                username: string;
+                avatar: string | null;
+                events: number;
+            };
             address: string | null;
             tags: string[] | null;
             cost: string | null;
@@ -12182,12 +12194,6 @@ export interface components {
             startDate: string;
             endDate: string;
             startTime: string;
-            organizer: {
-                name: string;
-                username: string;
-                avatar: string | null;
-                events: number;
-            };
             attendees: number;
             saved: boolean;
             eventAttendees: number;
@@ -12525,7 +12531,8 @@ export interface components {
             id: string;
             name: string;
             role: ("admin" | "member") | null;
-            type: components["schemas"]["UploadKind"];
+            /** @enum {string} */
+            type: "dancer" | "coach" | "organizer";
             slug: string;
             logoUrl: string | null;
             primaryColor: string | null;


### PR DESCRIPTION
Closes #86. Implements [ADR 0003](https://github.com/camerontredoux/studio2stadium/blob/main/docs/adr/0003-organizer-is-a-distinct-member-type.md).

An Organizer runs an Org's events and buys S2S Live. Filing them as a coach would put them in coach lists, roster queries and scouting surfaces, and would erode "coach" as a term both the product and the public site depend on.

## What this actually is

The enum value is one line. The rest separates two concepts that had been sharing `org_member_type`:

- **`OrgMemberType` (coach | dancer | organizer) vs `RosterType` (coach | dancer).** `event_rosters.type` and `csv_uploads.type` are narrowed to the latter in TypeScript *and* by a CHECK constraint, so an organizer membership cannot produce a Roster Entry even if application code slips.
- **An Organizer administers the Org whatever `role` says.** `grantsOrgAdmin()` replaces hand-rolled `role === "admin"` checks in five backend places and five frontend ones.
- **A person can hold both an organizer and a coach membership.** The unique index becomes two partial ones, so coach/dancer stay mutually exclusive exactly as before. That means multiple membership rows per Org, so every `.limit(1)` membership lookup becomes `loadOrgMemberships()` + `resolveEffectiveMembership()`.

## Five defects the audit turned up — none about the enum

1. `rosters/delete` rescinded **every** `role = "member"` membership when someone's last roster entry went, which would have stripped an Organizer of the Org they pay for. Now scoped to the participant types.
2. The transmit org-admin channel guard read one arbitrary membership row.
3. The scouting schools list excluded org admins by `role` alone, so an Organizer would have leaked into a dancer-facing list.
4. `dashboardLink` fell through to the dancer dashboard, giving an Organizer the **"Dancer" label** in the org stories rail and the profile organizations list — the exact term erosion ADR 0003 exists to prevent.
5. All three sidebars tested `role === "admin"` by hand, so an organizer passed the admin route guard and then found no view switcher inside it.

## Migration note

Drizzle runs all pending migrations in one transaction, and Postgres refuses DDL that names an enum label added in that same transaction. Every index and CHECK predicate is therefore written positively (`type in ('coach','dancer')`) from one shared `isRosterTypeSql()` fragment — the CHECKs, the partial index and the `ON CONFLICT` clause must stay identical or Postgres stops inferring the index.

The one exception is `org_memberships_organizer_per_user_per_org`, which has to read "not a Roster type". A fourth member type added later would share the organizer's uniqueness slot, so the comment tells whoever adds one to split the index first (`where type = 'organizer'` is safe in any later migration).

## Acceptance criteria

- [x] A membership of type organizer can be created and grants org admin access
- [x] An Organizer does not appear in coach-facing lists, roster queries, or scouting surfaces
- [x] An organizer membership produces no Roster Entry — enforced by TypeScript *and* a CHECK constraint
- [x] A person can hold both an organizer and a coach membership in the same Org
- [x] Every existing switch on the member type has been reviewed and handles the new value deliberately
- [x] Existing coach and dancer behaviour is unchanged

## Verification

Ran against a **fresh isolated database**, since the shared `s2s_test` was in use by a concurrent session working #85 — that database was never touched. Built a baseline worktree at the merge-base and compared:

- Backend: identical pre-existing failure set on both branches; this branch adds 19 passing tests. The suite is flaky on baseline too (18/12/7 failures across runs).
- Frontend: 22 tests pass. Both apps typecheck clean.
- No file gained a lint error the baseline didn't already have.
- The full migration chain applies cleanly to an empty database.

## Reviewer notes

- `apps/backend/app/database/schema/enums.ts` will conflict with `feat/event-tier-expand` (#85) — we each append an enum to that file. Both migrations are separate folders, so those don't collide.
- `org-roles.spec.ts` "orgDancer forbids type=coach even if role=admin" fails **on main too**. The test contradicts both the middleware and its own doc comment; fixing it would change `orgDancer` behaviour, which #86 doesn't ask for. Left alone deliberately.
- `get-org-members` now returns two rows for a person holding two memberships. Each row is keyed by membership id and edits its own row, so this is correct — but the admin dialog shows the same person twice, which may deserve UI polish in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
