### PR TITLE
fix(org): let members into their area between events

### DIFF
--- a/apps/frontend/src/features/org/components/dancer-sidebar.tsx
+++ b/apps/frontend/src/features/org/components/dancer-sidebar.tsx
@@ -27,7 +27,12 @@ import { scoutingQueries } from "@/features/org/api/scouting-queries";
 import { useTransmitSubscription } from "@/features/org/hooks/use-transmit";
 import { useSession } from "@/lib/session";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Link, useLocation, useNavigate, useParams } from "@tanstack/react-router";
+import {
+  Link,
+  useLocation,
+  useNavigate,
+  useParams,
+} from "@tanstack/react-router";
 import {
   CalendarIcon,
   CheckIcon,
@@ -54,15 +59,18 @@ const dashboardItem = {
 
 export function DancerSidebar() {
   const session = useSession();
-  const { org, membership, hasFeature } = useOrg();
+  const { org, membership, myRosters, hasFeature } = useOrg();
   const { orgSlug } = useParams({ strict: false }) as { orgSlug: string };
   const location = useLocation();
   const navigate = useNavigate();
   const qc = useQueryClient();
 
+  // Members with no dancer roster yet have no callbacks to fetch, and the
+  // endpoint requires a roster on the event.
+  const hasDancerRoster = myRosters.some((roster) => roster.type === "dancer");
   useQuery({
     ...scoutingQueries.dancerCallbacks(orgSlug),
-    enabled: hasFeature("callbacks"),
+    enabled: hasFeature("callbacks") && hasDancerRoster,
   });
 
   useTransmitSubscription(
@@ -124,7 +132,8 @@ export function DancerSidebar() {
     : location.pathname.includes("/coach")
       ? "Coach"
       : "Dancer";
-  const canSwitchView = membership?.role === "admin" || session.role === "admin";
+  const canSwitchView =
+    membership?.role === "admin" || session.role === "admin";
 
   function handleSelectView(view: "Admin" | "Coach" | "Dancer") {
     if (view === "Admin") {
@@ -239,7 +248,9 @@ export function DancerSidebar() {
                   <SidebarGroupLabel className="text-muted-foreground px-3 pt-2 pb-1 text-[10px] font-semibold tracking-widest uppercase">
                     {section.title}
                   </SidebarGroupLabel>
-                  <div className={`border-sidebar-border border-t ${section.items.length > 1 ? "grid grid-cols-2" : ""}`}>
+                  <div
+                    className={`border-sidebar-border border-t ${section.items.length > 1 ? "grid grid-cols-2" : ""}`}
+                  >
                     {section.items.map(({ label, icon: Icon, to }) => {
                       const isActive = isItemActive(to);
                       return (
@@ -346,7 +357,11 @@ export function DancerSidebar() {
                     closeOnClick
                     render={
                       <Link
-                        to={session.type === "school" ? "/explore/$username" : "/$username"}
+                        to={
+                          session.type === "school"
+                            ? "/explore/$username"
+                            : "/$username"
+                        }
                         params={{ username: session.username }}
                       />
                     }
@@ -386,7 +401,11 @@ export function DancerSidebar() {
                         [
                           { value: "light", label: "Light", icon: SunIcon },
                           { value: "dark", label: "Dark", icon: MoonIcon },
-                          { value: "system", label: "System", icon: MonitorIcon },
+                          {
+                            value: "system",
+                            label: "System",
+                            icon: MonitorIcon,
+                          },
                         ] as const
                       ).map(({ value, label, icon: Icon }) => (
                         <MenuItem

--- a/apps/frontend/src/features/org/lib/org-destination.spec.ts
+++ b/apps/frontend/src/features/org/lib/org-destination.spec.ts
@@ -30,6 +30,22 @@ describe("resolveOrgArea", () => {
     ).toBe("dancer");
   });
 
+  it("lets a member in without an event roster", () => {
+    // Between events a member has no roster, but still belongs in their area.
+    expect(
+      resolveOrgArea({
+        membership: { role: "member", type: "dancer" },
+        myRosters: [],
+      }),
+    ).toBe("dancer");
+    expect(
+      resolveOrgArea({
+        membership: { role: "member", type: "coach" },
+        myRosters: [],
+      }),
+    ).toBe("coach");
+  });
+
   it("falls back to rosters when the user has no membership row", () => {
     expect(resolveOrgArea({ myRosters: [dancerRoster] })).toBe("dancer");
     expect(resolveOrgArea({ myRosters: [coachRoster] })).toBe("coach");
@@ -40,12 +56,6 @@ describe("resolveOrgArea", () => {
       "no-access",
     );
     expect(resolveOrgArea(null)).toBe("no-access");
-    expect(
-      resolveOrgArea({
-        membership: { role: "member", type: "dancer" },
-        myRosters: [],
-      }),
-    ).toBe("no-access");
   });
 });
 

--- a/apps/frontend/src/features/org/lib/org-destination.ts
+++ b/apps/frontend/src/features/org/lib/org-destination.ts
@@ -10,23 +10,20 @@ const hasRoster = (access: OrgAccess | null | undefined, type: string) =>
   access?.myRosters?.some((roster) => roster.type === type) ?? false;
 
 /**
- * Where a member of this org belongs once they are signed in. Membership is the
- * source of truth when it exists, but users can be put on an event roster
- * without a membership row, so rosters act as the fallback signal.
+ * Where a member of this org belongs once they are signed in.
+ *
+ * Org membership alone is enough to reach an area — event rosters come and go
+ * per event, and a member between events still belongs in their own area (the
+ * page shows a pending state). Rosters only pick the area for users who are on
+ * an event roster without a membership row. No-access is for neither.
  */
 export function resolveOrgArea(access: OrgAccess | null | undefined): OrgArea {
   const role = access?.membership?.role;
   const type = access?.membership?.type;
 
   if (role === "admin") return "admin";
-  if (type === "coach") {
-    return hasRoster(access, "coach") || access?.myRoster
-      ? "coach"
-      : "no-access";
-  }
-  if (type === "dancer") {
-    return hasRoster(access, "dancer") ? "dancer" : "no-access";
-  }
+  if (type === "coach") return "coach";
+  if (type === "dancer") return "dancer";
 
   if (hasRoster(access, "coach")) return "coach";
   if (hasRoster(access, "dancer")) return "dancer";

--- a/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/coach/event-info.tsx
+++ b/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/coach/event-info.tsx
@@ -56,6 +56,17 @@ function EventInfo() {
     );
   }
 
+  // Members of the org who are not on any event roster yet: the scouting
+  // dashboard has nothing to show them and its endpoints require a roster.
+  if (!isAdmin && !myRoster) {
+    return (
+      <div className="text-muted-foreground py-12 text-center">
+        You are not on an event roster yet. Your event will appear here once the
+        organizer adds you.
+      </div>
+    );
+  }
+
   if (isAdmin && !myRoster && activeEvent) {
     return <AttendEventGate orgSlug={orgSlug} eventName={activeEvent.name} />;
   }

--- a/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/dancer/event-info.tsx
+++ b/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/dancer/event-info.tsx
@@ -67,7 +67,8 @@ function DancerEventInfo() {
   if (!event) {
     return (
       <div className="text-muted-foreground py-12 text-center">
-        No registered event.
+        You are not on an event roster yet. Your event will appear here once the
+        organizer adds you.
       </div>
     );
   }


### PR DESCRIPTION
Follow-up to #? (`fix/org-login-redirect`, merged as `0629af67`), covering the case that work didn't: a member of an org **between events**.

## The problem

Org membership and event rosters answer different questions:

- **Membership** — "you belong to this org, as a coach or a dancer." Permanent.
- **Roster** — "you are signed up for *this event*." Per-event, and absent between events.

`resolveOrgArea` was deciding area access on the *roster*. So once an audition ended and before the next roster was uploaded, a legitimate member had no roster and resolved to `no-access` — locked out of the org they belong to, for no reason other than that no event happened to be running.

## The change

Membership alone now picks the area. Rosters keep their existing fallback role for users placed on an event roster without a membership row.

Everything else follows from that:

- `coach/event-info.tsx` gains the empty state a rosterless coach now reaches; `dancer/event-info.tsx` gets matching copy in place of "No registered event."
- `dancer-sidebar.tsx` stops firing the callbacks query without a dancer roster — that endpoint requires one, so the request would have failed for exactly the users this change lets in.

Part of the `dancer-sidebar.tsx` diff is Prettier reflowing untouched lines (imports, `canSwitchView`, the theme menu). Incidental, not intent.

## Reviewer: please confirm the access model

**This widens access, and the widened access never lapses.** `org_memberships` has no expiry column, so a member added three years ago lands in the coach area today.

To be clear about what the old code was doing: the roster check was **not** an expiry mechanism, and neither version implements one. But because rosters are per-event, access did drift shut after an event as a side effect — and that side effect is precisely what was locking legitimate members out. Removing it is the fix, not a regression.

Whether that's right depends on something the code can't settle:

- **`org_memberships` has no date column at all.** That reads as a decision that membership is permanent, which makes this change correct.
- **`event_rosters.expirationDate` exists, is written by the dancer CSV upload, and is never read by any access check.** So roster-based expiry looks started and abandoned; it can't be leaned on.
- **`users.orgAccountTierExpiresAt` is genuinely enforced** (`auth/queries.ts`, `media/permissions/service.ts`, `get-dancer/service.ts`) — but that gates a Dancer's premium features on the main platform, not org area access. Different question.

If access is *supposed* to lapse, that's a separate piece of work and `expirationDate` is the dead column that was meant to do it.

Worth noting this is convenience gating — the pages show nothing without data, and the backend middleware remains authoritative.

## Verification

`pnpm --filter frontend exec vitest run` — 16 passed (5 files), including the 7 in `org-destination.spec.ts`. `pnpm --filter frontend build` succeeds.

The spec was updated in step with the logic: the old "member with no roster → no-access" assertion was moved out of the fallback test and replaced with a positive case, `"lets a member in without an event roster"`, covering both coach and dancer.

## Provenance

This existed only as uncommitted changes in a local worktree on the already-merged `fix/org-login-redirect` branch — not on `main` by any route, and not superseded by any later commit. Recovered onto a fresh branch off `main` rather than discarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
