### PR TITLE
ci: deploy to Fly only on push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,6 @@
 name: Deploy
 
 on:
-  pull_request:
-    paths:
-      - 'apps/backend/**'
-      - 'packages/openapi/**'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
   push:
     paths:
       - 'apps/backend/**'


### PR DESCRIPTION
## The bug

```yaml
on:
  pull_request:          # ← no branch filter
    paths: [...]
  push:
    paths: [...]
    branches: [main]     # ← applies only to push
```

`branches: [main]` constrains the `push` trigger only. The `pull_request` trigger matched every PR touching `apps/backend/**`, `packages/openapi/**`, `package.json`, or `pnpm-lock.yaml` — and the single job runs `flyctl deploy --remote-only` with no condition guarding it. Every such PR deployed to production.

## The fix

Drop the `pull_request` trigger. Deploys now happen on merges to `main`, which is what the `push` trigger already said.

## Worth knowing

This is the repo's **only** workflow, so nothing else is lost by removing that trigger — but it also means the 55 Japa specs in `apps/backend` never run in CI. There is currently no test gate on any PR. Worth adding separately, especially with several tickets from #84 in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)