### PR TITLE
fix(recruiting): stop CRV submissions jumping date groups when a row is written

### DIFF
--- a/apps/frontend/src/features/recruiting/components/school/school-submission-card.tsx
+++ b/apps/frontend/src/features/recruiting/components/school/school-submission-card.tsx
@@ -18,6 +18,7 @@ import { SubmissionVideoDialog } from "./submission-video-dialog";
 
 interface SchoolSubmissionCardProps {
   submission: SchoolSubmission;
+  onWatchingChange: (id: string | null) => void;
 }
 
 function statusBadge(status: SchoolSubmission["status"]) {
@@ -66,6 +67,7 @@ function watchedBadge(watched: boolean) {
 
 export function SchoolSubmissionCard({
   submission,
+  onWatchingChange,
 }: SchoolSubmissionCardProps) {
   const { dancer } = submission;
   const queryClient = useQueryClient();
@@ -83,6 +85,8 @@ export function SchoolSubmissionCard({
   };
 
   const handleOpenChange = (open: boolean) => {
+    onWatchingChange(open ? submission.id : null);
+
     if (open && !submission.watched) {
       const previous = optimisticUpdate({ watched: true });
       updateMutation.mutate(

--- a/apps/frontend/src/features/recruiting/components/school/school-submissions-list.tsx
+++ b/apps/frontend/src/features/recruiting/components/school/school-submissions-list.tsx
@@ -16,14 +16,20 @@ import { SchoolSubmissionCard } from "./school-submission-card";
 type SchoolSubmissionsListProps = {
   status: string;
   watched: string;
+  watchingId: string | null;
+  onWatchingChange: (id: string | null) => void;
 };
 
 function filterSubmissions(
   submissions: SchoolSubmission[],
   status: string,
   watched: string,
+  watchingId: string | null,
 ) {
   return submissions.filter((s) => {
+    // Never drop the submission whose video is open — filtering it out unmounts
+    // the card and takes the open dialog down with it.
+    if (s.id === watchingId) return true;
     if (status !== "all" && s.status !== status) return false;
     if (watched !== "all") {
       const isWatched = s.watched;
@@ -37,10 +43,10 @@ function filterSubmissions(
 function groupByDate(submissions: SchoolSubmission[]) {
   const groups: { date: string; submissions: SchoolSubmission[] }[] = [];
   const sorted = [...submissions].sort(
-    (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
   );
   for (const sub of sorted) {
-    const dateStr = formatDate(sub.updatedAt);
+    const dateStr = formatDate(sub.createdAt);
     const last = groups[groups.length - 1];
     if (last?.date === dateStr) {
       last.submissions.push(sub);
@@ -54,10 +60,12 @@ function groupByDate(submissions: SchoolSubmission[]) {
 export function SchoolSubmissionsList({
   status,
   watched,
+  watchingId,
+  onWatchingChange,
 }: SchoolSubmissionsListProps) {
   const { data } = useSuspenseQuery(recruitingQueries.schoolSubmissions());
 
-  const filtered = filterSubmissions(data, status, watched);
+  const filtered = filterSubmissions(data, status, watched, watchingId);
   const grouped = groupByDate(filtered);
 
   return (
@@ -84,6 +92,7 @@ export function SchoolSubmissionsList({
                 <SchoolSubmissionCard
                   key={submission.id}
                   submission={submission}
+                  onWatchingChange={onWatchingChange}
                 />
               ))}
             </div>

--- a/apps/frontend/src/features/recruiting/components/school/school-submissions-page.tsx
+++ b/apps/frontend/src/features/recruiting/components/school/school-submissions-page.tsx
@@ -15,6 +15,7 @@ import { SchoolSubmissionsList } from "./school-submissions-list";
 export function SchoolSubmissionsPage() {
   const [watched, setWatched] = useState("all");
   const [status, setStatus] = useState("all");
+  const [watchingId, setWatchingId] = useState<string | null>(null);
 
   return (
     <SidebarLayout
@@ -57,7 +58,12 @@ export function SchoolSubmissionsPage() {
         </div>
 
         <Suspense fallback={<SchoolListSkeleton />}>
-          <SchoolSubmissionsList status={status} watched={watched} />
+          <SchoolSubmissionsList
+            status={status}
+            watched={watched}
+            watchingId={watchingId}
+            onWatchingChange={setWatchingId}
+          />
         </Suspense>
       </div>
     </SidebarLayout>


### PR DESCRIPTION
A school reported that every time she clicks "Watch Video" on a Common Recruiting submission, the submission vanishes. Her screen recording shows the video dialog closing on its own roughly 0.8s after opening, with no interaction.

Both commits here come from the same underlying trap.

## The trap

`crv_submissions` uses the shared `timestamps` helper, whose `updatedAt` column has `.$onUpdate()`. **Any** write to a row bumps `updated_at` — including a watched-only update that shouldn't reorder anything. Both recruiting lists sorted and grouped by that field.

## Commit 1 — the reported bug (school side)

`SchoolSubmissionsList` sorts and groups by `updatedAt`, and opening the video dialog fires the "mark as watched" PATCH.

So: tap Watch Video → PATCH sets `watched = true` and silently bumps `updated_at` to today → the mutation invalidates the list → the refetch lands → that submission re-sorts into a brand-new "today" date group at the top of the page.

Because each date group renders as `<section key={group.date}>`, React unmounts the card from its old group and mounts a fresh instance in the new one. The `<Dialog>` lives inside the card, so it goes down with it — the video closes and the card is no longer where the recruiter was looking.

The **"Not Watched" filter** had the same shape of bug from a different direction: marking watched on open filters the card out from under her mid-video.

Fixed by grouping and sorting on `createdAt`, and by tracking the submission whose video is open (`watchingId`, held at page level) so it is never filtered out while the dialog is up.

## Commit 2 — the same field, the dancer side

The dancer's "schools I submitted to" list is a near-copy and grouped by `updatedAt` too, so its date headers didn't mean what they appear to mean. A header reading `August 20, 2026` looks like the day she submitted; it was really the last time a school touched her row. A coach watching her video or moving her to In Review silently relocated her card to a new date group at the top of her list — she did nothing, and her own submission got relabelled.

**This one could not close an open video** — the dancer's `SubmissionCard` is entirely read-only, no dialog and no mutation anywhere in that directory. So it's a correctness fix for the dates, not a second instance of the vanishing bug.

The dancer-side endpoint didn't select `createdAt` at all, so it's added to the query columns (the response already spreads the row) and `types.d.ts` regenerated — a one-line change to the generated file.

## Verification

For the school-side bug I built a temporary route replicating the exact stack — React 19, `useSuspenseQuery` under a Suspense boundary, the optimistic write, the mutation invalidation, and the same Base UI dialog — and drove it in a real browser:

- **Before:** the dialog closed by itself and the row jumped from "Jun 01 2026" to a new "Sep 01 2026" group at the top. Bug reproduced.
- **After:** the dialog stays open through the mutation and the refetch; on close the row is still in place, now badged "Watched".

The repro route is deleted and not part of this branch. Frontend `tsc --noEmit`, backend `pnpm typecheck`, and `eslint` on `src/features/recruiting` all pass clean.

The dancer-side change is a field swap verified by the type checker against the regenerated schema, not re-driven in a browser — it needs a seeded dancer account with live school activity, and there's no behavioural change to observe beyond the header text.

## Notes for the reviewer

- I swept both apps for other lists sorted on `updatedAt`. **These two were the only ones.** Every `orderBy` in `apps/backend/app` sorts on `createdAt`, names, `position`, `sortOrder`, `bibNumber`, or showcase number — I checked both the builder form and the object form. Other date-grouped lists key on stable identifiers (`group.category.id`, `group.value`). The two remaining `updatedAt` reads in the frontend are legitimate: a "last updated 3 hours ago" label in `video-library.tsx`, and optimistic cache stamps that don't feed a sorted list.
- No tests added — this is a mount/unmount timing bug in a component tree with no existing test setup for this feature. The browser repro above is the evidence.
- Unrelated pre-existing issues I hit and deliberately left alone: `pnpm --filter frontend check` runs `prettier --write .` and `eslint --fix` repo-wide and reformats ~77 untouched files; the repo has 128 pre-existing eslint errors (mostly `no-explicit-any`); and the backend won't boot locally without `MARKETING_SITE_URL` and the three `STRIPE_PRICE_ID_EVENT_TIER_*` vars, which aren't in `.env.example` territory yet. I passed dummies on the command line to regenerate types and left `.env` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SA6ZpVhmveRyED1azk3DAp
