### PR TITLE
fix(checkout): make the Checkout button work without a manual cycle pick

### DIFF
--- a/apps/frontend/src/features/checkout/components/checkout-dialog.tsx
+++ b/apps/frontend/src/features/checkout/components/checkout-dialog.tsx
@@ -40,7 +40,11 @@ export function CheckoutDialog({
       <DialogTrigger
         disabled={!billingCycle}
         render={
-          <Button size="lg" disabled={isPending} onClick={handleCheckout} />
+          <Button
+            size="lg"
+            disabled={isPending || !billingCycle}
+            onClick={handleCheckout}
+          />
         }
       >
         {isPending ? <Spinner label="Checking out..." /> : "Checkout"}

--- a/apps/frontend/src/features/checkout/components/checkout.tsx
+++ b/apps/frontend/src/features/checkout/components/checkout.tsx
@@ -12,7 +12,7 @@ export function Checkout() {
 
   const [plan, setPlan] = useState<"basic" | "premium">("premium");
   const [billingCycle, setBillingCycle] = useState<"monthly" | "yearly" | null>(
-    null,
+    "yearly",
   );
 
   const [granting, setGranting] = useState(false);


### PR DESCRIPTION
## Problem

Tapping **Checkout** on the Choose Your Plan page did nothing.

`Checkout` initialised `billingCycle` to `null`, and the guard for that lived on `DialogTrigger` (`disabled={!billingCycle}`) while the `Button` it renders only received `disabled={isPending}`. So on page load the button rendered in its normal enabled style but swallowed every tap, with nothing on screen explaining that a billing cycle had to be selected first.

## Fix

- `checkout.tsx` — default `billingCycle` to `"yearly"`, so the inert state never occurs on load.
- `checkout-dialog.tsx` — pass `disabled={isPending || !billingCycle}` to the `Button`, so it can never render as enabled while it is inert.

`PlanDetails` has no path that clears the cycle back to `null`, so with the default in place the second change is a regression guard rather than a state users can reach today.

## Verification

- `tsc -b` in `apps/frontend` passes.
- Not yet exercised in a browser against Stripe — worth a manual pass on the deploy preview.

## Follow-up (not in this PR)

`useCheckout()` destructures only `mutate`, `isPending`, `data`. If `POST /subscriptions/checkout` errors, nothing surfaces and the dialog sits on "Loading…" indefinitely. Adding an error branch there is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
