### PR TITLE
fix(events): stop staff preview rosters counting as participants

### DIFF
--- a/apps/backend/app/modules/orgs/events/create/service.spec.ts
+++ b/apps/backend/app/modules/orgs/events/create/service.spec.ts
@@ -13,6 +13,7 @@ import { CreateEventService } from "./service.ts";
 import { DatabaseService } from "#database/service";
 import { eq } from "drizzle-orm";
 import { E_DATABASE_ERROR } from "#exceptions/database";
+import { ListRosterService } from "../rosters/list/service.ts";
 import CreateEventController from "./controller.ts";
 import OrgAdminMiddleware from "#middleware/routes/org-admin";
 
@@ -140,6 +141,44 @@ test.group("CreateEventService", (group) => {
     );
     assert.isFalse(ev1.isActive);
     assert.isFalse(ev2.isActive);
+  });
+
+  test("the creator does not appear in the event's coach roster", async ({
+    assert,
+  }) => {
+    const actor = await makeActorUser();
+    const [summit] = await db
+      .select()
+      .from(organizations)
+      .where(eq(organizations.slug, "summit"));
+
+    const ev = await svc.execute(
+      summit!.id,
+      {
+        name: "Creator Roster",
+        startDate: "2026-06-13",
+        endDate: "2026-06-14",
+        isActive: true,
+      },
+      actor.id
+    );
+
+    const coaches = await new ListRosterService(new DatabaseService()).execute(
+      ev.id,
+      { type: "coach" }
+    );
+    assert.lengthOf(coaches.data, 0);
+    assert.equal(coaches.total, 0);
+
+    // The row still exists to anchor FKs — it is just flagged as staff, exactly
+    // as "view as coach" would have provisioned it.
+    const [row] = await db
+      .select()
+      .from(eventRosters)
+      .where(eq(eventRosters.eventId, ev.id));
+    assert.exists(row);
+    assert.equal(row!.userId, actor.id);
+    assert.isTrue(row!.isStaff);
   });
 });
 

--- a/apps/backend/app/modules/orgs/events/create/service.ts
+++ b/apps/backend/app/modules/orgs/events/create/service.ts
@@ -38,6 +38,10 @@ export class CreateEventService {
         .where(eq(users.id, actorId))
         .limit(1);
 
+      // The creator is an Organizer running the event, not a participant in it
+      // (ADR 0003). Seed the row as a staff/preview roster so it anchors FKs and
+      // matches what "view as coach" would provision, while staying out of every
+      // participant-facing and aggregate query.
       if (actor) {
         await tx.insert(eventRosters).values({
           eventId: ev!.id,
@@ -46,6 +50,7 @@ export class CreateEventService {
           email: actor.displayEmail,
           firstName: actor.firstName,
           lastName: actor.lastName,
+          isStaff: true,
         });
       }
 

--- a/apps/backend/app/modules/orgs/events/stats/service.spec.ts
+++ b/apps/backend/app/modules/orgs/events/stats/service.spec.ts
@@ -150,4 +150,80 @@ test.group("EventStatsService", (group) => {
     const stats = await svc.execute(event.id);
     assert.lengthOf(stats.recentUploads, 5);
   });
+
+  test("excludes staff view-as rosters from every count", async ({
+    assert,
+  }) => {
+    const dancer = await createUser({ username: "d1", email: "d1@x.co" });
+    const admin = await createUser({ username: "admin", email: "admin@x.co" });
+
+    await db.insert(eventRosters).values([
+      // Real participants: 1 activated dancer, 1 pending coach
+      {
+        eventId: event.id,
+        type: "dancer",
+        email: "d1@x.co",
+        firstName: "D",
+        lastName: "One",
+        userId: dancer.id,
+      },
+      {
+        eventId: event.id,
+        type: "coach",
+        email: "coach@x.co",
+        firstName: "C",
+        lastName: "O",
+      },
+      // Staff "view-as" sandboxes owned by an admin, one per type
+      {
+        eventId: event.id,
+        type: "coach",
+        email: "admin@x.co",
+        firstName: "A",
+        lastName: "D",
+        userId: admin.id,
+        isStaff: true,
+      },
+      {
+        eventId: event.id,
+        type: "dancer",
+        email: "admin@x.co",
+        firstName: "A",
+        lastName: "D",
+        userId: admin.id,
+        isStaff: true,
+      },
+      // Unactivated staff rows must not land in the pending buckets either
+      {
+        eventId: event.id,
+        type: "coach",
+        email: "staff-pending@x.co",
+        firstName: "S",
+        lastName: "P",
+        isStaff: true,
+      },
+      {
+        eventId: event.id,
+        type: "dancer",
+        email: "staff-pending@x.co",
+        firstName: "S",
+        lastName: "P",
+        isStaff: true,
+      },
+    ]);
+
+    const svc = new EventStatsService();
+    const stats = await svc.execute(event.id);
+
+    assert.equal(stats.coaches.activated, 0);
+    assert.equal(stats.coaches.pending, 1);
+    assert.equal(stats.coaches.total, 1);
+
+    assert.equal(stats.dancers.activated, 1);
+    assert.equal(stats.dancers.pending, 0);
+    assert.equal(stats.dancers.total, 1);
+
+    assert.equal(stats.registered, 1);
+    assert.equal(stats.pending, 1);
+  });
 });

--- a/apps/backend/app/modules/orgs/events/stats/service.ts
+++ b/apps/backend/app/modules/orgs/events/stats/service.ts
@@ -10,7 +10,9 @@ export class EventStatsService {
   async execute(eventId: string) {
     return this.db.use(async (db) => {
       // All counts derived from eventRosters.userId per activation semantics:
-      // activated = userId IS NOT NULL, pending = userId IS NULL
+      // activated = userId IS NOT NULL, pending = userId IS NULL.
+      // Staff "view-as" rows are preview sandboxes owned by admins, never
+      // participants, so they are excluded from every count below.
       const [coachActivated] = await db
         .select({ v: count() })
         .from(eventRosters)
@@ -18,6 +20,7 @@ export class EventStatsService {
           and(
             eq(eventRosters.eventId, eventId),
             eq(eventRosters.type, "coach"),
+            eq(eventRosters.isStaff, false),
             isNotNull(eventRosters.userId)
           )
         );
@@ -29,6 +32,7 @@ export class EventStatsService {
           and(
             eq(eventRosters.eventId, eventId),
             eq(eventRosters.type, "coach"),
+            eq(eventRosters.isStaff, false),
             isNull(eventRosters.userId)
           )
         );
@@ -40,6 +44,7 @@ export class EventStatsService {
           and(
             eq(eventRosters.eventId, eventId),
             eq(eventRosters.type, "dancer"),
+            eq(eventRosters.isStaff, false),
             isNotNull(eventRosters.userId)
           )
         );
@@ -51,6 +56,7 @@ export class EventStatsService {
           and(
             eq(eventRosters.eventId, eventId),
             eq(eventRosters.type, "dancer"),
+            eq(eventRosters.isStaff, false),
             isNull(eventRosters.userId)
           )
         );


### PR DESCRIPTION
Closes #98. Closes #99.

Two one-line fixes to the same invariant: a staff "view-as" roster is a preview sandbox, not a participant. #99 stops creating phantom participants; #98 stops counting them.

Both were found while auditing `org_member_type` for #86.

## #99 — `CreateEventService` made the creator a real coach

`apps/backend/app/modules/orgs/events/create/service.ts` inserted a Roster Entry for whoever created the event with `type: "coach"` and no `isStaff` flag. So creating an Org Event silently made the Organizer a **real coach participant** on it — visible in the admin Coaches table, CSV exports, the dancer-facing schools list, scouting surfaces and the stats counts.

The path was missed when `is_staff` landed (`846ad33a`, 2026-06-24) — the same day the old `attend` endpoint was removed (`ce468773`). It has been producing phantom rows ever since.

Fixed with `isStaff: true`, chosen over deleting the row so it still anchors FKs and matches exactly what "view as Coach" provisions.

**Note for reviewers:** the creator's row now occupies the same slot view-as uses — `event_rosters_staff_per_user` is unique on `(event_id, user_id, type)` where `is_staff = true`. So an Organizer who created an event and later clicks "view as Coach" gets that row reused rather than a duplicate inserted. Verified: the view-as spec passes against this branch. The two features now share a row by design.

## #98 — event stats counted the sandboxes

`apps/backend/app/modules/orgs/events/stats/service.ts` had four `count()` queries with no `is_staff` filter, so every admin preview permanently added +1 to that event's activated-coach count. `coaches.total`, `dancers.total`, `registered` and `pending` all inherited the error.

This was live: `summit` read 17 coaches instead of 14, `dance-team-night` 17 instead of 13, `prodigy` 14 instead of 13, and `core` 2 instead of 0.

## Verification

Each fix was reverted with its test kept, to confirm the test actually fails without it — neither is a test that would pass regardless.

- Combined branch: **353 passed, 7 failed** — the 7 are pre-existing on `main` (ExportRosterService ×2, StatsRosterService ×4, one org-roles middleware test).
- Typecheck clean. Lint identical to `main`.
- `#98`'s test asserts all eight outputs, including the derived aliases, against 4 staff rows and 2 real ones.
- `#99`'s test asserts through the real `ListRosterService` — not just the raw column — so it proves both halves: invisible to participants, still present as an anchor.

## Follow-up, not in scope

The production phantom rows have already been cleaned up separately via `backfill:staff-rosters`.

#100 tracks the pattern behind both bugs: 15 of 43 files touching `event_rosters` filter `is_staff`, so exclusion is opt-in and new code defaults to wrong. It also raises the question worth settling first — whether preview needs to persist a row at all, or whether a synthesised in-memory roster would remove this whole class of bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
