### PR TITLE
fix(scouting): read a coach's favorites and notes from the event she is viewing

### DIFF
--- a/apps/backend/.adonisjs/api.ts
+++ b/apps/backend/.adonisjs/api.ts
@@ -408,12 +408,12 @@ type OrgsIdDancersGetHead = {
   response: MakeTuyauResponse<import('../app/modules/orgs/scouting/dancers/list/controller.ts').default['handle'], true>
 }
 type OrgsIdDancersIdGetHead = {
-  request: unknown
-  response: MakeTuyauResponse<import('../app/modules/orgs/scouting/dancers/get-by-id/controller.ts').default['handle'], false>
+  request: MakeTuyauRequest<InferInput<typeof import('../app/modules/orgs/scouting/event-query-validator.ts')['eventQuerySchema']>>
+  response: MakeTuyauResponse<import('../app/modules/orgs/scouting/dancers/get-by-id/controller.ts').default['handle'], true>
 }
 type OrgsIdFavoritesGetHead = {
-  request: unknown
-  response: MakeTuyauResponse<import('../app/modules/orgs/scouting/favorites/list/controller.ts').default['handle'], false>
+  request: MakeTuyauRequest<InferInput<typeof import('../app/modules/orgs/scouting/event-query-validator.ts')['eventQuerySchema']>>
+  response: MakeTuyauResponse<import('../app/modules/orgs/scouting/favorites/list/controller.ts').default['handle'], true>
 }
 type OrgsIdFavoritesPost = {
   request: MakeTuyauRequest<InferInput<typeof import('../app/modules/orgs/scouting/favorites/create/validator.ts')['schema']>>

--- a/apps/backend/app/modules/orgs/scouting/coach-cross-event-access.spec.ts
+++ b/apps/backend/app/modules/orgs/scouting/coach-cross-event-access.spec.ts
@@ -227,6 +227,7 @@ test.group("coach cross-event scouting access", (group) => {
 
   test("an active-event coach retains full scouting writes", async ({
     client,
+    assert,
   }) => {
     const [org] = await db
       .insert(organizations)
@@ -318,6 +319,23 @@ test.group("coach cross-event scouting access", (group) => {
       .json({ dancerRosterId: dancer!.id })
       .header("Authorization", `Bearer ${token}`);
     callback.assertStatus(201);
+
+    // The row and the sheet opened from it read callbacks the same way.
+    const afterCallback = await client
+      .get(`/orgs/${org!.slug}/dancers`)
+      .qs({ eventId: event!.id })
+      .header("Authorization", `Bearer ${token}`);
+    afterCallback.assertStatus(200);
+    const calledBackRow = afterCallback
+      .body()
+      .find((row: { rosterId: string }) => row.rosterId === dancer!.id);
+    assert.isTrue(calledBackRow.isCalledBack);
+    const calledBackSheet = await client
+      .get(`/orgs/${org!.slug}/dancers/${dancer!.id}`)
+      .qs({ eventId: event!.id })
+      .header("Authorization", `Bearer ${token}`);
+    calledBackSheet.assertStatus(200);
+    assert.isTrue(calledBackSheet.body().isCalledBack);
     const crossEventRating = await client
       .put(`/orgs/${org!.slug}/dancers/${otherEventDancer!.id}/rating`)
       .json({ rating: 5 })
@@ -474,6 +492,90 @@ test.group("coach cross-event scouting access", (group) => {
       .header("Authorization", `Bearer ${token}`);
     activeFavorites.assertStatus(200);
     assert.lengthOf(activeFavorites.body(), 0);
+  });
+
+  test("starting the next showcase clears the callback in the list and the sheet alike", async ({
+    client,
+    assert,
+  }) => {
+    const [org] = await db
+      .insert(organizations)
+      .values({
+        name: "Showcase Org",
+        slug: "showcase-org",
+        features: { callbacks: true },
+      })
+      .returning();
+    const [event] = await db
+      .insert(orgEvents)
+      .values({
+        orgId: org!.id,
+        name: "Austin",
+        startDate: dateFromToday(-1),
+        endDate: dateFromToday(1),
+        isActive: true,
+      })
+      .returning();
+    const coach = await createUser("showcase_coach");
+    await db.insert(orgMemberships).values({
+      orgId: org!.id,
+      userId: coach.id,
+      role: "member",
+      type: "coach",
+    });
+    const [coachRoster] = await db
+      .insert(eventRosters)
+      .values({
+        eventId: event!.id,
+        userId: coach.id,
+        type: "coach",
+        email: coach.email,
+        firstName: "Showcase",
+        lastName: "Coach",
+      })
+      .returning();
+    const [dancer] = await db
+      .insert(eventRosters)
+      .values({
+        eventId: event!.id,
+        type: "dancer",
+        email: "showcase-dancer@example.com",
+        firstName: "Showcase",
+        lastName: "Dancer",
+        bibNumber: 80,
+      })
+      .returning();
+    // The callback was made during showcase 1, which has since been published
+    // and replaced by showcase 2 as the one running.
+    const [firstShowcase] = await db
+      .insert(eventShowcases)
+      .values({ eventId: event!.id, number: 1, status: "published" })
+      .returning();
+    await db
+      .insert(eventShowcases)
+      .values({ eventId: event!.id, number: 2, status: "active" });
+    await db.insert(eventCallbacks).values({
+      eventId: event!.id,
+      showcaseId: firstShowcase!.id,
+      coachRosterId: coachRoster!.id,
+      dancerRosterId: dancer!.id,
+    });
+
+    const token = await loginUser(coach.id);
+
+    const list = await client
+      .get(`/orgs/${org!.slug}/dancers`)
+      .qs({ eventId: event!.id })
+      .header("Authorization", `Bearer ${token}`);
+    list.assertStatus(200);
+    assert.isFalse(list.body()[0].isCalledBack);
+
+    const detail = await client
+      .get(`/orgs/${org!.slug}/dancers/${dancer!.id}`)
+      .qs({ eventId: event!.id })
+      .header("Authorization", `Bearer ${token}`);
+    detail.assertStatus(200);
+    assert.isFalse(detail.body().isCalledBack);
   });
 
   test("a coach absent from the active event still reads her past favorites", async ({

--- a/apps/backend/app/modules/orgs/scouting/coach-cross-event-access.spec.ts
+++ b/apps/backend/app/modules/orgs/scouting/coach-cross-event-access.spec.ts
@@ -325,6 +325,214 @@ test.group("coach cross-event scouting access", (group) => {
     crossEventRating.assertStatus(403);
   });
 
+  test("a coach reads back a past event's favorites, notes and ratings by filtering to it", async ({
+    client,
+    assert,
+  }) => {
+    const [org] = await db
+      .insert(organizations)
+      .values({ name: "History Org", slug: "history-org" })
+      .returning();
+    const [pastEvent, activeEvent] = await db
+      .insert(orgEvents)
+      .values([
+        {
+          orgId: org!.id,
+          name: "Tempe",
+          startDate: dateFromToday(-60),
+          endDate: dateFromToday(-58),
+        },
+        {
+          orgId: org!.id,
+          name: "Austin",
+          startDate: dateFromToday(-1),
+          endDate: dateFromToday(1),
+          isActive: true,
+        },
+      ])
+      .returning();
+    const coach = await createUser("history_coach");
+    await db.insert(orgMemberships).values({
+      orgId: org!.id,
+      userId: coach.id,
+      role: "member",
+      type: "coach",
+    });
+    // A coach holds a separate roster row per event — the reason the past
+    // event's marks were unreachable through the active-event roster.
+    const [pastCoachRoster] = await db
+      .insert(eventRosters)
+      .values([
+        {
+          eventId: pastEvent!.id,
+          userId: coach.id,
+          type: "coach",
+          email: coach.email,
+          firstName: "History",
+          lastName: "Coach",
+        },
+        {
+          eventId: activeEvent!.id,
+          userId: coach.id,
+          type: "coach",
+          email: coach.email,
+          firstName: "History",
+          lastName: "Coach",
+        },
+      ])
+      .returning();
+    const [pastDancer] = await db
+      .insert(eventRosters)
+      .values({
+        eventId: pastEvent!.id,
+        type: "dancer",
+        email: "tempe-dancer@example.com",
+        firstName: "Tempe",
+        lastName: "Dancer",
+        bibNumber: 50,
+      })
+      .returning();
+
+    await db.insert(eventFavorites).values({
+      eventId: pastEvent!.id,
+      coachRosterId: pastCoachRoster!.id,
+      dancerRosterId: pastDancer!.id,
+    });
+    await db.insert(eventNotes).values({
+      eventId: pastEvent!.id,
+      coachRosterId: pastCoachRoster!.id,
+      dancerRosterId: pastDancer!.id,
+      content: "Great turns at Tempe",
+    });
+    await db.insert(eventRatings).values({
+      eventId: pastEvent!.id,
+      coachRosterId: pastCoachRoster!.id,
+      dancerRosterId: pastDancer!.id,
+      rating: 5,
+    });
+
+    const token = await loginUser(coach.id);
+
+    const list = await client
+      .get(`/orgs/${org!.slug}/dancers`)
+      .qs({ eventId: pastEvent!.id })
+      .header("Authorization", `Bearer ${token}`);
+    list.assertStatus(200);
+    const listed = list.body()[0];
+    assert.equal(listed.rosterId, pastDancer!.id);
+    assert.isTrue(listed.isFavorited);
+    assert.isTrue(listed.hasNote);
+    assert.equal(listed.rating, 5);
+
+    const favorites = await client
+      .get(`/orgs/${org!.slug}/favorites`)
+      .qs({ eventId: pastEvent!.id })
+      .header("Authorization", `Bearer ${token}`);
+    favorites.assertStatus(200);
+    assert.deepEqual(
+      favorites.body().map((row: { rosterId: string }) => row.rosterId),
+      [pastDancer!.id]
+    );
+
+    const detail = await client
+      .get(`/orgs/${org!.slug}/dancers/${pastDancer!.id}`)
+      .qs({ eventId: pastEvent!.id })
+      .header("Authorization", `Bearer ${token}`);
+    detail.assertStatus(200);
+    assert.equal(detail.body().note, "Great turns at Tempe");
+    assert.equal(detail.body().rating, 5);
+    assert.isTrue(detail.body().isFavorited);
+    assert.isTrue(detail.body().isViewerRostered);
+
+    // "All events" keeps the active-event scoping, so the Tempe marks stay out.
+    const allEvents = await client
+      .get(`/orgs/${org!.slug}/dancers`)
+      .header("Authorization", `Bearer ${token}`);
+    allEvents.assertStatus(200);
+    const collapsed = allEvents
+      .body()
+      .find((row: { rosterId: string }) => row.rosterId === pastDancer!.id);
+    assert.isFalse(collapsed.isFavorited);
+    assert.isFalse(collapsed.hasNote);
+
+    const activeFavorites = await client
+      .get(`/orgs/${org!.slug}/favorites`)
+      .header("Authorization", `Bearer ${token}`);
+    activeFavorites.assertStatus(200);
+    assert.lengthOf(activeFavorites.body(), 0);
+  });
+
+  test("a coach who never attended an event sees an empty, flagged board for it", async ({
+    client,
+    assert,
+  }) => {
+    const [org] = await db
+      .insert(organizations)
+      .values({ name: "Absent Org", slug: "absent-org" })
+      .returning();
+    const [missedEvent, activeEvent] = await db
+      .insert(orgEvents)
+      .values([
+        {
+          orgId: org!.id,
+          name: "Lakeland",
+          startDate: dateFromToday(-60),
+          endDate: dateFromToday(-58),
+        },
+        {
+          orgId: org!.id,
+          name: "Austin",
+          startDate: dateFromToday(-1),
+          endDate: dateFromToday(1),
+          isActive: true,
+        },
+      ])
+      .returning();
+    const coach = await createUser("absent_coach");
+    await db.insert(orgMemberships).values({
+      orgId: org!.id,
+      userId: coach.id,
+      role: "member",
+      type: "coach",
+    });
+    await db.insert(eventRosters).values({
+      eventId: activeEvent!.id,
+      userId: coach.id,
+      type: "coach",
+      email: coach.email,
+      firstName: "Absent",
+      lastName: "Coach",
+    });
+    const [missedDancer] = await db
+      .insert(eventRosters)
+      .values({
+        eventId: missedEvent!.id,
+        type: "dancer",
+        email: "lakeland-dancer@example.com",
+        firstName: "Lakeland",
+        lastName: "Dancer",
+        bibNumber: 60,
+      })
+      .returning();
+
+    const token = await loginUser(coach.id);
+
+    const favorites = await client
+      .get(`/orgs/${org!.slug}/favorites`)
+      .qs({ eventId: missedEvent!.id })
+      .header("Authorization", `Bearer ${token}`);
+    favorites.assertStatus(200);
+    assert.lengthOf(favorites.body(), 0);
+
+    const detail = await client
+      .get(`/orgs/${org!.slug}/dancers/${missedDancer!.id}`)
+      .qs({ eventId: missedEvent!.id })
+      .header("Authorization", `Bearer ${token}`);
+    detail.assertStatus(200);
+    assert.isFalse(detail.body().isViewerRostered);
+    assert.isNull(detail.body().note);
+  });
+
   test("dancer denial and org-admin coach access are unchanged", async ({
     client,
   }) => {

--- a/apps/backend/app/modules/orgs/scouting/coach-cross-event-access.spec.ts
+++ b/apps/backend/app/modules/orgs/scouting/coach-cross-event-access.spec.ts
@@ -410,6 +410,18 @@ test.group("coach cross-event scouting access", (group) => {
       dancerRosterId: pastDancer!.id,
       rating: 5,
     });
+    // Callbacks are per-event and deliberately not retained, unlike the marks
+    // above — the past event's showcase is published, not active.
+    const [pastShowcase] = await db
+      .insert(eventShowcases)
+      .values({ eventId: pastEvent!.id, number: 1, status: "published" })
+      .returning();
+    await db.insert(eventCallbacks).values({
+      eventId: pastEvent!.id,
+      showcaseId: pastShowcase!.id,
+      coachRosterId: pastCoachRoster!.id,
+      dancerRosterId: pastDancer!.id,
+    });
 
     const token = await loginUser(coach.id);
 
@@ -423,6 +435,7 @@ test.group("coach cross-event scouting access", (group) => {
     assert.isTrue(listed.isFavorited);
     assert.isTrue(listed.hasNote);
     assert.equal(listed.rating, 5);
+    assert.isFalse(listed.isCalledBack);
 
     const favorites = await client
       .get(`/orgs/${org!.slug}/favorites`)
@@ -443,6 +456,7 @@ test.group("coach cross-event scouting access", (group) => {
     assert.equal(detail.body().rating, 5);
     assert.isTrue(detail.body().isFavorited);
     assert.isTrue(detail.body().isViewerRostered);
+    assert.isFalse(detail.body().isCalledBack);
 
     // "All events" keeps the active-event scoping, so the Tempe marks stay out.
     const allEvents = await client

--- a/apps/backend/app/modules/orgs/scouting/coach-cross-event-access.spec.ts
+++ b/apps/backend/app/modules/orgs/scouting/coach-cross-event-access.spec.ts
@@ -462,6 +462,81 @@ test.group("coach cross-event scouting access", (group) => {
     assert.lengthOf(activeFavorites.body(), 0);
   });
 
+  test("a coach absent from the active event still reads her past favorites", async ({
+    client,
+    assert,
+  }) => {
+    const [org] = await db
+      .insert(organizations)
+      .values({ name: "Absent Now Org", slug: "absent-now-org" })
+      .returning();
+    const [pastEvent] = await db
+      .insert(orgEvents)
+      .values([
+        {
+          orgId: org!.id,
+          name: "Tempe",
+          startDate: dateFromToday(-60),
+          endDate: dateFromToday(-58),
+        },
+        {
+          orgId: org!.id,
+          name: "Austin",
+          startDate: dateFromToday(-1),
+          endDate: dateFromToday(1),
+          isActive: true,
+        },
+      ])
+      .returning();
+    const coach = await createUser("lapsed_coach");
+    await db.insert(orgMemberships).values({
+      orgId: org!.id,
+      userId: coach.id,
+      role: "member",
+      type: "coach",
+    });
+    // Rostered at Tempe only — she is not attending the event running now.
+    const [pastCoachRoster] = await db
+      .insert(eventRosters)
+      .values({
+        eventId: pastEvent!.id,
+        userId: coach.id,
+        type: "coach",
+        email: coach.email,
+        firstName: "Lapsed",
+        lastName: "Coach",
+      })
+      .returning();
+    const [pastDancer] = await db
+      .insert(eventRosters)
+      .values({
+        eventId: pastEvent!.id,
+        type: "dancer",
+        email: "lapsed-dancer@example.com",
+        firstName: "Lapsed",
+        lastName: "Dancer",
+        bibNumber: 70,
+      })
+      .returning();
+    await db.insert(eventFavorites).values({
+      eventId: pastEvent!.id,
+      coachRosterId: pastCoachRoster!.id,
+      dancerRosterId: pastDancer!.id,
+    });
+
+    const token = await loginUser(coach.id);
+
+    const favorites = await client
+      .get(`/orgs/${org!.slug}/favorites`)
+      .qs({ eventId: pastEvent!.id })
+      .header("Authorization", `Bearer ${token}`);
+    favorites.assertStatus(200);
+    assert.deepEqual(
+      favorites.body().map((row: { rosterId: string }) => row.rosterId),
+      [pastDancer!.id]
+    );
+  });
+
   test("a coach who never attended an event sees an empty, flagged board for it", async ({
     client,
     assert,

--- a/apps/backend/app/modules/orgs/scouting/dancers/get-by-id/controller.ts
+++ b/apps/backend/app/modules/orgs/scouting/dancers/get-by-id/controller.ts
@@ -37,7 +37,8 @@ export default class GetDancerByIdController {
       ctx.org!.id,
       rosterId,
       view,
-      Boolean(query.eventId)
+      Boolean(query.eventId),
+      view !== null && view.eventId === ctx.orgEvent?.id
     );
     if (!result) return ctx.response.notFound({ message: "Dancer not found." });
     return ctx.response.ok(result);

--- a/apps/backend/app/modules/orgs/scouting/dancers/get-by-id/controller.ts
+++ b/apps/backend/app/modules/orgs/scouting/dancers/get-by-id/controller.ts
@@ -3,6 +3,7 @@ import type { HttpContext } from "@adonisjs/core/http";
 import { GetDancerByIdService } from "./service.ts";
 import { eventQuerySchema } from "../../event-query-validator.ts";
 import {
+  findActiveShowcaseId,
   resolveScoutingViewScope,
   type ScoutingViewScope,
 } from "../../view-scope.ts";
@@ -29,7 +30,7 @@ export default class GetDancerByIdController {
       view = {
         eventId: ctx.orgEvent.id,
         coachRosterId: ctx.orgRoster.id,
-        showcaseId: null,
+        showcaseId: await findActiveShowcaseId(ctx.orgEvent.id),
       };
     }
 
@@ -37,8 +38,7 @@ export default class GetDancerByIdController {
       ctx.org!.id,
       rosterId,
       view,
-      Boolean(query.eventId),
-      view !== null && view.eventId === ctx.orgEvent?.id
+      Boolean(query.eventId)
     );
     if (!result) return ctx.response.notFound({ message: "Dancer not found." });
     return ctx.response.ok(result);

--- a/apps/backend/app/modules/orgs/scouting/dancers/get-by-id/controller.ts
+++ b/apps/backend/app/modules/orgs/scouting/dancers/get-by-id/controller.ts
@@ -33,7 +33,12 @@ export default class GetDancerByIdController {
       };
     }
 
-    const result = await service.execute(ctx.org!.id, rosterId, view);
+    const result = await service.execute(
+      ctx.org!.id,
+      rosterId,
+      view,
+      Boolean(query.eventId)
+    );
     if (!result) return ctx.response.notFound({ message: "Dancer not found." });
     return ctx.response.ok(result);
   }

--- a/apps/backend/app/modules/orgs/scouting/dancers/get-by-id/controller.ts
+++ b/apps/backend/app/modules/orgs/scouting/dancers/get-by-id/controller.ts
@@ -1,17 +1,39 @@
 import { inject } from "@adonisjs/core";
 import type { HttpContext } from "@adonisjs/core/http";
 import { GetDancerByIdService } from "./service.ts";
+import { eventQuerySchema } from "../../event-query-validator.ts";
+import {
+  resolveScoutingViewScope,
+  type ScoutingViewScope,
+} from "../../view-scope.ts";
 
 export default class GetDancerByIdController {
   @inject()
   async handle(ctx: HttpContext, service: GetDancerByIdService) {
     const rosterId = ctx.params.rosterId as string;
-    const result = await service.execute(
-      ctx.org!.id,
-      ctx.orgEvent?.id ?? null,
-      rosterId,
-      ctx.orgRoster?.id ?? null
-    );
+    const query = await ctx.request.validateUsing(eventQuerySchema);
+
+    let view: ScoutingViewScope | null = null;
+    if (query.eventId) {
+      view = await resolveScoutingViewScope(
+        ctx.org!.id,
+        ctx.auth.user!.id,
+        query.eventId
+      );
+      if (!view) {
+        return ctx.response.unprocessableEntity({
+          message: "Selected event does not belong to this organization.",
+        });
+      }
+    } else if (ctx.orgEvent && ctx.orgRoster) {
+      view = {
+        eventId: ctx.orgEvent.id,
+        coachRosterId: ctx.orgRoster.id,
+        showcaseId: null,
+      };
+    }
+
+    const result = await service.execute(ctx.org!.id, rosterId, view);
     if (!result) return ctx.response.notFound({ message: "Dancer not found." });
     return ctx.response.ok(result);
   }

--- a/apps/backend/app/modules/orgs/scouting/dancers/get-by-id/service.ts
+++ b/apps/backend/app/modules/orgs/scouting/dancers/get-by-id/service.ts
@@ -23,7 +23,8 @@ export class GetDancerByIdService {
   async execute(
     orgId: string,
     dancerRosterId: string,
-    view: ScoutingViewScope | null
+    view: ScoutingViewScope | null,
+    requireEventMatch: boolean = false
   ) {
     const viewEventId = view?.eventId ?? null;
     const coachRosterId = view?.coachRosterId ?? null;
@@ -79,6 +80,13 @@ export class GetDancerByIdService {
     if (rows.length === 0) return null;
 
     const dancer = rows[0];
+
+    // Pairing an explicitly requested event with a roster row from a different
+    // one would silently return empty marks, which reads as "nothing scouted"
+    // rather than the mismatch it is. Only applies to an explicit selection —
+    // under "All events" the scope is the active event while the collapsed row
+    // may legitimately come from an older one.
+    if (requireEventMatch && dancer!.eventId !== viewEventId) return null;
 
     let note: string | null = null;
     let rating: number | null = null;

--- a/apps/backend/app/modules/orgs/scouting/dancers/get-by-id/service.ts
+++ b/apps/backend/app/modules/orgs/scouting/dancers/get-by-id/service.ts
@@ -24,11 +24,11 @@ export class GetDancerByIdService {
     orgId: string,
     dancerRosterId: string,
     view: ScoutingViewScope | null,
-    requireEventMatch: boolean = false,
-    isActiveEvent: boolean = true
+    requireEventMatch: boolean = false
   ) {
     const viewEventId = view?.eventId ?? null;
     const coachRosterId = view?.coachRosterId ?? null;
+    const viewShowcaseId = view?.showcaseId ?? null;
     const rows = await this.db.use((db) =>
       db
         .select({
@@ -135,27 +135,29 @@ export class GetDancerByIdService {
             )
             .limit(1)
         ),
-        this.db.use((db) =>
-          db
-            .select({ id: eventCallbacks.id })
-            .from(eventCallbacks)
-            .where(
-              and(
-                eq(eventCallbacks.eventId, viewEventId!),
-                eq(eventCallbacks.coachRosterId, coachRosterId),
-                eq(eventCallbacks.dancerRosterId, dancerRosterId)
-              )
-            )
-            .limit(1)
-        ),
+        viewShowcaseId === null
+          ? Promise.resolve([])
+          : this.db.use((db) =>
+              db
+                .select({ id: eventCallbacks.id })
+                .from(eventCallbacks)
+                .where(
+                  and(
+                    eq(eventCallbacks.showcaseId, viewShowcaseId),
+                    eq(eventCallbacks.coachRosterId, coachRosterId),
+                    eq(eventCallbacks.dancerRosterId, dancerRosterId)
+                  )
+                )
+                .limit(1)
+            ),
       ]);
 
       note = noteRow[0]?.content ?? null;
       rating = ratingRow[0]?.rating ?? null;
       isFavorited = favoriteRow.length > 0;
-      // Callbacks belong to the event in progress and are not retained across
-      // events, unlike favorites, notes and ratings.
-      isCalledBack = isActiveEvent && callbackRow.length > 0;
+      // Scoped to the showcase, exactly as the dancer list is, so a row and the
+      // sheet opened from it never disagree.
+      isCalledBack = callbackRow.length > 0;
     }
 
     return {

--- a/apps/backend/app/modules/orgs/scouting/dancers/get-by-id/service.ts
+++ b/apps/backend/app/modules/orgs/scouting/dancers/get-by-id/service.ts
@@ -14,6 +14,7 @@ import {
 } from "#database/schema/event-features";
 import { users } from "#database/schema/users";
 import { and, eq, sql } from "drizzle-orm";
+import type { ScoutingViewScope } from "../../view-scope.ts";
 
 @inject()
 export class GetDancerByIdService {
@@ -21,10 +22,11 @@ export class GetDancerByIdService {
 
   async execute(
     orgId: string,
-    activeEventId: string | null,
     dancerRosterId: string,
-    coachRosterId: string | null
+    view: ScoutingViewScope | null
   ) {
+    const viewEventId = view?.eventId ?? null;
+    const coachRosterId = view?.coachRosterId ?? null;
     const rows = await this.db.use((db) =>
       db
         .select({
@@ -83,7 +85,7 @@ export class GetDancerByIdService {
     let isFavorited = false;
     let isCalledBack = false;
 
-    if (coachRosterId !== null && activeEventId !== null) {
+    if (coachRosterId !== null && viewEventId !== null) {
       const [noteRow, ratingRow, favoriteRow, callbackRow] = await Promise.all([
         this.db.use((db) =>
           db
@@ -91,7 +93,7 @@ export class GetDancerByIdService {
             .from(eventNotes)
             .where(
               and(
-                eq(eventNotes.eventId, activeEventId!),
+                eq(eventNotes.eventId, viewEventId!),
                 eq(eventNotes.coachRosterId, coachRosterId),
                 eq(eventNotes.dancerRosterId, dancerRosterId)
               )
@@ -104,7 +106,7 @@ export class GetDancerByIdService {
             .from(eventRatings)
             .where(
               and(
-                eq(eventRatings.eventId, activeEventId!),
+                eq(eventRatings.eventId, viewEventId!),
                 eq(eventRatings.coachRosterId, coachRosterId),
                 eq(eventRatings.dancerRosterId, dancerRosterId)
               )
@@ -117,7 +119,7 @@ export class GetDancerByIdService {
             .from(eventFavorites)
             .where(
               and(
-                eq(eventFavorites.eventId, activeEventId!),
+                eq(eventFavorites.eventId, viewEventId!),
                 eq(eventFavorites.coachRosterId, coachRosterId),
                 eq(eventFavorites.dancerRosterId, dancerRosterId)
               )
@@ -130,7 +132,7 @@ export class GetDancerByIdService {
             .from(eventCallbacks)
             .where(
               and(
-                eq(eventCallbacks.eventId, activeEventId!),
+                eq(eventCallbacks.eventId, viewEventId!),
                 eq(eventCallbacks.coachRosterId, coachRosterId),
                 eq(eventCallbacks.dancerRosterId, dancerRosterId)
               )
@@ -152,6 +154,9 @@ export class GetDancerByIdService {
       isFavorited,
       isCalledBack,
       favoritedMyRosterId: null,
+      // Lets the sheet distinguish "nothing scouted here" from "you were never
+      // at this event", so an empty panel does not read as lost data.
+      isViewerRostered: coachRosterId !== null,
     };
   }
 }

--- a/apps/backend/app/modules/orgs/scouting/dancers/get-by-id/service.ts
+++ b/apps/backend/app/modules/orgs/scouting/dancers/get-by-id/service.ts
@@ -24,7 +24,8 @@ export class GetDancerByIdService {
     orgId: string,
     dancerRosterId: string,
     view: ScoutingViewScope | null,
-    requireEventMatch: boolean = false
+    requireEventMatch: boolean = false,
+    isActiveEvent: boolean = true
   ) {
     const viewEventId = view?.eventId ?? null;
     const coachRosterId = view?.coachRosterId ?? null;
@@ -152,7 +153,9 @@ export class GetDancerByIdService {
       note = noteRow[0]?.content ?? null;
       rating = ratingRow[0]?.rating ?? null;
       isFavorited = favoriteRow.length > 0;
-      isCalledBack = callbackRow.length > 0;
+      // Callbacks belong to the event in progress and are not retained across
+      // events, unlike favorites, notes and ratings.
+      isCalledBack = isActiveEvent && callbackRow.length > 0;
     }
 
     return {

--- a/apps/backend/app/modules/orgs/scouting/dancers/list/controller.ts
+++ b/apps/backend/app/modules/orgs/scouting/dancers/list/controller.ts
@@ -3,9 +3,10 @@ import type { HttpContext } from "@adonisjs/core/http";
 import { ListDancersService } from "./service.ts";
 import { EnsureActiveShowcaseService } from "../../showcases/ensure-active/service.ts";
 import { schema } from "./validator.ts";
-import { orgEvents } from "#database/schema/org-events";
-import { db } from "#database/connection";
-import { and, eq } from "drizzle-orm";
+import {
+  resolveScoutingViewScope,
+  type ScoutingViewScope,
+} from "../../view-scope.ts";
 
 export default class ListDancersController {
   @inject()
@@ -17,36 +18,40 @@ export default class ListDancersController {
     const payload = await ctx.request.validateUsing(schema);
     const event = ctx.orgEvent;
 
-    if (payload.eventId) {
-      const [selectedEvent] = await db
-        .select({ id: orgEvents.id })
-        .from(orgEvents)
-        .where(
-          and(
-            eq(orgEvents.id, payload.eventId),
-            eq(orgEvents.orgId, ctx.org!.id)
-          )
-        )
-        .limit(1);
-      if (!selectedEvent) {
-        return ctx.response.unprocessableEntity({
-          message: "Selected event does not belong to this organization.",
-        });
-      }
-    }
-
     // Cross-event browsing never hides unchecked dancers: check-in state only
     // has meaning within the active event, while this endpoint defaults to the
     // organization's complete dancer history.
     const filterCheckedInOnly = false;
-    const showcase = event ? await ensureShowcase.execute(event.id) : null;
+
+    let view: ScoutingViewScope | null = null;
+    if (payload.eventId) {
+      view = await resolveScoutingViewScope(
+        ctx.org!.id,
+        ctx.auth.user!.id,
+        payload.eventId
+      );
+      if (!view) {
+        return ctx.response.unprocessableEntity({
+          message: "Selected event does not belong to this organization.",
+        });
+      }
+    } else if (event && ctx.orgRoster) {
+      // "All events" collapses each dancer to one row, preferring the active
+      // event's, so the marks stay scoped to the active event there.
+      const showcase = await ensureShowcase.execute(event.id);
+      view = {
+        eventId: event.id,
+        coachRosterId: ctx.orgRoster.id,
+        showcaseId: showcase?.id ?? null,
+      };
+    }
+
     const rows = await service.execute(
       ctx.org!.id,
       event?.id ?? null,
-      ctx.orgRoster?.id ?? null,
+      view,
       payload,
       filterCheckedInOnly,
-      showcase?.id,
       payload.eventId
     );
     return ctx.response.ok(rows);

--- a/apps/backend/app/modules/orgs/scouting/dancers/list/service.spec.ts
+++ b/apps/backend/app/modules/orgs/scouting/dancers/list/service.spec.ts
@@ -436,7 +436,6 @@ test.group("ListDancersService", (group) => {
       null,
       {},
       false,
-      undefined,
       pastEvent!.id
     );
     assert.equal(pastOnly[0]!.bibNumber, 12);

--- a/apps/backend/app/modules/orgs/scouting/dancers/list/service.ts
+++ b/apps/backend/app/modules/orgs/scouting/dancers/list/service.ts
@@ -98,15 +98,24 @@ export class ListDancersService {
           )`
         : sql<boolean>`false`;
 
-      const isCalledBackSubquery =
-        viewCoachRosterId && viewShowcaseId
+      // A finished event has no active showcase, so fall back to the event as a
+      // whole there — otherwise this column would read false for every past
+      // event while the detail sheet, which matches on eventId, said true.
+      const isCalledBackSubquery = !viewCoachRosterId
+        ? sql<boolean>`false`
+        : viewShowcaseId
           ? sql<boolean>`EXISTS (
             SELECT 1 FROM ${eventCallbacks}
             WHERE ${eventCallbacks.dancerRosterId} = ${eventRosters.id}
               AND ${eventCallbacks.coachRosterId} = ${viewCoachRosterId}
               AND ${eventCallbacks.showcaseId} = ${viewShowcaseId}
           )`
-          : sql<boolean>`false`;
+          : sql<boolean>`EXISTS (
+            SELECT 1 FROM ${eventCallbacks}
+            WHERE ${eventCallbacks.dancerRosterId} = ${eventRosters.id}
+              AND ${eventCallbacks.coachRosterId} = ${viewCoachRosterId}
+              AND ${eventCallbacks.eventId} = ${viewEventId}
+          )`;
 
       if (filterCheckedInOnly) {
         filters.push(isNotNull(eventRosters.checkedInAt));

--- a/apps/backend/app/modules/orgs/scouting/dancers/list/service.ts
+++ b/apps/backend/app/modules/orgs/scouting/dancers/list/service.ts
@@ -15,6 +15,7 @@ import { dancerProfiles } from "#database/schema/dancers";
 import { users } from "#database/schema/users";
 import { and, eq, ilike, isNotNull, or, sql } from "drizzle-orm";
 import type { Validator } from "./validator.ts";
+import type { ScoutingViewScope } from "../../view-scope.ts";
 
 @inject()
 export class ListDancersService {
@@ -23,10 +24,9 @@ export class ListDancersService {
   async execute(
     orgId: string,
     activeEventId: string | null,
-    coachRosterId: string | null,
+    view: ScoutingViewScope | null,
     q: Validator,
     filterCheckedInOnly: boolean = false,
-    showcaseId?: string,
     selectedEventId?: string
   ) {
     const rows = await this.db.use((db) => {
@@ -53,50 +53,58 @@ export class ListDancersService {
         );
       }
 
-      const interestedSubquery = coachRosterId
+      // The coach's own marks live on the event being viewed, not on whichever
+      // event the org happens to have active. Browsing back to a past event
+      // re-scopes both halves of the (eventId, coachRosterId) key; a coach who
+      // never attended that event has no roster row there and sees nothing.
+      const viewEventId = view?.eventId ?? null;
+      const viewCoachRosterId = view?.coachRosterId ?? null;
+      const viewShowcaseId = view?.showcaseId ?? null;
+
+      const interestedSubquery = viewCoachRosterId
         ? sql<boolean>`EXISTS (
             SELECT 1 FROM event_school_selections ess
             WHERE ess.dancer_roster_id = ${eventRosters.id}
-              AND ess.coach_roster_id = ${coachRosterId}
-              AND ess.event_id = ${activeEventId}
+              AND ess.coach_roster_id = ${viewCoachRosterId}
+              AND ess.event_id = ${viewEventId}
           )`
         : sql<boolean>`false`;
 
-      const isFavoritedSubquery = coachRosterId
+      const isFavoritedSubquery = viewCoachRosterId
         ? sql<boolean>`EXISTS (
             SELECT 1 FROM ${eventFavorites}
             WHERE ${eventFavorites.dancerRosterId} = ${eventRosters.id}
-              AND ${eventFavorites.coachRosterId} = ${coachRosterId}
-              AND ${eventFavorites.eventId} = ${activeEventId}
+              AND ${eventFavorites.coachRosterId} = ${viewCoachRosterId}
+              AND ${eventFavorites.eventId} = ${viewEventId}
           )`
         : sql<boolean>`false`;
 
-      const ratingSubquery = coachRosterId
+      const ratingSubquery = viewCoachRosterId
         ? sql<number | null>`(
             SELECT ${eventRatings.rating} FROM ${eventRatings}
             WHERE ${eventRatings.dancerRosterId} = ${eventRosters.id}
-              AND ${eventRatings.coachRosterId} = ${coachRosterId}
-              AND ${eventRatings.eventId} = ${activeEventId}
+              AND ${eventRatings.coachRosterId} = ${viewCoachRosterId}
+              AND ${eventRatings.eventId} = ${viewEventId}
             LIMIT 1
           )`
         : sql<number | null>`NULL`;
 
-      const hasNoteSubquery = coachRosterId
+      const hasNoteSubquery = viewCoachRosterId
         ? sql<boolean>`EXISTS (
             SELECT 1 FROM ${eventNotes}
             WHERE ${eventNotes.dancerRosterId} = ${eventRosters.id}
-              AND ${eventNotes.coachRosterId} = ${coachRosterId}
-              AND ${eventNotes.eventId} = ${activeEventId}
+              AND ${eventNotes.coachRosterId} = ${viewCoachRosterId}
+              AND ${eventNotes.eventId} = ${viewEventId}
           )`
         : sql<boolean>`false`;
 
       const isCalledBackSubquery =
-        coachRosterId && showcaseId
+        viewCoachRosterId && viewShowcaseId
           ? sql<boolean>`EXISTS (
             SELECT 1 FROM ${eventCallbacks}
             WHERE ${eventCallbacks.dancerRosterId} = ${eventRosters.id}
-              AND ${eventCallbacks.coachRosterId} = ${coachRosterId}
-              AND ${eventCallbacks.showcaseId} = ${showcaseId}
+              AND ${eventCallbacks.coachRosterId} = ${viewCoachRosterId}
+              AND ${eventCallbacks.showcaseId} = ${viewShowcaseId}
           )`
           : sql<boolean>`false`;
 
@@ -105,13 +113,13 @@ export class ListDancersService {
         filters.push(isNotNull(eventRosters.userId));
       }
 
-      if (q.interested && coachRosterId) {
+      if (q.interested && viewCoachRosterId) {
         filters.push(
           sql`EXISTS (
             SELECT 1 FROM event_school_selections ess
             WHERE ess.dancer_roster_id = ${eventRosters.id}
-              AND ess.coach_roster_id = ${coachRosterId}
-              AND ess.event_id = ${activeEventId}
+              AND ess.coach_roster_id = ${viewCoachRosterId}
+              AND ess.event_id = ${viewEventId}
           )`
         );
       }

--- a/apps/backend/app/modules/orgs/scouting/dancers/list/service.ts
+++ b/apps/backend/app/modules/orgs/scouting/dancers/list/service.ts
@@ -98,24 +98,17 @@ export class ListDancersService {
           )`
         : sql<boolean>`false`;
 
-      // A finished event has no active showcase, so fall back to the event as a
-      // whole there — otherwise this column would read false for every past
-      // event while the detail sheet, which matches on eventId, said true.
-      const isCalledBackSubquery = !viewCoachRosterId
-        ? sql<boolean>`false`
-        : viewShowcaseId
+      // Callbacks belong to the showcase running at the time and are not
+      // retained across events, so a finished event reports none.
+      const isCalledBackSubquery =
+        viewCoachRosterId && viewShowcaseId
           ? sql<boolean>`EXISTS (
             SELECT 1 FROM ${eventCallbacks}
             WHERE ${eventCallbacks.dancerRosterId} = ${eventRosters.id}
               AND ${eventCallbacks.coachRosterId} = ${viewCoachRosterId}
               AND ${eventCallbacks.showcaseId} = ${viewShowcaseId}
           )`
-          : sql<boolean>`EXISTS (
-            SELECT 1 FROM ${eventCallbacks}
-            WHERE ${eventCallbacks.dancerRosterId} = ${eventRosters.id}
-              AND ${eventCallbacks.coachRosterId} = ${viewCoachRosterId}
-              AND ${eventCallbacks.eventId} = ${viewEventId}
-          )`;
+          : sql<boolean>`false`;
 
       if (filterCheckedInOnly) {
         filters.push(isNotNull(eventRosters.checkedInAt));

--- a/apps/backend/app/modules/orgs/scouting/favorites/list/controller.ts
+++ b/apps/backend/app/modules/orgs/scouting/favorites/list/controller.ts
@@ -1,10 +1,31 @@
 import { inject } from "@adonisjs/core";
 import type { HttpContext } from "@adonisjs/core/http";
 import { ListFavoritesService } from "./service.ts";
+import { eventQuerySchema } from "../../event-query-validator.ts";
+import { resolveScoutingViewScope } from "../../view-scope.ts";
 
 export default class ListFavoritesController {
   @inject()
   async handle(ctx: HttpContext, service: ListFavoritesService) {
+    const query = await ctx.request.validateUsing(eventQuerySchema);
+
+    if (query.eventId) {
+      const view = await resolveScoutingViewScope(
+        ctx.org!.id,
+        ctx.auth.user!.id,
+        query.eventId
+      );
+      if (!view) {
+        return ctx.response.unprocessableEntity({
+          message: "Selected event does not belong to this organization.",
+        });
+      }
+      // A coach who never attended the event simply has no favorites there.
+      if (!view.coachRosterId) return ctx.response.ok([]);
+      const rows = await service.execute(view.eventId, view.coachRosterId);
+      return ctx.response.ok(rows);
+    }
+
     if (!ctx.orgRoster) {
       return ctx.response.conflict({
         message: "You must be registered in this event as a coach to scout.",

--- a/apps/backend/app/modules/orgs/scouting/routes.ts
+++ b/apps/backend/app/modules/orgs/scouting/routes.ts
@@ -41,6 +41,10 @@ router
       description: "Coach-scoped dancer search by name, bib number, or event.",
     });
     router.get(":slug/dancers/:rosterId", [GetDancerById]);
+    // Reading a past event's favorites has to survive the coach not being on
+    // the active event's roster, so it belongs with the other browse routes
+    // rather than with the writes below.
+    router.get(":slug/favorites", [ListFavorites]);
   })
   .prefix("orgs")
   .use([
@@ -54,7 +58,6 @@ router
 
 router
   .group(() => {
-    router.get(":slug/favorites", [ListFavorites]);
     router
       .post(":slug/favorites", [CreateFavorite])
       .use(middleware.orgEventDancer());

--- a/apps/backend/app/modules/orgs/scouting/view-scope.ts
+++ b/apps/backend/app/modules/orgs/scouting/view-scope.ts
@@ -56,6 +56,7 @@ export async function resolveScoutingViewScope(
         eq(eventShowcases.status, "active")
       )
     )
+    .orderBy(desc(eventShowcases.number))
     .limit(1);
 
   return {

--- a/apps/backend/app/modules/orgs/scouting/view-scope.ts
+++ b/apps/backend/app/modules/orgs/scouting/view-scope.ts
@@ -45,23 +45,30 @@ export async function resolveScoutingViewScope(
     .orderBy(desc(eventRosters.createdAt))
     .limit(1);
 
-  // Read-only lookup on purpose: a past event must never have a showcase
-  // opened on it just because someone browsed back to it.
+  return {
+    eventId: event.id,
+    coachRosterId: roster?.id ?? null,
+    showcaseId: await findActiveShowcaseId(event.id),
+  };
+}
+
+/**
+ * Read-only on purpose: a past event must never have a showcase opened on it
+ * just because someone browsed back to it. A finished event's showcase is
+ * published rather than active, which is what keeps its callbacks — unlike its
+ * favorites, notes and ratings — out of the coach's view.
+ */
+export async function findActiveShowcaseId(eventId: string) {
   const [showcase] = await db
     .select({ id: eventShowcases.id })
     .from(eventShowcases)
     .where(
       and(
-        eq(eventShowcases.eventId, event.id),
+        eq(eventShowcases.eventId, eventId),
         eq(eventShowcases.status, "active")
       )
     )
     .orderBy(desc(eventShowcases.number))
     .limit(1);
-
-  return {
-    eventId: event.id,
-    coachRosterId: roster?.id ?? null,
-    showcaseId: showcase?.id ?? null,
-  };
+  return showcase?.id ?? null;
 }

--- a/apps/backend/app/modules/orgs/scouting/view-scope.ts
+++ b/apps/backend/app/modules/orgs/scouting/view-scope.ts
@@ -1,0 +1,66 @@
+import { db } from "#database/connection";
+import { eventRosters, orgEvents } from "#database/schema/org-events";
+import { eventShowcases } from "#database/schema/event-features";
+import { and, desc, eq } from "drizzle-orm";
+
+export interface ScoutingViewScope {
+  /** The event the coach's own scouting data is read against. */
+  eventId: string;
+  /** The coach's roster row for that event — null when they never attended it. */
+  coachRosterId: string | null;
+  /** That event's active showcase, if one was ever opened. */
+  showcaseId: string | null;
+}
+
+/**
+ * Favorites, notes and ratings are keyed by (eventId, coachRosterId), and a
+ * coach holds a separate roster row per event. Reading a past event therefore
+ * has to re-resolve both halves — the active-event roster hanging off the
+ * request context would match nothing and the coach would see an empty board.
+ *
+ * Returns null when the event does not belong to the org.
+ */
+export async function resolveScoutingViewScope(
+  orgId: string,
+  userId: string,
+  eventId: string
+): Promise<ScoutingViewScope | null> {
+  const [event] = await db
+    .select({ id: orgEvents.id })
+    .from(orgEvents)
+    .where(and(eq(orgEvents.id, eventId), eq(orgEvents.orgId, orgId)))
+    .limit(1);
+  if (!event) return null;
+
+  const [roster] = await db
+    .select({ id: eventRosters.id })
+    .from(eventRosters)
+    .where(
+      and(
+        eq(eventRosters.eventId, event.id),
+        eq(eventRosters.userId, userId),
+        eq(eventRosters.type, "coach")
+      )
+    )
+    .orderBy(desc(eventRosters.createdAt))
+    .limit(1);
+
+  // Read-only lookup on purpose: a past event must never have a showcase
+  // opened on it just because someone browsed back to it.
+  const [showcase] = await db
+    .select({ id: eventShowcases.id })
+    .from(eventShowcases)
+    .where(
+      and(
+        eq(eventShowcases.eventId, event.id),
+        eq(eventShowcases.status, "active")
+      )
+    )
+    .limit(1);
+
+  return {
+    eventId: event.id,
+    coachRosterId: roster?.id ?? null,
+    showcaseId: showcase?.id ?? null,
+  };
+}

--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -4811,6 +4811,21 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "eventId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
           }
         ],
         "responses": {
@@ -5009,6 +5024,21 @@
             "required": true,
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "eventId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             }
           }
         ],
@@ -16248,6 +16278,9 @@
           },
           "favoritedMyRosterId": {
             "type": "null"
+          },
+          "isViewerRostered": {
+            "type": "boolean"
           }
         },
         "required": [
@@ -16273,7 +16306,8 @@
           "isRegistered",
           "isFavorited",
           "isCalledBack",
-          "favoritedMyRosterId"
+          "favoritedMyRosterId",
+          "isViewerRostered"
         ]
       },
       "OrgsIdDancersIdNotesRequest": {

--- a/apps/frontend/src/features/org/api/scouting-queries.ts
+++ b/apps/frontend/src/features/org/api/scouting-queries.ts
@@ -16,13 +16,13 @@ export const scoutingQueries = {
         query: params,
       },
     }),
-  dancer: (slug: string, rosterId: string) =>
+  dancer: (slug: string, rosterId: string, eventId?: string) =>
     $api.queryOptions("get", "/orgs/{slug}/dancers/{rosterId}", {
-      params: { path: { slug, rosterId } },
+      params: { path: { slug, rosterId }, query: { eventId } },
     }),
-  favorites: (slug: string) =>
+  favorites: (slug: string, eventId?: string) =>
     $api.queryOptions("get", "/orgs/{slug}/favorites", {
-      params: { path: { slug } },
+      params: { path: { slug }, query: { eventId } },
     }),
   rankings: (slug: string) =>
     $api.queryOptions("get", "/orgs/{slug}/rankings", {

--- a/apps/frontend/src/features/org/components/callback-button.tsx
+++ b/apps/frontend/src/features/org/components/callback-button.tsx
@@ -8,15 +8,23 @@ import type { MouseEvent } from "react";
 export function CallbackButton({
   dancerRosterId,
   isCalledBack,
+  eventId,
   onToggle,
 }: {
   dancerRosterId: string;
   isCalledBack: boolean;
+  /** Must match the event the surrounding view reads, or the optimistic
+   *  update lands on a cache entry nothing is rendering. */
+  eventId?: string;
   onToggle?: (rosterId: string, current: boolean) => void;
 }) {
   const { org } = useOrg();
   const qc = useQueryClient();
-  const dancerKey = scoutingQueries.dancer(org.slug, dancerRosterId).queryKey;
+  const dancerKey = scoutingQueries.dancer(
+    org.slug,
+    dancerRosterId,
+    eventId,
+  ).queryKey;
   const callbacksKey = scoutingQueries.callbacks(org.slug).queryKey;
   const dancersPrefix = ["get", "/orgs/{slug}/dancers"] as const;
 

--- a/apps/frontend/src/features/org/components/compare-view.tsx
+++ b/apps/frontend/src/features/org/components/compare-view.tsx
@@ -15,6 +15,8 @@ interface CompareViewProps {
   onRemove: (rosterId: string) => void;
   onBack: () => void;
   onOpenSheet: (rosterId: string) => void;
+  /** Event being compared, so the marks match the list the coach came from. */
+  eventId?: string;
 }
 
 export function CompareView({
@@ -22,11 +24,14 @@ export function CompareView({
   onRemove,
   onBack,
   onOpenSheet,
+  eventId,
 }: CompareViewProps) {
   const { org } = useOrg();
 
   const dancerQueries = useQueries({
-    queries: compareIds.map((id) => scoutingQueries.dancer(org.slug, id)),
+    queries: compareIds.map((id) =>
+      scoutingQueries.dancer(org.slug, id, eventId),
+    ),
   });
 
   const dancerData = dancerQueries.map((q) => q.data);
@@ -68,6 +73,7 @@ export function CompareView({
             maxRating={maxRating}
             onRemove={onRemove}
             onOpenSheet={onOpenSheet}
+            eventId={eventId}
           />
         ))}
       </div>
@@ -82,6 +88,7 @@ function CompareColumn({
   maxRating,
   onRemove,
   onOpenSheet,
+  eventId,
 }: {
   rosterId: string;
   query: UseQueryResult<any>;
@@ -89,6 +96,7 @@ function CompareColumn({
   maxRating: number;
   onRemove: (rosterId: string) => void;
   onOpenSheet: (rosterId: string) => void;
+  eventId?: string;
 }) {
   const dancer = query.data;
 
@@ -185,7 +193,11 @@ function CompareColumn({
       </div>
 
       {/* Favorite */}
-      <FavoriteButton dancerRosterId={rosterId} isFavorited={dancer.isFavorited} />
+      <FavoriteButton
+        dancerRosterId={rosterId}
+        isFavorited={dancer.isFavorited}
+        eventId={eventId}
+      />
 
       {/* Notes */}
       <div>

--- a/apps/frontend/src/features/org/components/dancer-sheet.tsx
+++ b/apps/frontend/src/features/org/components/dancer-sheet.tsx
@@ -153,6 +153,7 @@ function DancerSheetContent({
       const dancerQueryKey = scoutingQueries.dancer(
         org.slug,
         rosterId,
+        eventId,
       ).queryKey;
 
       if (!notesFailed) {
@@ -248,6 +249,14 @@ function DancerSheetContent({
         {/* A past event is read-only, but the coach still needs to see what she
             scouted there — so the marks render either way and only the controls
             that write are withheld. */}
+        {readOnly && dancer.isViewerRostered === false && (
+          <p className="text-muted-foreground bg-muted/50 rounded-md px-3 py-2 text-sm">
+            {eventName
+              ? `You weren't rostered at ${eventName}, so there's nothing scouted here.`
+              : "You weren't rostered at this event, so there's nothing scouted here."}
+          </p>
+        )}
+
         <div className="flex items-center gap-2 pt-2">
           <div className="flex-1">
             <RatingInput
@@ -260,12 +269,14 @@ function DancerSheetContent({
             <CallbackButton
               dancerRosterId={rosterId}
               isCalledBack={dancer.isCalledBack ?? false}
+              eventId={eventId}
             />
           )}
           {!readOnly && (
             <FavoriteButton
               dancerRosterId={rosterId}
               isFavorited={dancer.isFavorited}
+              eventId={eventId}
               onToggle={onFavoriteToggle}
             />
           )}
@@ -305,9 +316,7 @@ function DancerSheetContent({
             </p>
           ) : (
             <p className="text-muted-foreground/50 text-sm italic">
-              {dancer.isViewerRostered === false && eventName
-                ? `You weren't rostered at ${eventName}.`
-                : "No notes from this event"}
+              No notes from this event
             </p>
           )}
         </div>

--- a/apps/frontend/src/features/org/components/dancer-sheet.tsx
+++ b/apps/frontend/src/features/org/components/dancer-sheet.tsx
@@ -28,6 +28,9 @@ interface DancerSheetProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   readOnly?: boolean;
+  /** Event whose scouting marks to show — defaults to the org's active event. */
+  eventId?: string;
+  eventName?: string;
   onFavoriteToggle?: (rosterId: string, current: boolean) => void;
   onSave?: (
     rosterId: string,
@@ -40,6 +43,8 @@ export function DancerSheet({
   open,
   onOpenChange,
   readOnly,
+  eventId,
+  eventName,
   onFavoriteToggle,
   onSave,
 }: DancerSheetProps) {
@@ -50,6 +55,8 @@ export function DancerSheet({
           <DancerSheetContent
             rosterId={rosterId}
             readOnly={readOnly}
+            eventId={eventId}
+            eventName={eventName}
             onFavoriteToggle={onFavoriteToggle}
             onSave={onSave}
           />
@@ -62,11 +69,15 @@ export function DancerSheet({
 function DancerSheetContent({
   rosterId,
   readOnly,
+  eventId,
+  eventName,
   onFavoriteToggle,
   onSave,
 }: {
   rosterId: string;
   readOnly?: boolean;
+  eventId?: string;
+  eventName?: string;
   onFavoriteToggle?: (rosterId: string, current: boolean) => void;
   onSave?: (
     rosterId: string,
@@ -76,7 +87,7 @@ function DancerSheetContent({
   const { org, hasFeature, isAdmin } = useOrg();
   const qc = useQueryClient();
   const { data: dancer, isLoading } = useQuery(
-    scoutingQueries.dancer(org.slug, rosterId),
+    scoutingQueries.dancer(org.slug, rosterId, eventId),
   );
 
   const [notes, setNotes] = useState<string | null>(null);
@@ -234,27 +245,34 @@ function DancerSheetContent({
       </SheetHeader>
 
       <SheetContent className="flex flex-col gap-4 px-4 pt-5 pb-3">
-        {!readOnly && (
-          <div className="flex items-center gap-2 pt-2">
-            <div className="flex-1">
-              <RatingInput
-                value={currentRating}
-                onChange={(v) => setRating(v)}
-              />
-            </div>
-            {hasFeature("callbacks") && (
-              <CallbackButton
-                dancerRosterId={rosterId}
-                isCalledBack={dancer.isCalledBack ?? false}
-              />
-            )}
+        {/* A past event is read-only, but the coach still needs to see what she
+            scouted there — so the marks render either way and only the controls
+            that write are withheld. */}
+        <div className="flex items-center gap-2 pt-2">
+          <div className="flex-1">
+            <RatingInput
+              value={currentRating}
+              onChange={(v) => setRating(v)}
+              readOnly={readOnly}
+            />
+          </div>
+          {!readOnly && hasFeature("callbacks") && (
+            <CallbackButton
+              dancerRosterId={rosterId}
+              isCalledBack={dancer.isCalledBack ?? false}
+            />
+          )}
+          {!readOnly && (
             <FavoriteButton
               dancerRosterId={rosterId}
               isFavorited={dancer.isFavorited}
               onToggle={onFavoriteToggle}
             />
-          </div>
-        )}
+          )}
+          {readOnly && dancer.isFavorited && (
+            <Badge variant="secondary">Favorited</Badge>
+          )}
+        </div>
 
         <div className={readOnly ? "pt-2" : undefined}>
           <label className="text-muted-foreground mb-1 block text-xs tracking-wide uppercase">
@@ -275,14 +293,24 @@ function DancerSheetContent({
           <DancerCallbackList orgSlug={org.slug} dancerRosterId={rosterId} />
         )}
 
-        {!readOnly && (
-          <div className="flex flex-1 flex-col">
-            <label className="text-muted-foreground mb-1 block text-xs tracking-wide uppercase">
-              Notes
-            </label>
+        <div className="flex flex-1 flex-col">
+          <label className="text-muted-foreground mb-1 block text-xs tracking-wide uppercase">
+            Notes
+          </label>
+          {!readOnly ? (
             <NotesEditor value={currentNotes} onChange={(v) => setNotes(v)} />
-          </div>
-        )}
+          ) : dancer.note ? (
+            <p className="text-muted-foreground text-sm whitespace-pre-wrap">
+              {dancer.note}
+            </p>
+          ) : (
+            <p className="text-muted-foreground/50 text-sm italic">
+              {dancer.isViewerRostered === false && eventName
+                ? `You weren't rostered at ${eventName}.`
+                : "No notes from this event"}
+            </p>
+          )}
+        </div>
       </SheetContent>
 
       {!readOnly && (

--- a/apps/frontend/src/features/org/components/favorite-button.tsx
+++ b/apps/frontend/src/features/org/components/favorite-button.tsx
@@ -8,16 +8,24 @@ import type { MouseEvent } from "react";
 export function FavoriteButton({
   dancerRosterId,
   isFavorited,
+  eventId,
   onToggle,
 }: {
   dancerRosterId: string;
   isFavorited: boolean;
+  /** Must match the event the surrounding view reads, or the optimistic
+   *  update lands on a cache entry nothing is rendering. */
+  eventId?: string;
   onToggle?: (rosterId: string, current: boolean) => void;
 }) {
   const { org } = useOrg();
   const qc = useQueryClient();
-  const dancerKey = scoutingQueries.dancer(org.slug, dancerRosterId).queryKey;
-  const favKey = scoutingQueries.favorites(org.slug).queryKey;
+  const dancerKey = scoutingQueries.dancer(
+    org.slug,
+    dancerRosterId,
+    eventId,
+  ).queryKey;
+  const favKey = scoutingQueries.favorites(org.slug, eventId).queryKey;
 
   const dancersPrefix = ["get", "/orgs/{slug}/dancers"] as const;
 

--- a/apps/frontend/src/features/org/components/rating-input.tsx
+++ b/apps/frontend/src/features/org/components/rating-input.tsx
@@ -3,9 +3,11 @@ import { Rating, RatingItem } from "@/components/ui/rating";
 export function RatingInput({
   value,
   onChange,
+  readOnly = false,
 }: {
   value: number | null;
   onChange: (value: number) => void;
+  readOnly?: boolean;
 }) {
   const onSet = (n: number) => {
     navigator.vibrate?.(10);
@@ -14,7 +16,7 @@ export function RatingInput({
 
   return (
     <div className="flex items-center gap-1">
-      <Rating value={value ?? 0} onValueChange={onSet}>
+      <Rating value={value ?? 0} onValueChange={onSet} readOnly={readOnly}>
         {Array.from({ length: 5 }, (_, i) => (
           <RatingItem key={i} index={i} />
         ))}

--- a/apps/frontend/src/lib/api/types.d.ts
+++ b/apps/frontend/src/lib/api/types.d.ts
@@ -4770,7 +4770,9 @@ export interface paths {
         };
         get: {
             parameters: {
-                query?: never;
+                query?: {
+                    eventId?: string | null;
+                };
                 header?: never;
                 path: {
                     slug: string;
@@ -4957,7 +4959,9 @@ export interface paths {
         };
         get: {
             parameters: {
-                query?: never;
+                query?: {
+                    eventId?: string | null;
+                };
                 header?: never;
                 path: {
                     slug: string;
@@ -11547,6 +11551,7 @@ export interface components {
             isFavorited: boolean;
             isCalledBack: boolean;
             favoritedMyRosterId: null;
+            isViewerRostered: boolean;
         };
         OrgsIdDancersIdNotesRequest: {
             content: string;

--- a/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/coach/dancers/index.tsx
+++ b/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/coach/dancers/index.tsx
@@ -137,10 +137,13 @@ function DancerSearch() {
     interested: interested || undefined,
     eventId: selectedEventId,
   };
-  const { data: dancers, isLoading } = useQuery({
+  const { data: dancers, isLoading: isDancersLoading } = useQuery({
     ...scoutingQueries.dancers(orgSlug, dancerParams),
     enabled: isEventResolved,
   });
+  // A disabled query reports isLoading false, so without the sentinel the table
+  // would flash its empty state while the default event is still resolving.
+  const isLoading = isDancersLoading || !isEventResolved;
   const { data: favorites } = useQuery({
     ...scoutingQueries.favorites(orgSlug, selectedEventId),
     enabled: isEventResolved && (canScout || Boolean(selectedEventId)),
@@ -167,6 +170,12 @@ function DancerSearch() {
 
   /* --- Sheet --- */
   const [sheetRosterId, setSheetRosterId] = useState<string | null>(null);
+
+  // The open sheet is scoped to the event it was opened against, so it must not
+  // outlive a change of event.
+  useEffect(() => {
+    setSheetRosterId(null);
+  }, [eventId]);
 
   /* --- Favorite toggle (optimistic on dancers list) --- */
   const qc = useQueryClient();
@@ -647,6 +656,7 @@ function DancerSearch() {
             }
             onBack={() => setCompareMode(false)}
             onOpenSheet={(rosterId) => setSheetRosterId(rosterId)}
+            eventId={selectedEventId}
           />
         ) : (
           <>

--- a/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/coach/dancers/index.tsx
+++ b/apps/frontend/src/routes/_org/o/$orgSlug/_authenticated/coach/dancers/index.tsx
@@ -86,7 +86,9 @@ function DancerSearch() {
   const [rated, setRated] = useState(false);
   const [hasNotes, setHasNotes] = useState(false);
   const [calledBack, setCalledBack] = useState(false);
-  const [eventId, setEventId] = useState<string | null>(null);
+  // `undefined` until the event list resolves, so the picker can default to the
+  // event in progress instead of flashing the org's whole history.
+  const [eventId, setEventId] = useState<string | null | undefined>(undefined);
   const deferredSearch = useDeferredValue(search);
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
@@ -118,18 +120,31 @@ function DancerSearch() {
   }, [rated]);
 
   /* --- Data --- */
+  const { data: events } = useQuery(adminQueries.events(orgSlug));
+
+  useEffect(() => {
+    if (eventId !== undefined || !events) return;
+    setEventId(events.find((event) => event.isActive)?.id ?? null);
+  }, [events, eventId]);
+
+  const isEventResolved = eventId !== undefined;
+  const selectedEventId = eventId ?? undefined;
+  const selectedEventName = events?.find(
+    (event) => event.id === selectedEventId,
+  )?.name;
+
   const dancerParams = {
     interested: interested || undefined,
-    eventId: eventId ?? undefined,
+    eventId: selectedEventId,
   };
-  const { data: dancers, isLoading } = useQuery(
-    scoutingQueries.dancers(orgSlug, dancerParams),
-  );
-  const { data: favorites } = useQuery({
-    ...scoutingQueries.favorites(orgSlug),
-    enabled: canScout,
+  const { data: dancers, isLoading } = useQuery({
+    ...scoutingQueries.dancers(orgSlug, dancerParams),
+    enabled: isEventResolved,
   });
-  const { data: events } = useQuery(adminQueries.events(orgSlug));
+  const { data: favorites } = useQuery({
+    ...scoutingQueries.favorites(orgSlug, selectedEventId),
+    enabled: isEventResolved && (canScout || Boolean(selectedEventId)),
+  });
 
   /* --- Compare clipboard --- */
   const [compareIds, setCompareIds] = useState<string[]>([]);
@@ -157,7 +172,7 @@ function DancerSearch() {
   const qc = useQueryClient();
   const dancersKey = scoutingQueries.dancers(orgSlug, dancerParams).queryKey;
 
-  const favKey = scoutingQueries.favorites(orgSlug).queryKey;
+  const favKey = scoutingQueries.favorites(orgSlug, selectedEventId).queryKey;
 
   const addFav = $api.useMutation("post", "/orgs/{slug}/favorites", {
     onMutate: async ({ body }) => {
@@ -207,7 +222,7 @@ function DancerSearch() {
     },
     meta: {
       invalidateQueries: [
-        scoutingQueries.favorites(orgSlug).queryKey,
+        scoutingQueries.favorites(orgSlug, selectedEventId).queryKey,
         dancersKey,
         scoutingQueries.rankings(orgSlug).queryKey,
       ],
@@ -248,7 +263,7 @@ function DancerSearch() {
       },
       meta: {
         invalidateQueries: [
-          scoutingQueries.favorites(orgSlug).queryKey,
+          scoutingQueries.favorites(orgSlug, selectedEventId).queryKey,
           dancersKey,
           scoutingQueries.rankings(orgSlug).queryKey,
         ],
@@ -651,7 +666,7 @@ function DancerSearch() {
             </section>
 
             <DancerFilterToolbar
-              eventId={eventId}
+              eventId={eventId ?? null}
               onEventIdChange={setEventId}
               events={(events ?? []).map((event) => ({
                 id: event.id,
@@ -754,6 +769,8 @@ function DancerSearch() {
       <DancerSheet
         rosterId={sheetRosterId}
         open={sheetRosterId !== null}
+        eventId={selectedEventId}
+        eventName={selectedEventName}
         onOpenChange={(open) => {
           if (!open) setSheetRosterId(null);
         }}


### PR DESCRIPTION
Reported by a client: a coach's past events showed none of her starred dancers, and there was doubt about whether coaches' notes were saving at all.

**The notes and favorites were never lost.** This was read-only breakage — the rows are all still in the database, so nothing needs backfilling.

## Root cause

Favorites, notes and ratings are keyed by `(eventId, coachRosterId, dancerRosterId)`, and a coach holds a **separate roster row per event**. Every coach-side read resolved both halves from `ctx.orgEvent` / `ctx.orgRoster`, which `middleware/routes/org-event.ts` only ever populates with the event where `isActive = true`.

So once the org moved on to a new event, filtering the dancer list back to Tempe or Lakeland listed the right dancers but computed every flag against the *active* event — `dancers/list/service.ts` pinned `isFavorited`, `rating` and `hasNote` to `activeEventId` regardless of the selected event, and `dancers/get-by-id` did the same for the detail sheet.

This is the half that `feat(scouting): decouple coach access from active event` didn't cover: browsing became cross-event, but the marks attached to the rows stayed pinned to the active event.

## The rule this establishes

| Event filter | Dancer table and the sheet opened from it both show |
| --- | --- |
| A specific event | that event's favorites, notes and ratings |
| All events | the active event's |

Callbacks follow the same rule at showcase granularity — they are per-event and deliberately **not** retained once an event ends.

## Changes

**Backend**
- New `scouting/view-scope.ts`: `resolveScoutingViewScope` validates the requested event belongs to the org and returns the coach's roster row for it (null when she never attended), plus that event's active showcase. The showcase lookup is deliberately read-only — browsing back must never open a showcase on a finished event.
- `dancers/list/service.ts`: the `isFavorited` / `rating` / `hasNote` / `interested` / `isCalledBack` subqueries use that scope. `activeEventId` still drives dedupe and bib display.
- `dancers/get-by-id` and `favorites/list` accept an `eventId` query param and return `isViewerRostered`.
- `GET /favorites` moves into the `coachDancerRead` route group. It sat with the writes, whose middleware rejects any coach without a roster on the active event — so a coach who attended Tempe but isn't at the current event had her dancer list work and her favorites **403**, which is exactly the coach this fix is for.
- The sheet's callbacks now match on `showcaseId` like the list does, instead of on the whole event. Previously a coach who called a dancer back in showcase 1 saw her row revert to "Call" when showcase 2 started while the sheet still read "Called Back".

**Frontend**
- The event picker defaults to the active event instead of "All events".
- The dancer sheet previously *hid* rating and notes whenever `readOnly` was set, so past-event data would have stayed invisible even with the backend fixed. It now renders them read-only, with a panel-level notice when she was never rostered at the event. Write controls stay hidden.
- `eventId` threaded through the sheet's save path and the favorite/callback buttons — they were writing and invalidating an unkeyed cache entry while reading a keyed one, so a saved note would have visibly reverted. Same for the compare view, which was showing a past event's dancers with the active event's marks.

## Deliberately unchanged

- **Writes stay gated to the active event** by the `orgEventDancer` middleware. The existing `coach-cross-event-access` tests cover this and still pass.
- **"All events" keeps active-event scoping.** Rows are collapsed one-per-dancer preferring the active event's row, so mixing marks across events there would make a star mean "at some event". Confirmed with the requester.

## Verification

- Backend and frontend typecheck clean; changed files add no lint errors (the ones ESLint reports in the buttons are identical on `main`).
- Seven tests in `coach-cross-event-access.spec.ts`. Each new one was confirmed to **fail against the code it fixes** — `expected false to be true` on `isFavorited`, `expected 403 to equal 200` on the favorites route, `expected true to be false` on the showcase divergence — and pass after.
- Full backend suite: 363 passed, 12 failed. Those same 12 fail on an unmodified `main` (check-in, roster export/stats, org-roles, email senders) — pre-existing and unrelated.

Reviewed by an independent pass, which found no cross-coach or cross-org leak and confirmed no write path was loosened. Its three HIGH findings are fixed in `a8f1c50`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFuXqwLykVVNaZRkPjJQQo
