### PR TITLE
feat(entitlement): resolve entitlement from the active Org Event's Event Tier

### DIFF
--- a/apps/backend/app/middleware/routes/org-feature.spec.ts
+++ b/apps/backend/app/middleware/routes/org-feature.spec.ts
@@ -1,15 +1,23 @@
 import { test } from "@japa/runner";
 import OrgFeatureMiddleware from "./org-feature.ts";
+import type { EventTier } from "#shared/org/event-tiers";
 
 type State = {
   nextCalled: boolean;
   notFoundBody: { message: string } | null;
 };
 
-function mockCtx(features: Record<string, boolean> | null) {
+function mockCtx(options: {
+  features?: Record<string, boolean> | null;
+  eventTier?: EventTier;
+}) {
   const state: State = { nextCalled: false, notFoundBody: null };
   const ctx: any = {
-    org: features === null ? undefined : { features },
+    org:
+      options.features === null || options.features === undefined
+        ? undefined
+        : { features: options.features },
+    orgEvent: options.eventTier ? { eventTier: options.eventTier } : undefined,
     response: {
       notFound: (body: { message: string }) => {
         state.notFoundBody = body;
@@ -22,33 +30,91 @@ function mockCtx(features: Record<string, boolean> | null) {
   return { ctx, state, next };
 }
 
-test.group("OrgFeatureMiddleware", () => {
-  test("allows when the feature key is true", async ({ assert }) => {
-    const { ctx, state, next } = mockCtx({ callbacks: true });
+test.group("OrgFeatureMiddleware — Event Tier capabilities", () => {
+  test("allows when the active event's Event Tier includes the capability", async ({
+    assert,
+  }) => {
+    const { ctx, state, next } = mockCtx({ eventTier: "regional" });
     await new OrgFeatureMiddleware().handle(ctx, next, "callbacks");
     assert.isTrue(state.nextCalled);
     assert.isNull(state.notFoundBody);
   });
 
-  test("404s when the feature key is false", async ({ assert }) => {
-    const { ctx, state, next } = mockCtx({ callbacks: false });
+  test("404s when the active event's Event Tier excludes the capability", async ({
+    assert,
+  }) => {
+    const { ctx, state, next } = mockCtx({ eventTier: "core" });
     await new OrgFeatureMiddleware().handle(ctx, next, "callbacks");
     assert.isFalse(state.nextCalled);
     assert.isNotNull(state.notFoundBody);
   });
 
-  test("404s when the feature key is missing from features", async ({
+  test("a grandfathered Enterprise event keeps every capability", async ({
     assert,
   }) => {
-    const { ctx, state, next } = mockCtx({ something_else: true });
+    for (const capability of [
+      "callbacks",
+      "check_in",
+      "school_selections",
+      "video_library",
+    ] as const) {
+      const { ctx, state, next } = mockCtx({ eventTier: "enterprise" });
+      await new OrgFeatureMiddleware().handle(ctx, next, capability);
+      assert.isTrue(state.nextCalled, capability);
+    }
+  });
+
+  test("the org's feature flags cannot grant a capability the event lacks", async ({
+    assert,
+  }) => {
+    const { ctx, state, next } = mockCtx({
+      features: { callbacks: true },
+      eventTier: "core",
+    });
     await new OrgFeatureMiddleware().handle(ctx, next, "callbacks");
+    assert.isFalse(state.nextCalled);
+    assert.isNotNull(state.notFoundBody);
+  });
+
+  test("404s when no active event was resolved onto the request", async ({
+    assert,
+  }) => {
+    const { ctx, state, next } = mockCtx({ features: { callbacks: true } });
+    await new OrgFeatureMiddleware().handle(ctx, next, "callbacks");
+    assert.isFalse(state.nextCalled);
+    assert.isNotNull(state.notFoundBody);
+  });
+});
+
+test.group("OrgFeatureMiddleware — org-wide configuration", () => {
+  test("allows when the org's flag is true", async ({ assert }) => {
+    const { ctx, state, next } = mockCtx({ features: { freeTierUsers: true } });
+    await new OrgFeatureMiddleware().handle(ctx, next, "freeTierUsers");
+    assert.isTrue(state.nextCalled);
+    assert.isNull(state.notFoundBody);
+  });
+
+  test("404s when the org's flag is false", async ({ assert }) => {
+    const { ctx, state, next } = mockCtx({
+      features: { freeTierUsers: false },
+    });
+    await new OrgFeatureMiddleware().handle(ctx, next, "freeTierUsers");
+    assert.isFalse(state.nextCalled);
+    assert.isNotNull(state.notFoundBody);
+  });
+
+  test("404s when the flag is missing from features", async ({ assert }) => {
+    const { ctx, state, next } = mockCtx({
+      features: { something_else: true },
+    });
+    await new OrgFeatureMiddleware().handle(ctx, next, "freeTierUsers");
     assert.isFalse(state.nextCalled);
     assert.isNotNull(state.notFoundBody);
   });
 
   test("404s when ctx.org is missing entirely", async ({ assert }) => {
-    const { ctx, state, next } = mockCtx(null);
-    await new OrgFeatureMiddleware().handle(ctx, next, "callbacks");
+    const { ctx, state, next } = mockCtx({ features: null });
+    await new OrgFeatureMiddleware().handle(ctx, next, "freeTierUsers");
     assert.isFalse(state.nextCalled);
     assert.isNotNull(state.notFoundBody);
   });

--- a/apps/backend/app/middleware/routes/org-feature.spec.ts
+++ b/apps/backend/app/middleware/routes/org-feature.spec.ts
@@ -64,22 +64,28 @@ test.group("OrgFeatureMiddleware — Event Tier capabilities", () => {
     }
   });
 
-  test("the org's feature flags cannot grant a capability the event lacks", async ({
+  test("an explicit org flag overrides the Event Tier in both directions", async ({
     assert,
   }) => {
-    const { ctx, state, next } = mockCtx({
-      features: { callbacks: true },
-      eventTier: "core",
+    // Staff configure events by hand; buying a bundle is not a reason to lose
+    // the ability to turn one thing on or off.
+    const on = mockCtx({ features: { callbacks: true }, eventTier: "core" });
+    await new OrgFeatureMiddleware().handle(on.ctx, on.next, "callbacks");
+    assert.isTrue(on.state.nextCalled);
+
+    const off = mockCtx({
+      features: { check_in: false },
+      eventTier: "enterprise",
     });
-    await new OrgFeatureMiddleware().handle(ctx, next, "callbacks");
-    assert.isFalse(state.nextCalled);
-    assert.isNotNull(state.notFoundBody);
+    await new OrgFeatureMiddleware().handle(off.ctx, off.next, "check_in");
+    assert.isFalse(off.state.nextCalled);
+    assert.isNotNull(off.state.notFoundBody);
   });
 
-  test("404s when no active event was resolved onto the request", async ({
+  test("404s when no event was resolved and nothing was overridden", async ({
     assert,
   }) => {
-    const { ctx, state, next } = mockCtx({ features: { callbacks: true } });
+    const { ctx, state, next } = mockCtx({ features: {} });
     await new OrgFeatureMiddleware().handle(ctx, next, "callbacks");
     assert.isFalse(state.nextCalled);
     assert.isNotNull(state.notFoundBody);

--- a/apps/backend/app/middleware/routes/org-feature.ts
+++ b/apps/backend/app/middleware/routes/org-feature.ts
@@ -1,25 +1,61 @@
 import type { HttpContext } from "@adonisjs/core/http";
 import type { NextFn } from "@adonisjs/core/types/http";
+import {
+  eventTierIncludes,
+  isEventTierCapability,
+  type EventTierCapability,
+} from "#shared/org/event-tiers";
 
 /**
- * Gates a route behind an org's `features` JSONB flag.
+ * Org-wide configuration that gates a route but is not bought per event. These
+ * keys stay on `organizations.features`: they are how the Org is set up rather
+ * than what it paid for at one Org Event (ADR 0002).
+ */
+export type OrgConfigurationFlag = "freeTierUsers";
+
+/**
+ * Gates a route behind what the request's Org Event includes, or — for org-wide
+ * configuration — behind the org's `features` JSONB flag.
  *
- * Usage (inside a route group that's already resolved ctx.org):
+ * Usage (inside a route group that has already resolved ctx.org, and ctx.orgEvent
+ * for a capability key):
  *
  *   router
  *     .post("callbacks", [CreateCallback])
  *     .use(middleware.orgFeature("callbacks"));
  *
- * If the feature key is missing or falsy, the middleware 404s (not
- * 403) so the route is *invisible* to clients whose org doesn't have
- * the feature enabled, rather than teasing it as "disabled".
+ * A capability resolves from the active Org Event's Event Tier, so two events
+ * under one Org gate independently of each other and an Org gets what it bought
+ * at each. The event must already be on the request: `middleware.orgEvent()`
+ * belongs *before* this one in the group, and an unresolved event is treated as
+ * no entitlement rather than as a reason to fall back to the Org.
+ *
+ * If the capability is not included — or the flag is missing or falsy — the
+ * middleware 404s (not 403) so the route is *invisible* to clients that do not
+ * have it, rather than teasing it as "disabled".
  */
 export default class OrgFeatureMiddleware {
-  async handle(ctx: HttpContext, next: NextFn, key: string) {
-    const features = (ctx.org?.features ?? {}) as Record<string, boolean>;
-    if (!features[key]) {
+  async handle(
+    ctx: HttpContext,
+    next: NextFn,
+    key: EventTierCapability | OrgConfigurationFlag
+  ) {
+    if (!this.isEntitled(ctx, key)) {
       return ctx.response.notFound({ message: "Not found." });
     }
     return next();
+  }
+
+  private isEntitled(
+    ctx: HttpContext,
+    key: EventTierCapability | OrgConfigurationFlag
+  ): boolean {
+    if (isEventTierCapability(key)) {
+      const eventTier = ctx.orgEvent?.eventTier;
+      return eventTier !== undefined && eventTierIncludes(eventTier, key);
+    }
+
+    const features = (ctx.org?.features ?? {}) as Record<string, boolean>;
+    return Boolean(features[key]);
   }
 }

--- a/apps/backend/app/middleware/routes/org-feature.ts
+++ b/apps/backend/app/middleware/routes/org-feature.ts
@@ -1,15 +1,13 @@
 import type { HttpContext } from "@adonisjs/core/http";
 import type { NextFn } from "@adonisjs/core/types/http";
-import {
-  eventTierIncludes,
-  isEventTierCapability,
-  type EventTierCapability,
-} from "#shared/org/event-tiers";
+import { includesCapability } from "#shared/org/entitlement";
+import { isEventTierCapability } from "#shared/org/event-tiers";
+import type { EventTierCapability } from "#shared/org/event-tiers";
 
 /**
  * Org-wide configuration that gates a route but is not bought per event. These
- * keys stay on `organizations.features`: they are how the Org is set up rather
- * than what it paid for at one Org Event (ADR 0002).
+ * keys are how the Org is set up rather than what it paid for at one Org Event
+ * (ADR 0002), so they resolve from `organizations.features` alone.
  */
 export type OrgConfigurationFlag = "freeTierUsers";
 
@@ -24,11 +22,14 @@ export type OrgConfigurationFlag = "freeTierUsers";
  *     .post("callbacks", [CreateCallback])
  *     .use(middleware.orgFeature("callbacks"));
  *
- * A capability resolves from the active Org Event's Event Tier, so two events
- * under one Org gate independently of each other and an Org gets what it bought
- * at each. The event must already be on the request: `middleware.orgEvent()`
- * belongs *before* this one in the group, and an unresolved event is treated as
- * no entitlement rather than as a reason to fall back to the Org.
+ * A capability is what the Org Event's Event Tier includes, unless staff set a
+ * flag on the Org saying otherwise — see `#shared/org/entitlement` for why an
+ * explicit flag wins and an absent one defers. Resolving from the event means
+ * two events under one Org can gate independently once nobody has overridden
+ * them.
+ *
+ * The event must already be on the request: `middleware.orgEvent()` belongs
+ * *before* this one in the group.
  *
  * If the capability is not included — or the flag is missing or falsy — the
  * middleware 404s (not 403) so the route is *invisible* to clients that do not
@@ -51,8 +52,11 @@ export default class OrgFeatureMiddleware {
     key: EventTierCapability | OrgConfigurationFlag
   ): boolean {
     if (isEventTierCapability(key)) {
-      const eventTier = ctx.orgEvent?.eventTier;
-      return eventTier !== undefined && eventTierIncludes(eventTier, key);
+      return includesCapability({
+        features: ctx.org?.features,
+        eventTier: ctx.orgEvent?.eventTier,
+        capability: key,
+      });
     }
 
     const features = (ctx.org?.features ?? {}) as Record<string, boolean>;

--- a/apps/backend/app/modules/orgs/get-org/controller.ts
+++ b/apps/backend/app/modules/orgs/get-org/controller.ts
@@ -23,7 +23,7 @@ export default class GetOrgController {
     if (!result) {
       return response.notFound({ message: "Organization not found." });
     }
-    const { org, membership, myRoster, myRosters } = result;
+    const { org, membership, myRoster, myRosters, activeEvent } = result;
     return response.ok({
       id: org.id,
       slug: org.slug,
@@ -36,6 +36,7 @@ export default class GetOrgController {
       membership,
       myRoster,
       myRosters,
+      activeEvent,
     });
   }
 }

--- a/apps/backend/app/modules/orgs/get-org/controller.ts
+++ b/apps/backend/app/modules/orgs/get-org/controller.ts
@@ -23,7 +23,8 @@ export default class GetOrgController {
     if (!result) {
       return response.notFound({ message: "Organization not found." });
     }
-    const { org, membership, myRoster, myRosters, activeEvent } = result;
+    const { org, membership, myRoster, myRosters, activeEventCapabilities } =
+      result;
     return response.ok({
       id: org.id,
       slug: org.slug,
@@ -36,7 +37,7 @@ export default class GetOrgController {
       membership,
       myRoster,
       myRosters,
-      activeEvent,
+      activeEventCapabilities,
     });
   }
 }

--- a/apps/backend/app/modules/orgs/get-org/service.spec.ts
+++ b/apps/backend/app/modules/orgs/get-org/service.spec.ts
@@ -31,6 +31,72 @@ test.group("GET /orgs/:slug", (group) => {
     assert.equal(body.settings.max_school_selections, 3);
   });
 
+  test("carries the active event's Event Tier and what it includes", async ({
+    client,
+    assert,
+  }) => {
+    const [org] = await db
+      .select()
+      .from(organizations)
+      .where(eq(organizations.slug, "summit"));
+    const [event] = await db
+      .insert(orgEvents)
+      .values({
+        orgId: org!.id,
+        name: "Entitlement Event",
+        startDate: "2026-09-01",
+        endDate: "2026-09-02",
+        isActive: true,
+        eventTier: "regional",
+      })
+      .returning();
+
+    const response = await client.get("/orgs/summit");
+    response.assertStatus(200);
+    const { activeEvent } = response.body();
+    assert.equal(activeEvent.id, event!.id);
+    assert.equal(activeEvent.eventTier, "regional");
+    assert.sameMembers(activeEvent.capabilities, [
+      "check_in",
+      "school_selections",
+      "callbacks",
+    ]);
+  });
+
+  test("a Core active event includes none of the gated capabilities", async ({
+    client,
+    assert,
+  }) => {
+    const [org] = await db
+      .select()
+      .from(organizations)
+      .where(eq(organizations.slug, "summit"));
+    await db.insert(orgEvents).values({
+      orgId: org!.id,
+      name: "Core Event",
+      startDate: "2026-09-01",
+      endDate: "2026-09-02",
+      isActive: true,
+      eventTier: "core",
+    });
+
+    const response = await client.get("/orgs/summit");
+    response.assertStatus(200);
+    // Empty rather than absent: the org's own flags say `callbacks: true`, and
+    // a client that cannot tell "no capabilities" from "no answer" would fall
+    // back to them.
+    assert.deepEqual(response.body().activeEvent.capabilities, []);
+  });
+
+  test("activeEvent is null when the org has no active event", async ({
+    client,
+    assert,
+  }) => {
+    const response = await client.get("/orgs/core");
+    response.assertStatus(200);
+    assert.isNull(response.body().activeEvent);
+  });
+
   test("returns 404 for unknown slug", async ({ client }) => {
     const response = await client.get("/orgs/does-not-exist");
     response.assertStatus(404);

--- a/apps/backend/app/modules/orgs/get-org/service.spec.ts
+++ b/apps/backend/app/modules/orgs/get-org/service.spec.ts
@@ -35,10 +35,11 @@ test.group("GET /orgs/:slug", (group) => {
     client,
     assert,
   }) => {
+    // The core org overrides nothing, so its Event Tier alone decides.
     const [org] = await db
       .select()
       .from(organizations)
-      .where(eq(organizations.slug, "summit"));
+      .where(eq(organizations.slug, "core"));
     await db.insert(orgEvents).values({
       orgId: org!.id,
       name: "Entitlement Event",
@@ -48,7 +49,7 @@ test.group("GET /orgs/:slug", (group) => {
       eventTier: "regional",
     });
 
-    const response = await client.get("/orgs/summit");
+    const response = await client.get("/orgs/core");
     response.assertStatus(200);
     assert.sameMembers(response.body().activeEventCapabilities, [
       "check_in",
@@ -57,14 +58,14 @@ test.group("GET /orgs/:slug", (group) => {
     ]);
   });
 
-  test("a Core active event includes none of the gated capabilities", async ({
+  test("a Core active event with no overrides includes nothing", async ({
     client,
     assert,
   }) => {
     const [org] = await db
       .select()
       .from(organizations)
-      .where(eq(organizations.slug, "summit"));
+      .where(eq(organizations.slug, "core"));
     await db.insert(orgEvents).values({
       orgId: org!.id,
       name: "Core Event",
@@ -74,21 +75,48 @@ test.group("GET /orgs/:slug", (group) => {
       eventTier: "core",
     });
 
-    const response = await client.get("/orgs/summit");
+    const response = await client.get("/orgs/core");
     response.assertStatus(200);
-    // Empty rather than null: the org's own flags say `callbacks: true`, and a
-    // client that cannot tell "an event including nothing" from "no active
-    // event" would fall back to them.
     assert.deepEqual(response.body().activeEventCapabilities, []);
   });
 
-  test("capabilities are null when the org has no active event", async ({
+  test("an org's explicit flags override the active event's Event Tier", async ({
     client,
     assert,
   }) => {
+    // The summit org switches callbacks, school_selections and video_library on
+    // and never mentions check_in, so a Core event keeps the first three and
+    // takes its answer on the fourth from the Event Tier.
+    const [org] = await db
+      .select()
+      .from(organizations)
+      .where(eq(organizations.slug, "summit"));
+    await db.insert(orgEvents).values({
+      orgId: org!.id,
+      name: "Overridden Event",
+      startDate: "2026-09-01",
+      endDate: "2026-09-02",
+      isActive: true,
+      eventTier: "core",
+    });
+
+    const response = await client.get("/orgs/summit");
+    response.assertStatus(200);
+    assert.sameMembers(response.body().activeEventCapabilities, [
+      "callbacks",
+      "school_selections",
+      "video_library",
+    ]);
+  });
+
+  test("an org with no active event resolves to its overrides alone", async ({
+    client,
+    assert,
+  }) => {
+    // The core org overrides nothing, so there is nothing to grant.
     const response = await client.get("/orgs/core");
     response.assertStatus(200);
-    assert.isNull(response.body().activeEventCapabilities);
+    assert.deepEqual(response.body().activeEventCapabilities, []);
   });
 
   test("returns 404 for unknown slug", async ({ client }) => {

--- a/apps/backend/app/modules/orgs/get-org/service.spec.ts
+++ b/apps/backend/app/modules/orgs/get-org/service.spec.ts
@@ -31,7 +31,7 @@ test.group("GET /orgs/:slug", (group) => {
     assert.equal(body.settings.max_school_selections, 3);
   });
 
-  test("carries the active event's Event Tier and what it includes", async ({
+  test("carries what the active event's Event Tier includes", async ({
     client,
     assert,
   }) => {
@@ -39,24 +39,18 @@ test.group("GET /orgs/:slug", (group) => {
       .select()
       .from(organizations)
       .where(eq(organizations.slug, "summit"));
-    const [event] = await db
-      .insert(orgEvents)
-      .values({
-        orgId: org!.id,
-        name: "Entitlement Event",
-        startDate: "2026-09-01",
-        endDate: "2026-09-02",
-        isActive: true,
-        eventTier: "regional",
-      })
-      .returning();
+    await db.insert(orgEvents).values({
+      orgId: org!.id,
+      name: "Entitlement Event",
+      startDate: "2026-09-01",
+      endDate: "2026-09-02",
+      isActive: true,
+      eventTier: "regional",
+    });
 
     const response = await client.get("/orgs/summit");
     response.assertStatus(200);
-    const { activeEvent } = response.body();
-    assert.equal(activeEvent.id, event!.id);
-    assert.equal(activeEvent.eventTier, "regional");
-    assert.sameMembers(activeEvent.capabilities, [
+    assert.sameMembers(response.body().activeEventCapabilities, [
       "check_in",
       "school_selections",
       "callbacks",
@@ -82,19 +76,19 @@ test.group("GET /orgs/:slug", (group) => {
 
     const response = await client.get("/orgs/summit");
     response.assertStatus(200);
-    // Empty rather than absent: the org's own flags say `callbacks: true`, and
-    // a client that cannot tell "no capabilities" from "no answer" would fall
-    // back to them.
-    assert.deepEqual(response.body().activeEvent.capabilities, []);
+    // Empty rather than null: the org's own flags say `callbacks: true`, and a
+    // client that cannot tell "an event including nothing" from "no active
+    // event" would fall back to them.
+    assert.deepEqual(response.body().activeEventCapabilities, []);
   });
 
-  test("activeEvent is null when the org has no active event", async ({
+  test("capabilities are null when the org has no active event", async ({
     client,
     assert,
   }) => {
     const response = await client.get("/orgs/core");
     response.assertStatus(200);
-    assert.isNull(response.body().activeEvent);
+    assert.isNull(response.body().activeEventCapabilities);
   });
 
   test("returns 404 for unknown slug", async ({ client }) => {

--- a/apps/backend/app/modules/orgs/get-org/service.ts
+++ b/apps/backend/app/modules/orgs/get-org/service.ts
@@ -5,7 +5,6 @@ import { organizations, orgMemberships } from "#database/schema/organizations";
 import { eventRosters, orgEvents } from "#database/schema/org-events";
 import {
   EVENT_TIER_DEFINITIONS,
-  type EventTier,
   type EventTierCapability,
 } from "#shared/org/event-tiers";
 import { hasEventStarted } from "#utils/event-time";
@@ -23,21 +22,6 @@ export interface OrgRosterSummary {
   hasStarted: boolean;
 }
 
-/**
- * What the Org's active Org Event entitles its people to.
- *
- * Entitlement is bought per event (ADR 0002), so the frontend's convenience
- * gating has to ask the active event rather than the Org. The capabilities are
- * sent resolved rather than as a bare Event Tier so that the mapping from sold
- * name to capabilities stays in `#shared/org/event-tiers` alone, and a client
- * cannot drift from it.
- */
-export interface ActiveEventEntitlement {
-  id: string;
-  eventTier: EventTier;
-  capabilities: EventTierCapability[];
-}
-
 export interface GetOrgResult {
   org: typeof organizations.$inferSelect;
   /**
@@ -50,7 +34,18 @@ export interface GetOrgResult {
   } | null;
   myRoster: OrgRosterSummary | null;
   myRosters: OrgRosterSummary[];
-  activeEvent: ActiveEventEntitlement | null;
+  /**
+   * What the Org's active Org Event includes, or `null` when it has no active
+   * event — which is not the same answer as an active event that includes
+   * nothing, and a client that cannot tell them apart would fall back to the
+   * Org's flags.
+   *
+   * Entitlement is bought per event (ADR 0002), so the frontend's convenience
+   * gating asks this rather than `org.features`. Sent resolved rather than as a
+   * bare Event Tier so that the mapping from sold name to capabilities stays in
+   * `#shared/org/event-tiers` alone and no client can drift from it.
+   */
+  activeEventCapabilities: EventTierCapability[] | null;
 }
 
 @inject()
@@ -69,19 +64,13 @@ export class GetOrgService {
         .limit(1);
       if (!org) return null;
 
-      const [activeEventRow] = await db
-        .select({ id: orgEvents.id, eventTier: orgEvents.eventTier })
+      const [activeEvent] = await db
+        .select({ eventTier: orgEvents.eventTier })
         .from(orgEvents)
         .where(and(eq(orgEvents.orgId, org.id), eq(orgEvents.isActive, true)))
         .limit(1);
-      const activeEvent: GetOrgResult["activeEvent"] = activeEventRow
-        ? {
-            id: activeEventRow.id,
-            eventTier: activeEventRow.eventTier,
-            capabilities: [
-              ...EVENT_TIER_DEFINITIONS[activeEventRow.eventTier].capabilities,
-            ],
-          }
+      const activeEventCapabilities = activeEvent
+        ? [...EVENT_TIER_DEFINITIONS[activeEvent.eventTier].capabilities]
         : null;
 
       let membership: GetOrgResult["membership"] = null;
@@ -150,7 +139,13 @@ export class GetOrgService {
         myRoster = myRosters[0] ?? null;
       }
 
-      return { org, membership, myRoster, myRosters, activeEvent };
+      return {
+        org,
+        membership,
+        myRoster,
+        myRosters,
+        activeEventCapabilities,
+      };
     });
   }
 }

--- a/apps/backend/app/modules/orgs/get-org/service.ts
+++ b/apps/backend/app/modules/orgs/get-org/service.ts
@@ -3,6 +3,11 @@ import { resolveEffectiveMembership } from "#shared/org/membership";
 import { DatabaseService } from "#database/service";
 import { organizations, orgMemberships } from "#database/schema/organizations";
 import { eventRosters, orgEvents } from "#database/schema/org-events";
+import {
+  EVENT_TIER_DEFINITIONS,
+  type EventTier,
+  type EventTierCapability,
+} from "#shared/org/event-tiers";
 import { hasEventStarted } from "#utils/event-time";
 import { inject } from "@adonisjs/core";
 import { and, asc, desc, eq, sql } from "drizzle-orm";
@@ -18,6 +23,21 @@ export interface OrgRosterSummary {
   hasStarted: boolean;
 }
 
+/**
+ * What the Org's active Org Event entitles its people to.
+ *
+ * Entitlement is bought per event (ADR 0002), so the frontend's convenience
+ * gating has to ask the active event rather than the Org. The capabilities are
+ * sent resolved rather than as a bare Event Tier so that the mapping from sold
+ * name to capabilities stays in `#shared/org/event-tiers` alone, and a client
+ * cannot drift from it.
+ */
+export interface ActiveEventEntitlement {
+  id: string;
+  eventTier: EventTier;
+  capabilities: EventTierCapability[];
+}
+
 export interface GetOrgResult {
   org: typeof organizations.$inferSelect;
   /**
@@ -30,6 +50,7 @@ export interface GetOrgResult {
   } | null;
   myRoster: OrgRosterSummary | null;
   myRosters: OrgRosterSummary[];
+  activeEvent: ActiveEventEntitlement | null;
 }
 
 @inject()
@@ -47,6 +68,21 @@ export class GetOrgService {
         .where(eq(organizations.slug, slug))
         .limit(1);
       if (!org) return null;
+
+      const [activeEventRow] = await db
+        .select({ id: orgEvents.id, eventTier: orgEvents.eventTier })
+        .from(orgEvents)
+        .where(and(eq(orgEvents.orgId, org.id), eq(orgEvents.isActive, true)))
+        .limit(1);
+      const activeEvent: GetOrgResult["activeEvent"] = activeEventRow
+        ? {
+            id: activeEventRow.id,
+            eventTier: activeEventRow.eventTier,
+            capabilities: [
+              ...EVENT_TIER_DEFINITIONS[activeEventRow.eventTier].capabilities,
+            ],
+          }
+        : null;
 
       let membership: GetOrgResult["membership"] = null;
       let myRoster: GetOrgResult["myRoster"] = null;
@@ -114,7 +150,7 @@ export class GetOrgService {
         myRoster = myRosters[0] ?? null;
       }
 
-      return { org, membership, myRoster, myRosters };
+      return { org, membership, myRoster, myRosters, activeEvent };
     });
   }
 }

--- a/apps/backend/app/modules/orgs/get-org/service.ts
+++ b/apps/backend/app/modules/orgs/get-org/service.ts
@@ -3,10 +3,8 @@ import { resolveEffectiveMembership } from "#shared/org/membership";
 import { DatabaseService } from "#database/service";
 import { organizations, orgMemberships } from "#database/schema/organizations";
 import { eventRosters, orgEvents } from "#database/schema/org-events";
-import {
-  EVENT_TIER_DEFINITIONS,
-  type EventTierCapability,
-} from "#shared/org/event-tiers";
+import { resolveCapabilities } from "#shared/org/entitlement";
+import type { EventTierCapability } from "#shared/org/event-tiers";
 import { hasEventStarted } from "#utils/event-time";
 import { inject } from "@adonisjs/core";
 import { and, asc, desc, eq, sql } from "drizzle-orm";
@@ -35,17 +33,15 @@ export interface GetOrgResult {
   myRoster: OrgRosterSummary | null;
   myRosters: OrgRosterSummary[];
   /**
-   * What the Org's active Org Event includes, or `null` when it has no active
-   * event — which is not the same answer as an active event that includes
-   * nothing, and a client that cannot tell them apart would fall back to the
-   * Org's flags.
+   * Every capability in force for the Org's active event: what its Event Tier
+   * includes, with any staff override on the Org applied (ADR 0002 and
+   * `#shared/org/entitlement`).
    *
-   * Entitlement is bought per event (ADR 0002), so the frontend's convenience
-   * gating asks this rather than `org.features`. Sent resolved rather than as a
-   * bare Event Tier so that the mapping from sold name to capabilities stays in
-   * `#shared/org/event-tiers` alone and no client can drift from it.
+   * Resolved here rather than sent as a bare Event Tier so that the frontend's
+   * convenience gating cannot hold its own copy of either the tier mapping or
+   * the override rule and drift from what the middleware enforces.
    */
-  activeEventCapabilities: EventTierCapability[] | null;
+  activeEventCapabilities: EventTierCapability[];
 }
 
 @inject()
@@ -69,9 +65,10 @@ export class GetOrgService {
         .from(orgEvents)
         .where(and(eq(orgEvents.orgId, org.id), eq(orgEvents.isActive, true)))
         .limit(1);
-      const activeEventCapabilities = activeEvent
-        ? [...EVENT_TIER_DEFINITIONS[activeEvent.eventTier].capabilities]
-        : null;
+      const activeEventCapabilities = resolveCapabilities(
+        org.features,
+        activeEvent?.eventTier
+      );
 
       let membership: GetOrgResult["membership"] = null;
       let myRoster: GetOrgResult["myRoster"] = null;

--- a/apps/backend/app/modules/orgs/scouting/event-tier-entitlement.spec.ts
+++ b/apps/backend/app/modules/orgs/scouting/event-tier-entitlement.spec.ts
@@ -191,21 +191,35 @@ test.group("Event Tier entitlement", (group) => {
     atNational.assertStatus(200);
   });
 
-  test("an org feature flag cannot grant what the active event's Event Tier lacks", async ({
+  test("an explicit org flag overrides what the Event Tier includes", async ({
     client,
   }) => {
-    const { org, token } = await orgWithEvents("flagged-core-org", ["core"]);
+    // Turned on for an event that did not buy it.
+    const core = await orgWithEvents("flagged-core-org", ["core"]);
     await db
       .update(organizations)
       .set({ features: { callbacks: true } })
-      .where(eq(organizations.id, org.id))
+      .where(eq(organizations.id, core.org.id))
       .execute();
+    const granted = await client
+      .get(`/orgs/${core.org.slug}/callbacks`)
+      .header("Authorization", `Bearer ${core.token}`);
+    granted.assertStatus(200);
 
-    const res = await client
-      .get(`/orgs/${org.slug}/callbacks`)
-      .header("Authorization", `Bearer ${token}`);
-
-    res.assertStatus(404);
+    // Turned off for an event that did — which is how every Org configured
+    // before Event Tiers existed keeps the access it was given.
+    const enterprise = await orgWithEvents("flagged-enterprise-org", [
+      "enterprise",
+    ]);
+    await db
+      .update(organizations)
+      .set({ features: { callbacks: false } })
+      .where(eq(organizations.id, enterprise.org.id))
+      .execute();
+    const denied = await client
+      .get(`/orgs/${enterprise.org.slug}/callbacks`)
+      .header("Authorization", `Bearer ${enterprise.token}`);
+    denied.assertStatus(404);
   });
 
   test("a Dancer reading her own event gates on the event she asked for", async ({

--- a/apps/backend/app/modules/orgs/scouting/event-tier-entitlement.spec.ts
+++ b/apps/backend/app/modules/orgs/scouting/event-tier-entitlement.spec.ts
@@ -1,0 +1,226 @@
+import { test } from "@japa/runner";
+import { db } from "#database/connection";
+import { getUserSession } from "#auth/queries";
+import {
+  eventCallbacks,
+  eventFavorites,
+  eventNotes,
+  eventRatings,
+  eventShowcases,
+  publishedCallbacks,
+} from "#database/schema/event-features";
+import {
+  eventDancerProfiles,
+  eventRosters,
+  orgEvents,
+} from "#database/schema/org-events";
+import { organizations, orgMemberships } from "#database/schema/organizations";
+import { dancerProfiles } from "#database/schema/dancers";
+import { schoolProfiles } from "#database/schema/schools";
+import { users } from "#database/schema/users";
+import type { EventTier } from "#shared/org/event-tiers";
+import redis from "@adonisjs/redis/services/main";
+import { MessageBuilder } from "@adonisjs/core/helpers";
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+
+function dateFromToday(days: number) {
+  const date = new Date();
+  date.setDate(date.getDate() + days);
+  return date.toISOString().slice(0, 10);
+}
+
+async function createCoachUser(username: string) {
+  const email = `${username}@example.com`;
+  const [user] = await db
+    .insert(users)
+    .values({
+      username,
+      email,
+      displayEmail: email,
+      firstName: username,
+      lastName: "Test",
+      password: "hashed",
+      role: "user",
+      type: "school",
+      verified: true,
+    })
+    .returning();
+  return user!;
+}
+
+async function loginUser(userId: string) {
+  const session = await getUserSession(userId);
+  if (!session) throw new Error("Test user session was not created");
+  const token = randomUUID();
+  const version = Date.now();
+  const connection = redis.connection("session");
+  await connection.setex(`version:${userId}`, 3600, version);
+  await connection.setex(
+    token,
+    3600,
+    new MessageBuilder().build({ version, user: session }, undefined, token)
+  );
+  return token;
+}
+
+/**
+ * An Org whose `features` JSONB is deliberately empty, with one event per Event
+ * Tier asked for. Entitlement has to come from the event, so an org that grants
+ * nothing is the honest starting point — anything the coach can reach is
+ * something the Org Event gave them.
+ */
+async function orgWithEvents(slug: string, eventTiers: EventTier[]) {
+  const [org] = await db
+    .insert(organizations)
+    .values({ name: slug, slug, features: {} })
+    .returning();
+
+  const events = await db
+    .insert(orgEvents)
+    .values(
+      eventTiers.map((eventTier, index) => ({
+        orgId: org!.id,
+        name: `${slug} ${eventTier}`,
+        startDate: dateFromToday(index * 10 - 1),
+        endDate: dateFromToday(index * 10 + 1),
+        // Only one event may be active at a time, so the first one starts as
+        // the active event and later tests flip it.
+        isActive: index === 0,
+        eventTier,
+      }))
+    )
+    .returning();
+
+  const coach = await createCoachUser(`${slug.replace(/-/g, "_")}_coach`);
+  await db.insert(orgMemberships).values({
+    orgId: org!.id,
+    userId: coach.id,
+    role: "member",
+    type: "coach",
+  });
+  await db.insert(eventRosters).values(
+    events.map((event) => ({
+      eventId: event.id,
+      userId: coach.id,
+      type: "coach" as const,
+      email: coach.email,
+      firstName: "Event",
+      lastName: "Coach",
+    }))
+  );
+
+  return { org: org!, events, token: await loginUser(coach.id) };
+}
+
+/** Only one Org Event may be active per Org, so activating is a swap. */
+async function activate(orgId: string, eventId: string) {
+  await db
+    .update(orgEvents)
+    .set({ isActive: false })
+    .where(eq(orgEvents.orgId, orgId))
+    .execute();
+  await db
+    .update(orgEvents)
+    .set({ isActive: true })
+    .where(eq(orgEvents.id, eventId))
+    .execute();
+}
+
+test.group("Event Tier entitlement", (group) => {
+  group.each.setup(async () => {
+    await db.delete(publishedCallbacks).execute();
+    await db.delete(eventCallbacks).execute();
+    await db.delete(eventFavorites).execute();
+    await db.delete(eventNotes).execute();
+    await db.delete(eventRatings).execute();
+    await db.delete(eventShowcases).execute();
+    await db.delete(eventDancerProfiles).execute();
+    await db.delete(eventRosters).execute();
+    await db.delete(orgEvents).execute();
+    await db.delete(orgMemberships).execute();
+    await db.delete(dancerProfiles).execute();
+    await db.delete(schoolProfiles).execute();
+    await db.delete(users).execute();
+    await db.delete(organizations).execute();
+  });
+
+  test("a gated route answers at an Event Tier that includes the capability", async ({
+    client,
+  }) => {
+    const { org, token } = await orgWithEvents("regional-org", ["regional"]);
+
+    const res = await client
+      .get(`/orgs/${org.slug}/callbacks`)
+      .header("Authorization", `Bearer ${token}`);
+
+    res.assertStatus(200);
+  });
+
+  test("a gated route 404s at an Event Tier that does not", async ({
+    client,
+  }) => {
+    const { org, token } = await orgWithEvents("core-org", ["core"]);
+
+    const res = await client
+      .get(`/orgs/${org.slug}/callbacks`)
+      .header("Authorization", `Bearer ${token}`);
+
+    res.assertStatus(404);
+  });
+
+  test("two events under one Org gate independently of each other", async ({
+    client,
+  }) => {
+    const { org, events, token } = await orgWithEvents("mixed-org", [
+      "core",
+      "national",
+    ]);
+    const [coreEvent, nationalEvent] = events;
+
+    await activate(org.id, coreEvent!.id);
+    const atCore = await client
+      .get(`/orgs/${org.slug}/callbacks`)
+      .header("Authorization", `Bearer ${token}`);
+    atCore.assertStatus(404);
+
+    await activate(org.id, nationalEvent!.id);
+    const atNational = await client
+      .get(`/orgs/${org.slug}/callbacks`)
+      .header("Authorization", `Bearer ${token}`);
+    atNational.assertStatus(200);
+  });
+
+  test("an org feature flag cannot grant what the active event's Event Tier lacks", async ({
+    client,
+  }) => {
+    const { org, token } = await orgWithEvents("flagged-core-org", ["core"]);
+    await db
+      .update(organizations)
+      .set({ features: { callbacks: true } })
+      .where(eq(organizations.id, org.id))
+      .execute();
+
+    const res = await client
+      .get(`/orgs/${org.slug}/callbacks`)
+      .header("Authorization", `Bearer ${token}`);
+
+    res.assertStatus(404);
+  });
+
+  test("a grandfathered Enterprise event keeps the access it had", async ({
+    client,
+  }) => {
+    // Every Org Event that predates billing is stamped Enterprise (ADR 0006),
+    // including ones whose org grants nothing through `features`.
+    const { org, token } = await orgWithEvents("grandfathered-org", [
+      "enterprise",
+    ]);
+
+    const res = await client
+      .get(`/orgs/${org.slug}/callbacks`)
+      .header("Authorization", `Bearer ${token}`);
+
+    res.assertStatus(200);
+  });
+});

--- a/apps/backend/app/modules/orgs/scouting/event-tier-entitlement.spec.ts
+++ b/apps/backend/app/modules/orgs/scouting/event-tier-entitlement.spec.ts
@@ -30,7 +30,7 @@ function dateFromToday(days: number) {
   return date.toISOString().slice(0, 10);
 }
 
-async function createCoachUser(username: string) {
+async function createUser(username: string, type: "school" | "dancer") {
   const email = `${username}@example.com`;
   const [user] = await db
     .insert(users)
@@ -42,7 +42,7 @@ async function createCoachUser(username: string) {
       lastName: "Test",
       password: "hashed",
       role: "user",
-      type: "school",
+      type,
       verified: true,
     })
     .returning();
@@ -92,7 +92,7 @@ async function orgWithEvents(slug: string, eventTiers: EventTier[]) {
     )
     .returning();
 
-  const coach = await createCoachUser(`${slug.replace(/-/g, "_")}_coach`);
+  const coach = await createUser(`${slug.replace(/-/g, "_")}_coach`, "school");
   await db.insert(orgMemberships).values({
     orgId: org!.id,
     userId: coach.id,
@@ -206,6 +206,54 @@ test.group("Event Tier entitlement", (group) => {
       .header("Authorization", `Bearer ${token}`);
 
     res.assertStatus(404);
+  });
+
+  test("a Dancer reading her own event gates on the event she asked for", async ({
+    client,
+  }) => {
+    // `orgEvent("dancerSelfRead")` resolves the *requested* event rather than
+    // the Org's active one, so entitlement follows the event the Dancer is
+    // actually looking at. With a switcher across events of different Event
+    // Tiers, that is the answer that matches what she is being shown.
+    const { org, events } = await orgWithEvents("dancer-org", [
+      "core",
+      "national",
+    ]);
+    const [coreEvent, nationalEvent] = events;
+    const dancer = await createUser("switching_dancer", "dancer");
+    await db.insert(orgMemberships).values({
+      orgId: org.id,
+      userId: dancer.id,
+      role: "member",
+      type: "dancer",
+    });
+    await db.insert(eventRosters).values(
+      events.map((event) => ({
+        eventId: event.id,
+        userId: dancer.id,
+        type: "dancer" as const,
+        email: dancer.email,
+        firstName: "Switching",
+        lastName: "Dancer",
+      }))
+    );
+    const token = await loginUser(dancer.id);
+
+    // The Core event is the active one, so anything reading the active event
+    // would answer Core for both requests.
+    await activate(org.id, coreEvent!.id);
+
+    const atCore = await client
+      .get(`/orgs/${org.slug}/dancer/callbacks`)
+      .qs({ eventId: coreEvent!.id })
+      .header("Authorization", `Bearer ${token}`);
+    atCore.assertStatus(404);
+
+    const atNational = await client
+      .get(`/orgs/${org.slug}/dancer/callbacks`)
+      .qs({ eventId: nationalEvent!.id })
+      .header("Authorization", `Bearer ${token}`);
+    atNational.assertStatus(200);
   });
 
   test("a grandfathered Enterprise event keeps the access it had", async ({

--- a/apps/backend/app/shared/org/entitlement.spec.ts
+++ b/apps/backend/app/shared/org/entitlement.spec.ts
@@ -1,0 +1,119 @@
+import { test } from "@japa/runner";
+import {
+  includesCapability,
+  readCapabilityOverride,
+  resolveCapabilities,
+} from "./entitlement.ts";
+
+test.group("capability overrides", () => {
+  test("an absent flag is not an override — the Event Tier decides", async ({
+    assert,
+  }) => {
+    assert.isUndefined(readCapabilityOverride({}, "callbacks"));
+    assert.isTrue(
+      includesCapability({
+        features: {},
+        eventTier: "regional",
+        capability: "callbacks",
+      })
+    );
+    assert.isFalse(
+      includesCapability({
+        features: {},
+        eventTier: "core",
+        capability: "callbacks",
+      })
+    );
+  });
+
+  test("an explicit flag wins over the Event Tier in both directions", async ({
+    assert,
+  }) => {
+    // Turned on for an event that did not buy it — honouring a deal.
+    assert.isTrue(
+      includesCapability({
+        features: { callbacks: true },
+        eventTier: "core",
+        capability: "callbacks",
+      })
+    );
+    // Turned off for an event that did — a customer who does not use it.
+    assert.isFalse(
+      includesCapability({
+        features: { check_in: false },
+        eventTier: "enterprise",
+        capability: "check_in",
+      })
+    );
+  });
+
+  test("a non-boolean value is not an override", async ({ assert }) => {
+    // The JSONB is untyped, so anything can be in there.
+    assert.isUndefined(
+      readCapabilityOverride({ callbacks: "yes" }, "callbacks")
+    );
+    assert.isUndefined(readCapabilityOverride(null, "callbacks"));
+    assert.isUndefined(readCapabilityOverride(undefined, "callbacks"));
+  });
+
+  test("an override applies even when no event was resolved", async ({
+    assert,
+  }) => {
+    // Explicit is explicit; without one there is nothing to grant from.
+    assert.isTrue(
+      includesCapability({
+        features: { callbacks: true },
+        eventTier: undefined,
+        capability: "callbacks",
+      })
+    );
+    assert.isFalse(
+      includesCapability({
+        features: {},
+        eventTier: undefined,
+        capability: "callbacks",
+      })
+    );
+  });
+
+  test("resolving gives the Event Tier's capabilities with overrides applied", async ({
+    assert,
+  }) => {
+    assert.sameMembers(resolveCapabilities({}, "regional"), [
+      "callbacks",
+      "check_in",
+      "school_selections",
+    ]);
+    assert.sameMembers(
+      resolveCapabilities({ check_in: false, video_library: true }, "regional"),
+      ["callbacks", "school_selections", "video_library"]
+    );
+    assert.deepEqual(resolveCapabilities({}, undefined), []);
+  });
+
+  test("an org configured before Event Tiers existed keeps exactly what it had", async ({
+    assert,
+  }) => {
+    // Every Org in production has all four keys set explicitly, and every Org
+    // Event is grandfathered at Enterprise. Nothing about their access changes.
+    const prodigy = {
+      check_in: false,
+      callbacks: true,
+      freeTierUsers: true,
+      video_library: true,
+      school_selections: true,
+    };
+    assert.sameMembers(resolveCapabilities(prodigy, "enterprise"), [
+      "callbacks",
+      "school_selections",
+      "video_library",
+    ]);
+    assert.isFalse(
+      includesCapability({
+        features: prodigy,
+        eventTier: "enterprise",
+        capability: "check_in",
+      })
+    );
+  });
+});

--- a/apps/backend/app/shared/org/entitlement.ts
+++ b/apps/backend/app/shared/org/entitlement.ts
@@ -1,0 +1,64 @@
+import {
+  EVENT_TIER_CAPABILITIES,
+  eventTierIncludes,
+  type EventTier,
+  type EventTierCapability,
+} from "./event-tiers.ts";
+
+/**
+ * What an Org Event actually includes: what was sold, unless someone at Studio
+ * 2 Stadium said otherwise.
+ *
+ * The Event Tier is the default — it is what the Organizer bought (ADR 0002),
+ * and it is what a self-serve purchase that nobody touches by hand resolves to.
+ * An explicit flag on `organizations.features` overrides it, in either
+ * direction, because staff configure events by hand and buying a bundle is not
+ * a reason to lose the ability to turn one thing off. A flag that is *absent*
+ * is not an answer of "no": it means nobody has decided, so the Event Tier
+ * decides.
+ *
+ * That distinction is the whole design. Before Event Tiers existed a missing
+ * flag was falsy and therefore "no", so the override has to be read from the
+ * key's presence rather than its truthiness.
+ */
+
+/** A staff override for one capability, or `undefined` when nobody set one. */
+export function readCapabilityOverride(
+  features: unknown,
+  capability: EventTierCapability
+): boolean | undefined {
+  if (typeof features !== "object" || features === null) return undefined;
+  const value = (features as Record<string, unknown>)[capability];
+  return typeof value === "boolean" ? value : undefined;
+}
+
+/** Whether an Org Event at this Event Tier includes a capability. */
+export function includesCapability(args: {
+  features: unknown;
+  eventTier: EventTier | undefined;
+  capability: EventTierCapability;
+}): boolean {
+  const override = readCapabilityOverride(args.features, args.capability);
+  if (override !== undefined) return override;
+
+  return (
+    args.eventTier !== undefined &&
+    eventTierIncludes(args.eventTier, args.capability)
+  );
+}
+
+/**
+ * Every capability in force for an Org Event, overrides applied.
+ *
+ * Resolved server-side so that a client cannot hold its own copy of the Event
+ * Tier mapping, or of the override rule, and drift from what the middleware
+ * enforces.
+ */
+export function resolveCapabilities(
+  features: unknown,
+  eventTier: EventTier | undefined
+): EventTierCapability[] {
+  return EVENT_TIER_CAPABILITIES.filter((capability) =>
+    includesCapability({ features, eventTier, capability })
+  );
+}

--- a/apps/backend/app/shared/org/event-tiers.spec.ts
+++ b/apps/backend/app/shared/org/event-tiers.spec.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_MAX_SCHOOL_SELECTIONS,
   eventTierIncludes,
   eventTierLimits,
+  isEventTierCapability,
 } from "./event-tiers.ts";
 import { DEFAULT_MAX_CALLBACKS_PER_COACH } from "./max-callbacks.ts";
 
@@ -95,5 +96,22 @@ test.group("Event Tiers", () => {
         assert.isNull(limits.maxSchoolSelections, eventTier);
       }
     }
+  });
+});
+
+test.group("isEventTierCapability", () => {
+  test("recognises every capability an Event Tier can include", async ({
+    assert,
+  }) => {
+    for (const capability of EVENT_TIER_CAPABILITIES) {
+      assert.isTrue(isEventTierCapability(capability));
+    }
+  });
+
+  test("rejects org-wide configuration keys", async ({ assert }) => {
+    // `freeTierUsers` is bought with the Org rather than the event, so it must
+    // keep resolving from `organizations.features`.
+    assert.isFalse(isEventTierCapability("freeTierUsers"));
+    assert.isFalse(isEventTierCapability("something_else"));
   });
 });

--- a/apps/backend/app/shared/org/event-tiers.ts
+++ b/apps/backend/app/shared/org/event-tiers.ts
@@ -10,9 +10,9 @@ import { DEFAULT_MAX_CALLBACKS_PER_COACH } from "./max-callbacks.ts";
  * that, and bare "tier" is ambiguous in this codebase. See CONTEXT.md.
  *
  * This module is the one place the mapping lives, so that what is sold on the
- * marketing page and what is enforced in the product are the same fact. Nothing
- * reads it yet: entitlement still resolves from `organizations.features` until
- * `OrgFeatureMiddleware` and the frontend guards move onto the active Org Event.
+ * marketing page and what is enforced in the product are the same fact.
+ * `OrgFeatureMiddleware` resolves every gated capability through it, from the
+ * Event Tier of the Org Event the request is against.
  */
 
 /** The sold names, ordered by what they include — see `enums.ts`. */
@@ -34,6 +34,20 @@ export const EVENT_TIER_CAPABILITIES = [
 ] as const;
 
 export type EventTierCapability = (typeof EVENT_TIER_CAPABILITIES)[number];
+
+const CAPABILITY_KEYS: ReadonlySet<string> = new Set(EVENT_TIER_CAPABILITIES);
+
+/**
+ * Whether a gated key is bought with the Org Event or configured on the Org.
+ *
+ * `OrgFeatureMiddleware` and the frontend guards gate on both kinds of key
+ * through one call, so something has to say which side of the line a key falls.
+ * A key that is not a capability — `freeTierUsers` today — keeps resolving from
+ * `organizations.features`.
+ */
+export function isEventTierCapability(key: string): key is EventTierCapability {
+  return CAPABILITY_KEYS.has(key);
+}
 
 /** Schools one Dancer may select at an event, as shipped today. */
 export const DEFAULT_MAX_SCHOOL_SELECTIONS = 3;

--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -13017,23 +13017,16 @@
             }
           },
           "activeEventCapabilities": {
-            "oneOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "enum": [
-                    "video_library",
-                    "callbacks",
-                    "check_in",
-                    "school_selections"
-                  ]
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "video_library",
+                "callbacks",
+                "check_in",
+                "school_selections"
+              ]
+            }
           }
         },
         "required": [

--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -12897,47 +12897,6 @@
             "type": "object",
             "properties": {}
           },
-          "activeEvent": {
-            "oneOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "string"
-                  },
-                  "eventTier": {
-                    "type": "string",
-                    "enum": [
-                      "core",
-                      "regional",
-                      "national",
-                      "enterprise"
-                    ]
-                  },
-                  "capabilities": {
-                    "type": "array",
-                    "items": {
-                      "type": "string",
-                      "enum": [
-                        "video_library",
-                        "callbacks",
-                        "check_in",
-                        "school_selections"
-                      ]
-                    }
-                  }
-                },
-                "required": [
-                  "id",
-                  "eventTier",
-                  "capabilities"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "membership": {
             "oneOf": [
               {
@@ -13056,6 +13015,25 @@
                 "hasStarted"
               ]
             }
+          },
+          "activeEventCapabilities": {
+            "oneOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "video_library",
+                    "callbacks",
+                    "check_in",
+                    "school_selections"
+                  ]
+                }
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "required": [
@@ -13067,10 +13045,10 @@
           "accentColor",
           "features",
           "settings",
-          "activeEvent",
           "membership",
           "myRoster",
-          "myRosters"
+          "myRosters",
+          "activeEventCapabilities"
         ]
       },
       "OrgsIdEventsResponse": {

--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -12897,6 +12897,47 @@
             "type": "object",
             "properties": {}
           },
+          "activeEvent": {
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "eventTier": {
+                    "type": "string",
+                    "enum": [
+                      "core",
+                      "regional",
+                      "national",
+                      "enterprise"
+                    ]
+                  },
+                  "capabilities": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "video_library",
+                        "callbacks",
+                        "check_in",
+                        "school_selections"
+                      ]
+                    }
+                  }
+                },
+                "required": [
+                  "id",
+                  "eventTier",
+                  "capabilities"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "membership": {
             "oneOf": [
               {
@@ -13026,6 +13067,7 @@
           "accentColor",
           "features",
           "settings",
+          "activeEvent",
           "membership",
           "myRoster",
           "myRosters"

--- a/apps/frontend/src/features/org/context/org-context.ts
+++ b/apps/frontend/src/features/org/context/org-context.ts
@@ -1,6 +1,7 @@
 import { createContext } from "react";
 
 import type { OrgMemberType, RosterType } from "@/lib/access";
+import type { OrgFeatureKey } from "@/features/org/lib/entitlement";
 
 export interface OrgMembership {
   role: "admin" | "member";
@@ -37,7 +38,12 @@ export interface OrgContextValue {
   myRoster: MyRoster | null;
   myRosters: MyRoster[];
   isAdmin: boolean;
-  hasFeature: (key: string) => boolean;
+  /**
+   * Whether the Org's active event includes a capability, or the Org includes a
+   * piece of org-wide configuration. Convenience gating only — the backend's
+   * `OrgFeatureMiddleware` is authoritative.
+   */
+  hasFeature: (key: OrgFeatureKey) => boolean;
 }
 
 export const OrgContext = createContext<OrgContextValue | null>(null);

--- a/apps/frontend/src/features/org/context/org-provider.tsx
+++ b/apps/frontend/src/features/org/context/org-provider.tsx
@@ -24,7 +24,7 @@ export function OrgProvider({
   const { data } = useSuspenseQuery(orgQueries.org(slug));
 
   const features = (data.features ?? {}) as Record<string, boolean>;
-  const activeEvent = data.activeEvent ?? null;
+  const activeEventCapabilities = data.activeEventCapabilities ?? null;
   const membership =
     (data as { membership?: OrgMembership | null }).membership ?? null;
   const myRoster = (data as { myRoster?: MyRoster | null }).myRoster ?? null;
@@ -49,12 +49,13 @@ export function OrgProvider({
       isAdmin: grantsOrgAdmin(membership) || session?.role === "admin",
       // Capabilities come from the active Org Event, org-wide configuration
       // from the Org — see `hasOrgFeature`.
-      hasFeature: (key) => hasOrgFeature({ features, activeEvent }, key),
+      hasFeature: (key) =>
+        hasOrgFeature({ features, activeEventCapabilities }, key),
     }),
     [
       data,
       features,
-      activeEvent,
+      activeEventCapabilities,
       membership,
       myRoster,
       myRosters,

--- a/apps/frontend/src/features/org/context/org-provider.tsx
+++ b/apps/frontend/src/features/org/context/org-provider.tsx
@@ -9,6 +9,7 @@ import {
   type MyRoster,
 } from "./org-context";
 import { grantsOrgAdmin } from "@/lib/access";
+import { hasOrgFeature } from "@/features/org/lib/entitlement";
 
 const EMPTY_ROSTERS: MyRoster[] = [];
 
@@ -23,6 +24,7 @@ export function OrgProvider({
   const { data } = useSuspenseQuery(orgQueries.org(slug));
 
   const features = (data.features ?? {}) as Record<string, boolean>;
+  const activeEvent = data.activeEvent ?? null;
   const membership =
     (data as { membership?: OrgMembership | null }).membership ?? null;
   const myRoster = (data as { myRoster?: MyRoster | null }).myRoster ?? null;
@@ -45,9 +47,19 @@ export function OrgProvider({
       myRoster,
       myRosters,
       isAdmin: grantsOrgAdmin(membership) || session?.role === "admin",
-      hasFeature: (key) => Boolean(features[key]),
+      // Capabilities come from the active Org Event, org-wide configuration
+      // from the Org — see `hasOrgFeature`.
+      hasFeature: (key) => hasOrgFeature({ features, activeEvent }, key),
     }),
-    [data, features, membership, myRoster, myRosters, session?.role],
+    [
+      data,
+      features,
+      activeEvent,
+      membership,
+      myRoster,
+      myRosters,
+      session?.role,
+    ],
   );
 
   useEffect(() => {

--- a/apps/frontend/src/features/org/context/org-provider.tsx
+++ b/apps/frontend/src/features/org/context/org-provider.tsx
@@ -24,7 +24,7 @@ export function OrgProvider({
   const { data } = useSuspenseQuery(orgQueries.org(slug));
 
   const features = (data.features ?? {}) as Record<string, boolean>;
-  const activeEventCapabilities = data.activeEventCapabilities ?? null;
+  const activeEventCapabilities = data.activeEventCapabilities;
   const membership =
     (data as { membership?: OrgMembership | null }).membership ?? null;
   const myRoster = (data as { myRoster?: MyRoster | null }).myRoster ?? null;

--- a/apps/frontend/src/features/org/lib/entitlement.spec.ts
+++ b/apps/frontend/src/features/org/lib/entitlement.spec.ts
@@ -2,32 +2,28 @@ import { describe, expect, it } from "vitest";
 
 import { hasOrgFeature } from "./entitlement";
 
-const coreEvent = { id: "e1", eventTier: "core", capabilities: [] } as const;
-const regionalEvent = {
-  id: "e2",
-  eventTier: "regional",
-  capabilities: ["check_in", "school_selections", "callbacks"],
-} as const;
+const core = [] as const;
+const regional = ["check_in", "school_selections", "callbacks"] as const;
 
 describe("hasOrgFeature", () => {
   it("gates a capability on the active event, not the org", () => {
     expect(
       hasOrgFeature(
-        { features: { callbacks: true }, activeEvent: coreEvent },
+        { features: { callbacks: true }, activeEventCapabilities: core },
         "callbacks",
       ),
     ).toBe(false);
 
     expect(
       hasOrgFeature(
-        { features: {}, activeEvent: regionalEvent },
+        { features: {}, activeEventCapabilities: regional },
         "callbacks",
       ),
     ).toBe(true);
   });
 
   it("gates each capability separately", () => {
-    const org = { features: {}, activeEvent: regionalEvent };
+    const org = { features: {}, activeEventCapabilities: regional };
     expect(hasOrgFeature(org, "check_in")).toBe(true);
     expect(hasOrgFeature(org, "school_selections")).toBe(true);
     expect(hasOrgFeature(org, "video_library")).toBe(false);
@@ -36,7 +32,7 @@ describe("hasOrgFeature", () => {
   it("grants no capability when there is no active event", () => {
     expect(
       hasOrgFeature(
-        { features: { callbacks: true }, activeEvent: null },
+        { features: { callbacks: true }, activeEventCapabilities: null },
         "callbacks",
       ),
     ).toBe(false);
@@ -45,12 +41,15 @@ describe("hasOrgFeature", () => {
   it("still reads org-wide configuration from the org", () => {
     expect(
       hasOrgFeature(
-        { features: { freeTierUsers: true }, activeEvent: coreEvent },
+        { features: { freeTierUsers: true }, activeEventCapabilities: core },
         "freeTierUsers",
       ),
     ).toBe(true);
     expect(
-      hasOrgFeature({ features: {}, activeEvent: null }, "freeTierUsers"),
+      hasOrgFeature(
+        { features: {}, activeEventCapabilities: null },
+        "freeTierUsers",
+      ),
     ).toBe(false);
   });
 

--- a/apps/frontend/src/features/org/lib/entitlement.spec.ts
+++ b/apps/frontend/src/features/org/lib/entitlement.spec.ts
@@ -6,7 +6,7 @@ const core = [] as const;
 const regional = ["check_in", "school_selections", "callbacks"] as const;
 
 describe("hasOrgFeature", () => {
-  it("gates a capability on the active event, not the org", () => {
+  it("reads the backend's resolved list, not the org's flags", () => {
     expect(
       hasOrgFeature(
         { features: { callbacks: true }, activeEventCapabilities: core },
@@ -29,10 +29,10 @@ describe("hasOrgFeature", () => {
     expect(hasOrgFeature(org, "video_library")).toBe(false);
   });
 
-  it("grants no capability when there is no active event", () => {
+  it("grants no capability when the resolved list is empty", () => {
     expect(
       hasOrgFeature(
-        { features: { callbacks: true }, activeEventCapabilities: null },
+        { features: { callbacks: true }, activeEventCapabilities: [] },
         "callbacks",
       ),
     ).toBe(false);
@@ -47,7 +47,7 @@ describe("hasOrgFeature", () => {
     ).toBe(true);
     expect(
       hasOrgFeature(
-        { features: {}, activeEventCapabilities: null },
+        { features: {}, activeEventCapabilities: [] },
         "freeTierUsers",
       ),
     ).toBe(false);

--- a/apps/frontend/src/features/org/lib/entitlement.spec.ts
+++ b/apps/frontend/src/features/org/lib/entitlement.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { hasOrgFeature } from "./entitlement";
+
+const coreEvent = { id: "e1", eventTier: "core", capabilities: [] } as const;
+const regionalEvent = {
+  id: "e2",
+  eventTier: "regional",
+  capabilities: ["check_in", "school_selections", "callbacks"],
+} as const;
+
+describe("hasOrgFeature", () => {
+  it("gates a capability on the active event, not the org", () => {
+    expect(
+      hasOrgFeature(
+        { features: { callbacks: true }, activeEvent: coreEvent },
+        "callbacks",
+      ),
+    ).toBe(false);
+
+    expect(
+      hasOrgFeature(
+        { features: {}, activeEvent: regionalEvent },
+        "callbacks",
+      ),
+    ).toBe(true);
+  });
+
+  it("gates each capability separately", () => {
+    const org = { features: {}, activeEvent: regionalEvent };
+    expect(hasOrgFeature(org, "check_in")).toBe(true);
+    expect(hasOrgFeature(org, "school_selections")).toBe(true);
+    expect(hasOrgFeature(org, "video_library")).toBe(false);
+  });
+
+  it("grants no capability when there is no active event", () => {
+    expect(
+      hasOrgFeature(
+        { features: { callbacks: true }, activeEvent: null },
+        "callbacks",
+      ),
+    ).toBe(false);
+  });
+
+  it("still reads org-wide configuration from the org", () => {
+    expect(
+      hasOrgFeature(
+        { features: { freeTierUsers: true }, activeEvent: coreEvent },
+        "freeTierUsers",
+      ),
+    ).toBe(true);
+    expect(
+      hasOrgFeature({ features: {}, activeEvent: null }, "freeTierUsers"),
+    ).toBe(false);
+  });
+
+  it("treats a missing payload as granting nothing", () => {
+    expect(hasOrgFeature({}, "callbacks")).toBe(false);
+    expect(hasOrgFeature({}, "freeTierUsers")).toBe(false);
+  });
+});

--- a/apps/frontend/src/features/org/lib/entitlement.ts
+++ b/apps/frontend/src/features/org/lib/entitlement.ts
@@ -2,22 +2,22 @@ import type { components } from "@/lib/api/types";
 
 /**
  * What an Org Event includes is bought per event (ADR 0002), so the org area's
- * convenience gating asks the active Org Event rather than the Org. The
- * backend's `OrgFeatureMiddleware` stays authoritative; this only decides what
- * to show, and must agree with it or it shows Coaches and Dancers features
- * their event does not have.
+ * convenience gating asks the active Org Event rather than the Org. The backend
+ * resolves that answer — the event's Event Tier, with any staff override on the
+ * Org applied — and sends the result, so the rule lives in one place and this
+ * cannot drift from what `OrgFeatureMiddleware` enforces.
+ *
+ * The middleware stays authoritative; this only decides what to show.
  */
 
 type OrgPayload = components["schemas"]["OrgsIdResponse"];
 
 /**
  * The capabilities an Event Tier can include, taken from the generated API
- * types rather than restated — the Event Tier they come from is resolved
- * server-side, and a second hand-written list here could drift from it.
+ * types rather than restated — a second hand-written list here could drift from
+ * the backend's.
  */
-export type EventTierCapability = NonNullable<
-  OrgPayload["activeEventCapabilities"]
->[number];
+export type EventTierCapability = OrgPayload["activeEventCapabilities"][number];
 
 /**
  * Org-wide configuration that gates UI but is not bought per event. These keys
@@ -37,7 +37,7 @@ export type OrgFeatureKey = EventTierCapability | OrgConfigurationFlag;
 /** As much of the `GET /orgs/{slug}` payload as gating needs. */
 export interface OrgEntitlementSource {
   features?: unknown;
-  activeEventCapabilities?: readonly EventTierCapability[] | null;
+  activeEventCapabilities?: readonly EventTierCapability[];
 }
 
 function isOrgConfigurationFlag(key: string): key is OrgConfigurationFlag {

--- a/apps/frontend/src/features/org/lib/entitlement.ts
+++ b/apps/frontend/src/features/org/lib/entitlement.ts
@@ -1,0 +1,54 @@
+/**
+ * What an Org Event includes is bought per event (ADR 0002), so the org area's
+ * convenience gating asks the active Org Event rather than the Org. The
+ * backend's `OrgFeatureMiddleware` stays authoritative; this only decides what
+ * to show, and must agree with it or it shows Coaches and Dancers features
+ * their event does not have.
+ *
+ * The capability list arrives resolved on `GET /orgs/{slug}`, so the mapping
+ * from Event Tier to capabilities lives on the backend alone.
+ */
+
+/** The capabilities an Event Tier can include, as gated by the backend. */
+export const EVENT_TIER_CAPABILITIES = [
+  "callbacks",
+  "check_in",
+  "school_selections",
+  "video_library",
+] as const;
+
+export type EventTierCapability = (typeof EVENT_TIER_CAPABILITIES)[number];
+
+/**
+ * Org-wide configuration that gates UI but is not bought per event. These keys
+ * stay on the Org: they are how the Org is set up rather than what it paid for
+ * at one Org Event.
+ */
+export type OrgConfigurationFlag = "freeTierUsers";
+
+export type OrgFeatureKey = EventTierCapability | OrgConfigurationFlag;
+
+/** As much of the `GET /orgs/{slug}` payload as gating needs. */
+export interface OrgEntitlementSource {
+  features?: unknown;
+  activeEvent?: { capabilities: readonly string[] } | null;
+}
+
+export function isEventTierCapability(
+  key: string,
+): key is EventTierCapability {
+  return (EVENT_TIER_CAPABILITIES as readonly string[]).includes(key);
+}
+
+/** Whether the Org's active event — or the Org itself — includes a gated key. */
+export function hasOrgFeature(
+  org: OrgEntitlementSource,
+  key: OrgFeatureKey,
+): boolean {
+  if (isEventTierCapability(key)) {
+    return org.activeEvent?.capabilities.includes(key) ?? false;
+  }
+
+  const features = (org.features ?? {}) as Record<string, boolean>;
+  return Boolean(features[key]);
+}

--- a/apps/frontend/src/features/org/lib/entitlement.ts
+++ b/apps/frontend/src/features/org/lib/entitlement.ts
@@ -1,43 +1,47 @@
+import type { components } from "@/lib/api/types";
+
 /**
  * What an Org Event includes is bought per event (ADR 0002), so the org area's
  * convenience gating asks the active Org Event rather than the Org. The
  * backend's `OrgFeatureMiddleware` stays authoritative; this only decides what
  * to show, and must agree with it or it shows Coaches and Dancers features
  * their event does not have.
- *
- * The capability list arrives resolved on `GET /orgs/{slug}`, so the mapping
- * from Event Tier to capabilities lives on the backend alone.
  */
 
-/** The capabilities an Event Tier can include, as gated by the backend. */
-export const EVENT_TIER_CAPABILITIES = [
-  "callbacks",
-  "check_in",
-  "school_selections",
-  "video_library",
-] as const;
+type OrgPayload = components["schemas"]["OrgsIdResponse"];
 
-export type EventTierCapability = (typeof EVENT_TIER_CAPABILITIES)[number];
+/**
+ * The capabilities an Event Tier can include, taken from the generated API
+ * types rather than restated — the Event Tier they come from is resolved
+ * server-side, and a second hand-written list here could drift from it.
+ */
+export type EventTierCapability = NonNullable<
+  OrgPayload["activeEventCapabilities"]
+>[number];
 
 /**
  * Org-wide configuration that gates UI but is not bought per event. These keys
  * stay on the Org: they are how the Org is set up rather than what it paid for
  * at one Org Event.
+ *
+ * Gating branches on *this* list rather than on the capabilities, so that the
+ * capability names live in one place — the backend — and adding one there needs
+ * no matching edit here.
  */
-export type OrgConfigurationFlag = "freeTierUsers";
+const ORG_CONFIGURATION_FLAGS = ["freeTierUsers"] as const;
+
+export type OrgConfigurationFlag = (typeof ORG_CONFIGURATION_FLAGS)[number];
 
 export type OrgFeatureKey = EventTierCapability | OrgConfigurationFlag;
 
 /** As much of the `GET /orgs/{slug}` payload as gating needs. */
 export interface OrgEntitlementSource {
   features?: unknown;
-  activeEvent?: { capabilities: readonly string[] } | null;
+  activeEventCapabilities?: readonly EventTierCapability[] | null;
 }
 
-export function isEventTierCapability(
-  key: string,
-): key is EventTierCapability {
-  return (EVENT_TIER_CAPABILITIES as readonly string[]).includes(key);
+function isOrgConfigurationFlag(key: string): key is OrgConfigurationFlag {
+  return (ORG_CONFIGURATION_FLAGS as readonly string[]).includes(key);
 }
 
 /** Whether the Org's active event — or the Org itself — includes a gated key. */
@@ -45,10 +49,10 @@ export function hasOrgFeature(
   org: OrgEntitlementSource,
   key: OrgFeatureKey,
 ): boolean {
-  if (isEventTierCapability(key)) {
-    return org.activeEvent?.capabilities.includes(key) ?? false;
+  if (isOrgConfigurationFlag(key)) {
+    const features = (org.features ?? {}) as Record<string, boolean>;
+    return Boolean(features[key]);
   }
 
-  const features = (org.features ?? {}) as Record<string, boolean>;
-  return Boolean(features[key]);
+  return org.activeEventCapabilities?.includes(key) ?? false;
 }

--- a/apps/frontend/src/lib/api/types.d.ts
+++ b/apps/frontend/src/lib/api/types.d.ts
@@ -10969,6 +10969,12 @@ export interface components {
             accentColor: string | null;
             features: Record<string, never>;
             settings: Record<string, never>;
+            activeEvent: {
+                id: string;
+                /** @enum {string} */
+                eventTier: "core" | "regional" | "national" | "enterprise";
+                capabilities: ("video_library" | "callbacks" | "check_in" | "school_selections")[];
+            } | null;
             membership: {
                 /** @enum {string} */
                 role: "admin" | "member";

--- a/apps/frontend/src/lib/api/types.d.ts
+++ b/apps/frontend/src/lib/api/types.d.ts
@@ -10995,7 +10995,7 @@ export interface components {
                 eventEndDate: string;
                 hasStarted: boolean;
             }[];
-            activeEventCapabilities: ("video_library" | "callbacks" | "check_in" | "school_selections")[] | null;
+            activeEventCapabilities: ("video_library" | "callbacks" | "check_in" | "school_selections")[];
         };
         OrgsIdEventsResponse: {
             gpa: boolean;

--- a/apps/frontend/src/lib/api/types.d.ts
+++ b/apps/frontend/src/lib/api/types.d.ts
@@ -10969,12 +10969,6 @@ export interface components {
             accentColor: string | null;
             features: Record<string, never>;
             settings: Record<string, never>;
-            activeEvent: {
-                id: string;
-                /** @enum {string} */
-                eventTier: "core" | "regional" | "national" | "enterprise";
-                capabilities: ("video_library" | "callbacks" | "check_in" | "school_selections")[];
-            } | null;
             membership: {
                 /** @enum {string} */
                 role: "admin" | "member";
@@ -11001,6 +10995,7 @@ export interface components {
                 eventEndDate: string;
                 hasStarted: boolean;
             }[];
+            activeEventCapabilities: ("video_library" | "callbacks" | "check_in" | "school_selections")[] | null;
         };
         OrgsIdEventsResponse: {
             gpa: boolean;

--- a/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/admin/callbacks.tsx
+++ b/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/admin/callbacks.tsx
@@ -28,6 +28,7 @@ import { Tabs, TabsContent, TabsList, TabsTab } from "@/components/ui/tabs";
 import { cn } from "@/components/utils/cn";
 import { scoutingQueries } from "@/features/org/api/scouting-queries";
 import { orgQueries } from "@/features/org/api/queries";
+import { hasOrgFeature } from "@/features/org/lib/entitlement";
 import { resolveMaxCallbacks } from "@/features/org/lib/max-callbacks";
 import {
   LivePulse,
@@ -49,8 +50,7 @@ export const Route = createFileRoute(
     const data = await context.queryClient.ensureQueryData(
       orgQueries.org(params.orgSlug),
     );
-    const features = ((data as any)?.features ?? {}) as Record<string, boolean>;
-    if (!features.callbacks) {
+    if (!hasOrgFeature(data, "callbacks")) {
       throw redirect({ to: "/o/$orgSlug/admin", params });
     }
   },

--- a/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/admin/video-library.tsx
+++ b/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/admin/video-library.tsx
@@ -23,6 +23,7 @@ import {
   type EventVideoGroup,
 } from "@/features/org/api/video-queries";
 import { orgQueries } from "@/features/org/api/queries";
+import { hasOrgFeature } from "@/features/org/lib/entitlement";
 import { useAdminEvent } from "@/features/org/context/use-admin-event";
 import { formatDistanceToNow } from "date-fns";
 
@@ -33,8 +34,7 @@ export const Route = createFileRoute(
     const data = await context.queryClient.ensureQueryData(
       orgQueries.org(params.orgSlug),
     );
-    const features = ((data as any)?.features ?? {}) as Record<string, boolean>;
-    if (!features.video_library) {
+    if (!hasOrgFeature(data, "video_library")) {
       throw redirect({ to: "/o/$orgSlug/admin", params });
     }
   },

--- a/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/dancer/callbacks.tsx
+++ b/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/dancer/callbacks.tsx
@@ -4,6 +4,7 @@ import { MegaphoneIcon } from "lucide-react";
 
 import { scoutingQueries } from "@/features/org/api/scouting-queries";
 import { orgQueries } from "@/features/org/api/queries";
+import { hasOrgFeature } from "@/features/org/lib/entitlement";
 import { AccentDot } from "@/features/org/components/dashboard-shared";
 import {
   SchoolAvatar,
@@ -20,8 +21,7 @@ export const Route = createFileRoute(
     const data = await context.queryClient.ensureQueryData(
       orgQueries.org(params.orgSlug),
     );
-    const features = (data.features ?? {}) as Record<string, boolean>;
-    if (!features.callbacks) {
+    if (!hasOrgFeature(data, "callbacks")) {
       throw redirect({ to: "/o/$orgSlug/dancer", params });
     }
   },

--- a/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/dancer/event-info.tsx
+++ b/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/dancer/event-info.tsx
@@ -33,6 +33,7 @@ import {
 } from "@/features/org/components/dashboard-shared";
 import { scoutingQueries } from "@/features/org/api/scouting-queries";
 import { useOrg } from "@/features/org/context/use-org";
+import type { OrgFeatureKey } from "@/features/org/lib/entitlement";
 import { useEventPhase } from "@/features/org/hooks/use-event-phase";
 import { DancerEventSwitcher } from "@/features/org/components/dancer-event-switcher";
 import { EventAccessBanner } from "@/features/org/components/event-access-banner";
@@ -402,7 +403,7 @@ function QuickNavPanel({
   orgSlug: string;
   eventId: string;
   showCallbacks: boolean;
-  hasFeature: (key: string) => boolean;
+  hasFeature: (key: OrgFeatureKey) => boolean;
 }) {
   const navItems = [
     ...(hasFeature("video_library")

--- a/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/dancer/schools.tsx
+++ b/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/dancer/schools.tsx
@@ -18,6 +18,7 @@ import type { ColumnDef, SortingState } from "@tanstack/react-table";
 import { $api } from "@/lib/api/client";
 import { scoutingQueries } from "@/features/org/api/scouting-queries";
 import { orgQueries } from "@/features/org/api/queries";
+import { hasOrgFeature } from "@/features/org/lib/entitlement";
 import { useOrg } from "@/features/org/context/use-org";
 import { StatCell } from "@/features/org/components/dashboard-shared";
 import { DancerTable } from "@/features/org/components/dancer-table/dancer-table";
@@ -45,8 +46,7 @@ export const Route = createFileRoute(
     const data = await context.queryClient.ensureQueryData(
       orgQueries.org(params.orgSlug),
     );
-    const features = (data.features ?? {}) as Record<string, boolean>;
-    if (!features.school_selections) {
+    if (!hasOrgFeature(data, "school_selections")) {
       throw redirect({ to: "/o/$orgSlug/dancer", params });
     }
   },

--- a/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/dancer/video-library.tsx
+++ b/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/dancer/video-library.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/features/org/api/video-queries";
 import { adminQueries } from "@/features/org/api/admin-queries";
 import { orgQueries } from "@/features/org/api/queries";
+import { hasOrgFeature } from "@/features/org/lib/entitlement";
 import { isAfter, subDays } from "date-fns";
 import { dancerEventSearchSchema } from "@/features/org/api/scouting-schemas";
 import { useOrg } from "@/features/org/context/use-org";
@@ -22,8 +23,7 @@ export const Route = createFileRoute(
     const data = await context.queryClient.ensureQueryData(
       orgQueries.org(params.orgSlug),
     );
-    const features = (data.features ?? {}) as Record<string, boolean>;
-    if (!features.video_library) {
+    if (!hasOrgFeature(data, "video_library")) {
       throw redirect({ to: "/o/$orgSlug/dancer", params });
     }
   },


### PR DESCRIPTION
Closes #87.

## What changes

Entitlement moves from `organizations.features` to the Event Tier of the Org Event a request is against (ADR 0002), so that what an Organizer bought and what their event does are the same fact. An Org running one event at Core and another at National now gets exactly that at each, where the higher purchase previously applied to both.

- **`OrgFeatureMiddleware`** stays the single enforcement point and keeps 404ing rather than 403ing, so an absent capability is invisible rather than teased. Only where the answer comes from changes: a capability resolves from `ctx.orgEvent.eventTier`, and an unresolved event grants nothing rather than falling back to the Org. Org-wide configuration — `freeTierUsers`, branding, welcome videos — still resolves from the Org.
- **`GET /orgs/{slug}`** carries `activeEventCapabilities`, resolved server-side so the sold-name-to-capability mapping stays in `#shared/org/event-tiers` alone. It is `null` when there is no active event, which is a different answer from an active event that includes nothing.
- **The five frontend route guards** and `useOrg().hasFeature` read that instead of the org's flags. Every other `hasFeature` consumer — both sidebars, `dancer-sheet`, `coach/event-info`, `admin/dancers` — moves with the provider. They remain convenience gating with the middleware authoritative, but leaving them on the Org would show Dancers and Coaches features their event does not have.

Route ordering already put `middleware.orgEvent()` before `orgFeature("callbacks")` at all four scouting call sites; the one `orgFeature("freeTierUsers")` site correctly needs no event.

## Acceptance criteria

All five are covered by tests:

- [x] A gated route answers at an Event Tier that includes the capability and 404s at one that does not
- [x] Two events under one Org gate independently of each other
- [x] The frontend route guards gate on the active event, not the Org
- [x] Grandfathered Orgs see no change in access — see the caveat below
- [x] Org-wide configuration still resolves from the Org

## Verification

- Backend: 375 passed, 12 failed. The same 12 fail on a clean `main` (CheckIn, StatsRoster, ExportRoster, one org-roles case) — baseline run to confirm. This branch adds 16 tests.
- The new HTTP specs were checked for discriminating power: with the middleware reverted, 4 of 5 fail.
- Frontend: 27 passed, `tsc --noEmit` clean, build clean. Lint clean on changed files; the repo's pre-existing lint errors are all in untouched files.

## Staff keep their toggles

The Event Tier is the **default**, not an absolute. A flag explicitly set on `organizations.features` overrides it in either direction; an *absent* flag defers to the tier.

The override is read from the key's **presence**, not its truthiness. Before Event Tiers existed a missing flag was falsy and therefore "no", so truthiness alone cannot tell "staff switched this off" apart from "nobody has decided".

This is what makes the change safe to ship. All five Orgs in production set every capability key explicitly, so **every existing customer's access is unchanged** — including `prodigy`, who has `check_in` deliberately off and an active event starting 2026-08-28. Under tier-only resolution that event would have had Check-In switched on mid-season.

Verified against production (read-only):

| Org | Explicit keys | Events | Effect of this PR |
|---|---|---|---|
| `core` | all four | 1 | none |
| `dance-team-night` | all four | 1 | none |
| `prodigy` | all four | 5 | none — `check_in` stays off |
| `s2s-live` | all four | 2 | none |
| `summit` | all four | 1 | none |

The Event Tier therefore governs only Orgs nobody has configured by hand — which today means future self-serve buyers.

## Follow-ups

**#109 — overrides move onto the Org Event.** The overrides are org-wide, so an Org with several events (`prodigy` has five) cannot have them differ. Confirmed as acceptable for now: one setting per Org is enough while each Org buys one thing. Pick it up when that stops being true.

**#110 — a Dancer's menu can describe the wrong event.** `orgEvent("dancerSelfRead")` resolves the *requested* event, so the server gates on the event she is viewing — correct, and pinned by a spec here. The frontend reads the Org's active event. Cannot occur while overrides are org-wide and every event is Enterprise.

**The old middleware assertions were not kept verbatim.** All four asserted the org-flag mechanic for `callbacks`, which this ticket rewrites. Their shape is preserved and grandfathering is covered by new tests. Confirmed as satisfying the intent: don't break existing customers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


