### PR TITLE
fix(recruiting): group a dancer's submissions by when she submitted

### DIFF
--- a/apps/backend/app/modules/dancers/common-recruiting/get-submissions/service.ts
+++ b/apps/backend/app/modules/dancers/common-recruiting/get-submissions/service.ts
@@ -15,6 +15,7 @@ export class Service {
           status: true,
           watched: true,
           watchedAt: true,
+          createdAt: true,
           updatedAt: true,
         },
         with: {

--- a/apps/frontend/src/features/recruiting/components/submissions/utils.ts
+++ b/apps/frontend/src/features/recruiting/components/submissions/utils.ts
@@ -4,10 +4,10 @@ import type { Submission } from "@/shared/types";
 export function groupByDate(submissions: Submission[]) {
   const groups: { date: string; submissions: Submission[] }[] = [];
   const sorted = [...submissions].sort(
-    (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
   );
   for (const sub of sorted) {
-    const dateStr = formatDate(sub.updatedAt);
+    const dateStr = formatDate(sub.createdAt);
     const last = groups[groups.length - 1];
     if (last?.date === dateStr) {
       last.submissions.push(sub);

--- a/apps/frontend/src/lib/api/types.d.ts
+++ b/apps/frontend/src/lib/api/types.d.ts
@@ -11985,6 +11985,7 @@ export interface components {
             id: string;
             /** @enum {string} */
             status: "accepted" | "pending" | "released" | "in_review";
+            createdAt: string;
             updatedAt: string;
             school: {
                 avatar: string | null;


### PR DESCRIPTION
Follow-up to #115. This change was the second commit on that branch, but #115 merged with only its first commit, so this never reached main. Re-opened here, cherry-picked onto current main and re-verified.

## The bug

A dancer's "schools I submitted to" list groups and sorts by `updatedAt`. `crv_submissions` uses the shared `timestamps` helper, whose `updatedAt` column has `.$onUpdate()` — so **any** write to the row bumps `updated_at`, including ones the dancer didn't make.

The date headers therefore don't mean what they appear to mean. A header reading `August 20, 2026` looks like the day she submitted; it's really the last time a *school* touched her row.

The visible effect: a coach watching her video or moving her to In Review silently relocates her card to a new date group at the top of her list. She did nothing, and her own submission got relabelled with a date that has no meaning to her.

## The fix

Group and sort by `createdAt` — the date the header claims to show, and one that doesn't move.

The dancer-side endpoint didn't select `createdAt` at all, so it's added to the query columns (the response already spreads the row) and `types.d.ts` regenerated. That's a one-line addition to the generated file.

## Relationship to #115

Same root cause as the school-side bug — both recruiting lists sorted on a field that `$onUpdate` silently bumps. But **this one could not close an open video.** The dancer's `SubmissionCard` is entirely read-only: no dialog, no mutation anywhere in that directory. Nothing she does from a row writes to the row, so nothing re-sorts under her. This is a correctness fix for the dates, not a second instance of the vanishing-video bug.

With this merged, the `updatedAt`-as-sort-key problem is cleared from both recruiting lists. I swept both apps when I found the first one: these two were the only instances. Every `orderBy` in `apps/backend/app` sorts on `createdAt`, names, `position`, `sortOrder`, `bibNumber`, or showcase number; other date-grouped lists key on stable identifiers.

## Verification

Frontend `tsc --noEmit`, backend `pnpm typecheck`, `eslint` on `src/features/recruiting`, and the full frontend suite (43 tests, 8 files) all pass on top of current main.

This is a field swap verified by the type checker against the regenerated schema — I did not re-drive it in a browser, since it needs a seeded dancer account with live school activity and there's no behaviour to observe beyond the header text changing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SA6ZpVhmveRyED1azk3DAp
